### PR TITLE
add span processor + exporter to tracer provider

### DIFF
--- a/kitchen-sink-example.yaml
+++ b/kitchen-sink-example.yaml
@@ -8,8 +8,8 @@ exporters:
     protocol: http/protobuf
     # Sets the endpoint.
     #
-    # Environment variable: OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-    endpoint: http://localhost:4318/v1/metrics
+    # Environment variable: OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    endpoint: http://localhost:4318
     # Sets the certificate.
     #
     # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
@@ -113,6 +113,14 @@ propagators: [tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace]
 
 # Configure tracer provider.
 tracer_provider:
+  span_processors:
+    batch/otlp:
+      exporter:
+        # expand the otlp-exporter anchor
+        <<: *otlp-exporter
+    batch/console:
+      exporter:
+        console: {}
   # Configure span limits. See also attribute_limits.
   limits:
     # Set the max span attribute value size. Overrides attribute_limits.attribute_value_length_limit.

--- a/kitchen-sink-example.yaml
+++ b/kitchen-sink-example.yaml
@@ -113,11 +113,28 @@ propagators: [tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace]
 
 # Configure tracer provider.
 tracer_provider:
-  span_processors:
+  processors:
     batch/otlp:
+      # Sets the delay interval between two consecutive exports.
+      #
+      # Environment variable: OTEL_BSP_SCHEDULE_DELAY
+      schedule_delay: 5000
+      # Sets the maximum allowed time to export data.
+      #
+      # Environment variable: OTEL_BSP_EXPORT_TIMEOUT
+      export_timeout: 30000
+      # Sets the maximum queue size.
+      #
+      # Environment variable: OTEL_BSP_MAX_QUEUE_SIZE
+      max_queue_size: 2048
+      # Sets the maximum batch size.
+      #
+      # Environment variable: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+      max_export_batch_size: 512
       exporter:
-        # expand the otlp-exporter anchor
-        <<: *otlp-exporter
+        otlp:
+          # expand the otlp-exporter anchor
+          <<: *otlp-exporter
     batch/console:
       exporter:
         console: {}

--- a/schema/common.json
+++ b/schema/common.json
@@ -8,6 +8,52 @@
             "type": "object",
             "additionalProperties": true,
             "title": "Headers"
+        },
+        "Otlp": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protocol": {
+                    "type": "string",
+                    "pattern": "^(http|grpc)\\/(protobuf|json)"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "certificate": {
+                    "type": "string"
+                },
+                "client_key": {
+                    "type": "string"
+                },
+                "client_certificate": {
+                    "type": "string"
+                },
+                "headers": {
+                    "$ref": "#/$defs/Headers"
+                },
+                "compression": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
+                },
+                "temporality_preference": {
+                    "type": "string"
+                },
+                "default_histogram_aggregation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "endpoint",
+                "protocol"
+            ],
+            "title": "Otlp"
+        },
+        "Console": {
+            "type": "object",
+            "additionalProperties": false
         }
     }
 }

--- a/schema/common.json
+++ b/schema/common.json
@@ -37,12 +37,6 @@
                 },
                 "timeout": {
                     "type": "integer"
-                },
-                "temporality_preference": {
-                    "type": "string"
-                },
-                "default_histogram_aggregation": {
-                    "type": "string"
                 }
             },
             "required": [

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -61,7 +61,7 @@
                     "$ref": "#/$defs/OtlpMetric"
                 },
                 "console": {
-                    "$ref": "common.js#/$defs/Console"
+                    "$ref": "common.json#/$defs/Console"
                 },
                 "prometheus": {
                     "$ref": "#/$defs/Prometheus"
@@ -84,6 +84,48 @@
                     "type": "integer"
                 }
             }
+        },
+        "OtlpMetric": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protocol": {
+                    "type": "string",
+                    "pattern": "^(http|grpc)\\/(protobuf|json)"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "certificate": {
+                    "type": "string"
+                },
+                "client_key": {
+                    "type": "string"
+                },
+                "client_certificate": {
+                    "type": "string"
+                },
+                "headers": {
+                    "$ref": "common.json#/$defs/Headers"
+                },
+                "compression": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
+                },
+                "temporality_preference": {
+                    "type": "string"
+                },
+                "default_histogram_aggregation": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "endpoint",
+                "protocol"
+            ],
+            "title": "OtlpMetric"
         }
     }
 }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -58,10 +58,10 @@
             "maxProperties": 1,
             "properties": {
                 "otlp": {
-                    "$ref": "#/$defs/Otlp"
+                    "$ref": "#/$defs/OtlpMetric"
                 },
                 "console": {
-                    "$ref": "#/$defs/Console"
+                    "$ref": "common.js#/$defs/Console"
                 },
                 "prometheus": {
                     "$ref": "#/$defs/Prometheus"
@@ -72,53 +72,6 @@
                     "type": "object"
                 }
             }
-        },
-        "Console": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "Otlp": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "protocol": {
-                    "type": "string",
-                    "pattern": "^(http|grpc)\\/(protobuf|json)"
-                },
-                "endpoint": {
-                    "type": "string"
-                },
-                "certificate": {
-                    "type": "string"
-                },
-                "client_key": {
-                    "type": "string"
-                },
-                "client_certificate": {
-                    "type": "string"
-                },
-                "headers": {
-                    "$ref": "common.json#/$defs/Headers"
-                },
-                "compression": {
-                    "type": "string"
-                },
-                "timeout": {
-                    "type": "integer"
-                },
-                "temporality_preference": {
-                    "type": "string"
-                },
-                "default_histogram_aggregation": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "endpoint",
-                "protocol"
-            ],
-            "title": "Otlp"
         },
         "Prometheus": {
             "type": "object",

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -59,6 +59,18 @@
             "additionalProperties": false,
             "title": "BatchSpanProcessor",
             "properties": {
+                "schedule_delay": {
+                    "type": "integer"
+                },
+                "export_timeout": {
+                    "type": "integer"
+                },
+                "max_queue_size": {
+                    "type": "integer"
+                },
+                "max_export_batch_size": {
+                    "type": "integer"
+                },
                 "exporter": {
                     "$ref": "#/$defs/SpanExporter"
                 }
@@ -67,12 +79,19 @@
         "SpanExporter": {
             "type": "object",
             "additionalProperties": true,
-            "patternProperties": {
-                "^otlp.*": {
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+                "otlp": {
                     "$ref": "common.json#/$defs/Otlp"
                 },
-                "^console.*": {
+                "console": {
                     "$ref": "common.json#/$defs/Console"
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "type": "object"
                 }
             }
         }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -5,6 +5,18 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "processors": {
+            "type": "object",
+            "additionalProperties": true,
+            "patternProperties": {
+                "^batch.*": {
+                    "$ref": "#/$defs/BatchSpanProcessor"
+                },
+                "^simple.*": {
+                    "$ref": "#/$defs/SimpleSpanProcessor"
+                }
+            }
+        },
         "limits": {
             "title": "SpanLimits",
             "type": "object",
@@ -29,6 +41,81 @@
                     "type": "integer"
                 }
             }
+        }
+    },
+    "$defs": {
+        "SimpleSpanProcessor": {
+            "type": "object",
+            "additionalProperties": false,
+            "title": "SimpleSpanProcessor",
+            "properties": {
+                "exporter": {
+                    "$ref": "#/$defs/SpanExporter"
+                }
+            }
+        },
+        "BatchSpanProcessor": {
+            "type": "object",
+            "additionalProperties": false,
+            "title": "BatchSpanProcessor",
+            "properties": {
+                "exporter": {
+                    "$ref": "#/$defs/SpanExporter"
+                }
+            }
+        },
+        "SpanExporter": {
+            "type": "object",
+            "additionalProperties": true,
+            "patternProperties": {
+                "^otlp.*": {
+                    "$ref": "#/$defs/Otlp"
+                },
+                "^console.*": {
+                    "$ref": "#/$defs/Console"
+                }
+            }
+        },
+        "Console": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+        },
+        "Otlp": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "protocol": {
+                    "type": "string",
+                    "pattern": "^(http|grpc)\\/(protobuf|json)"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "certificate": {
+                    "type": "string"
+                },
+                "client_key": {
+                    "type": "string"
+                },
+                "client_certificate": {
+                    "type": "string"
+                },
+                "headers": {
+                    "$ref": "common.json#/$defs/Headers"
+                },
+                "compression": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "endpoint",
+                "protocol"
+            ],
+            "title": "Otlp"
         }
     }
 }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -69,53 +69,12 @@
             "additionalProperties": true,
             "patternProperties": {
                 "^otlp.*": {
-                    "$ref": "#/$defs/Otlp"
+                    "$ref": "common.json#/$defs/Otlp"
                 },
                 "^console.*": {
-                    "$ref": "#/$defs/Console"
+                    "$ref": "common.json#/$defs/Console"
                 }
             }
-        },
-        "Console": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {}
-        },
-        "Otlp": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "protocol": {
-                    "type": "string",
-                    "pattern": "^(http|grpc)\\/(protobuf|json)"
-                },
-                "endpoint": {
-                    "type": "string"
-                },
-                "certificate": {
-                    "type": "string"
-                },
-                "client_key": {
-                    "type": "string"
-                },
-                "client_certificate": {
-                    "type": "string"
-                },
-                "headers": {
-                    "$ref": "common.json#/$defs/Headers"
-                },
-                "compression": {
-                    "type": "string"
-                },
-                "timeout": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "endpoint",
-                "protocol"
-            ],
-            "title": "Otlp"
         }
     }
 }


### PR DESCRIPTION
This PR adds configuration for two processors (simple + batch) and span exporters for OTLP and console output.