### PR TITLE
Add sampler configuration aligned with metric exporter schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ all: install-tools compile-schema validate-example
 compile-schema:
 	@if ! npm ls ajv-cli; then npm install; fi
 	@for f in $(SCHEMA_FILES); do \
-	    npx --no ajv-cli compile --spec=draft2020 -s ./schema/$$f -r "./schema/!($$f)" \
+	    npx --no ajv-cli compile --spec=draft2020 --allow-matching-properties -s ./schema/$$f -r "./schema/!($$f)" \
 	        || exit 1; \
 	done
 
 .PHONY: validate-example
 validate-example:
 	@if ! npm ls ajv-cli; then npm install; fi
-	npx --no ajv-cli validate --spec=draft2020 --errors=text -s ./schema/opentelemetry_configuration.json -r "./schema/!(opentelemetry_configuration.json)" -d ./kitchen-sink-example.yaml
+	npx --no ajv-cli validate --spec=draft2020 --allow-matching-properties --errors=text -s ./schema/opentelemetry_configuration.json -r "./schema/!(opentelemetry_configuration.json)" -d ./kitchen-sink-example.yaml
 
 .PHONY: install-tools
 install-tools:

--- a/kitchen-sink-example.yaml
+++ b/kitchen-sink-example.yaml
@@ -138,6 +138,38 @@ tracer_provider:
     #
     # Environment variable: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
     link_attribute_count_limit: 128
+  # Configure the sampler.
+  sampler:
+    # Set the sampler to be parent_based. Known values include: always_off, always_on, jaeger_remote, parent_based, trace_id_ratio_based.
+    #
+    # Environment variable: OTEL_TRACES_SAMPLER=parentbased_*
+    parent_based:
+      # Configure the parent_based root sampler.
+      #
+      # Environment variable: OTEL_TRACES_SAMPLER=parentbased_traceidratio
+      root:
+        # Set the sampler to be trace_id_ratio_based.
+        trace_id_ratio_based:
+          # Set the trace_id_ratio_based sampler trace_id_ratio.
+          #
+          # Environment variable: OTEL_TRACES_SAMPLER_ARG=traceidratio=0.0001
+          ratio: 0.0001
+      # Configure the parent_based remote_parent_sampled sampler.
+      remote_parent_sampled:
+        # Set the sampler to be always_on.
+        always_on: {}
+      # Configure the parent_based remote_parent_not_sampled sampler.
+      remote_parent_not_sampled:
+        # Set the sampler to be always_off.
+        always_off: {}
+      # Configure the parent_based local_parent_sampled sampler.
+      local_parent_sampled:
+        # Set the sampler to be always_on.
+        always_on: {}
+      # Configure the parent_based local_parent_not_sampled sampler.
+      local_parent_not_sampled:
+        # Set the sampler to be always_off.
+        always_off: {}
 
 # Configure resource for all signals.
 resource:

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -29,6 +29,77 @@
                     "type": "integer"
                 }
             }
+        },
+        "sampler": {
+            "$ref": "#/$defs/Sampler"
+        }
+    },
+    "$defs": {
+        "Sampler": {
+            "type": "object",
+            "additionalProperties": true,
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+                "always_off": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "always_on": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "jaeger_remote": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "interval": {
+                            "type": "integer"
+                        },
+                        "initial_sampler": {
+                            "$ref": "#/$defs/Sampler"
+                        }
+                    }
+                },
+                "parent_based": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "root": {
+                            "$ref": "#/$defs/Sampler"
+                        },
+                        "remote_parent_sampled": {
+                            "$ref": "#/$defs/Sampler"
+                        },
+                        "remote_parent_not_sampled": {
+                            "$ref": "#/$defs/Sampler"
+                        },
+                        "local_parent_sampled": {
+                            "$ref": "#/$defs/Sampler"
+                        },
+                        "local_parent_not_sampled": {
+                            "$ref": "#/$defs/Sampler"
+                        }
+                    }
+                },
+                "trace_id_ratio_based": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "ratio": {
+                            "type": "number"
+                        }
+                    }
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "type": "object"
+                }
+            }
         }
     }
 }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -47,6 +47,28 @@
         }
     },
     "$defs": {
+        "BatchSpanProcessor": {
+            "type": "object",
+            "additionalProperties": false,
+            "title": "BatchSpanProcessor",
+            "properties": {
+                "schedule_delay": {
+                    "type": "integer"
+                },
+                "export_timeout": {
+                    "type": "integer"
+                },
+                "max_queue_size": {
+                    "type": "integer"
+                },
+                "max_export_batch_size": {
+                    "type": "integer"
+                },
+                "exporter": {
+                    "$ref": "#/$defs/SpanExporter"
+                }
+            }
+        },
         "Sampler": {
             "type": "object",
             "additionalProperties": true,
@@ -112,36 +134,12 @@
                     "type": "object"
                 }
             }
-        }
-    },
-    "$defs": {
+        },
         "SimpleSpanProcessor": {
             "type": "object",
             "additionalProperties": false,
             "title": "SimpleSpanProcessor",
             "properties": {
-                "exporter": {
-                    "$ref": "#/$defs/SpanExporter"
-                }
-            }
-        },
-        "BatchSpanProcessor": {
-            "type": "object",
-            "additionalProperties": false,
-            "title": "BatchSpanProcessor",
-            "properties": {
-                "schedule_delay": {
-                    "type": "integer"
-                },
-                "export_timeout": {
-                    "type": "integer"
-                },
-                "max_queue_size": {
-                    "type": "integer"
-                },
-                "max_export_batch_size": {
-                    "type": "integer"
-                },
                 "exporter": {
                     "$ref": "#/$defs/SpanExporter"
                 }


### PR DESCRIPTION
Alternative to #21 which doesn't use `allOf` and which is aligned with the pattern established with MetricExporter.