### PR TITLE
add unit in view selector

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -182,6 +182,8 @@ meter_provider:
         instrument_name: my-instrument
         # Configure instrument type selection criteria.
         instrument_type: histogram
+        # Configure the instrument unit selection criteria.
+        unit: ms
         # Configure meter name selection criteria.
         meter_name: my-meter
         # Configure meter version selection criteria.

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -159,6 +159,9 @@
                         "instrument_type": {
                             "type": "string"
                         },
+                        "unit": {
+                            "type": "string"
+                        },
                         "meter_name": {
                             "type": "string"
                         },


### PR DESCRIPTION
`unit` is listed in the instrument selection criteria: https://github.com/open-telemetry/opentelemetry-specification/blob/bc76c97525eef0f81550d939a3f87f44b182cef9/specification/metrics/sdk.md#instrument-selection-criteria