### PR TITLE
make exporter required for log and span processors

### DIFF
--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -23,7 +23,10 @@
                 "exporter": {
                     "$ref": "#/$defs/LogRecordExporter"
                 }
-            }
+            },
+            "required": [
+                "exporter"
+            ]
         },
         "BatchLogRecordProcessor": {
             "type": "object",
@@ -44,7 +47,10 @@
                 "exporter": {
                     "$ref": "#/$defs/LogRecordExporter"
                 }
-            }
+            },
+            "required": [
+                "exporter"
+            ]
         },
         "LogRecordExporter": {
             "type": "object",

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -39,7 +39,10 @@
                 "exporter": {
                     "$ref": "#/$defs/SpanExporter"
                 }
-            }
+            },
+            "required": [
+                "exporter"
+            ]
         },
         "Sampler": {
             "type": "object",
@@ -115,7 +118,10 @@
                 "exporter": {
                     "$ref": "#/$defs/SpanExporter"
                 }
-            }
+            },
+            "required": [
+                "exporter"
+            ]
         },
         "SpanExporter": {
             "type": "object",


### PR DESCRIPTION
This is already the case for meter provider, making it consistent across all signals.