### PR TITLE
Prevent multiple metric exporters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ all: install-tools compile-schema validate-example
 compile-schema:
 	@if ! npm ls ajv-cli; then npm install; fi
 	@for f in $(SCHEMA_FILES); do \
-	    npx --no ajv-cli compile --spec=draft2020 -s ./schema/$$f -r "./schema/!($$f)" \
+	    npx --no ajv-cli compile --spec=draft2020 --allow-matching-properties -s ./schema/$$f -r "./schema/!($$f)" \
 	        || exit 1; \
 	done
 
 .PHONY: validate-example
 validate-example:
 	@if ! npm ls ajv-cli; then npm install; fi
-	npx --no ajv-cli validate --spec=draft2020 --errors=text -s ./schema/opentelemetry_configuration.json -r "./schema/!(opentelemetry_configuration.json)" -d ./kitchen-sink-example.yaml
+	npx --no ajv-cli validate --spec=draft2020 --allow-matching-properties --errors=text -s ./schema/opentelemetry_configuration.json -r "./schema/!(opentelemetry_configuration.json)" -d ./kitchen-sink-example.yaml
 
 .PHONY: install-tools
 install-tools:

--- a/kitchen-sink-example.yaml
+++ b/kitchen-sink-example.yaml
@@ -1,7 +1,7 @@
 # The file format version
 file_format: "0.1"
-exporters: &otlp-exporter
-  otlp:
+exporters:
+  otlp: &otlp-exporter
     # Sets the protocol.
     #
     # Environment variable: OTEL_EXPORTER_OTLP_PROTOCOL, OTEL_EXPORTER_OTLP_METRICS_PROTOCOL
@@ -91,16 +91,17 @@ meter_provider:
       #
       # Environment variable: OTEL_METRICS_EXPORTER
       exporter:
-        # expand the otlp-exporter anchor and add metric specific configuration
-        <<: *otlp-exporter
-        # Sets the temporality preference.
-        #
-        # Environment variable: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-        temporality_preference: delta
-        # Sets the default histogram aggregation.
-        #
-        # Environment variable: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
-        default_histogram_aggregation: exponential_bucket_histogram
+        otlp:
+          # expand the otlp-exporter anchor and add metric specific configuration
+          <<: *otlp-exporter
+          # Sets the temporality preference.
+          #
+          # Environment variable: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+          temporality_preference: delta
+          # Sets the default histogram aggregation.
+          #
+          # Environment variable: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+          default_histogram_aggregation: exponential_bucket_histogram
     periodic/console:
       exporter:
         console: {}

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -54,15 +54,22 @@
         "MetricExporter": {
             "type": "object",
             "additionalProperties": true,
-            "patternProperties": {
-                "^otlp.*": {
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+                "otlp": {
                     "$ref": "#/$defs/Otlp"
                 },
-                "^console.*": {
+                "console": {
                     "$ref": "#/$defs/Console"
                 },
-                "^prometheus.*": {
+                "prometheus": {
                     "$ref": "#/$defs/Prometheus"
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "type": "object"
                 }
             }
         },


### PR DESCRIPTION
Right now there's nothing preventing multiple metric exporters from being registered, i.e.:
```
meter_provider:
  readers:
    periodic/otlp:
      exporter:
        otlp:
          endpoint: ...
        console:
```
This PR adds `minProperties` and `maxProperties` to prevent multiple. Also enforces that unrecognized exporter keys (i.e. custom exporters) must be type `object`. 