### PR TITLE
Add propagators configuration

### DIFF
--- a/kitchen-sink-example.yaml
+++ b/kitchen-sink-example.yaml
@@ -28,6 +28,11 @@ logger_provider:
 # Configure meter provider.
 meter_provider: {}
 
+# Configure context propagators.
+#
+# Environment variable: OTEL_PROPAGATORS
+propagators: [tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace]
+
 # Configure tracer provider.
 tracer_provider:
   # Configure span limits. See also attribute_limits.

--- a/schema/opentelemetry_configuration.json
+++ b/schema/opentelemetry_configuration.json
@@ -27,6 +27,12 @@
         "meter_provider": {
             "$ref": "meter_provider.json"
         },
+        "propagators": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "tracer_provider": {
             "$ref": "tracer_provider.json"
         },


### PR DESCRIPTION
I considered making each propagator an object to allow future propagators to include configuration options:
```
propagators:
  foo_propagator:
    key: value
```
But chose against it because none of the current propagators accept configuration, and we can evolve into this future if needed with something like:
```
# Entries provide configuration options for .propagators entires.
propagator_config:
  foo_propagator:
    key: value
propagators: [foo_propagator]
```