### PR TITLE
Update propagator configuration to reflect spec

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -216,10 +216,11 @@ meter_provider:
           - key1
           - key2
 
-# Configure context propagators.
+# Configure text map context propagators.
 #
 # Environment variable: OTEL_PROPAGATORS
-propagators: [tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace]
+propagator:
+  composite: [tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace]
 
 # Configure tracer provider.
 tracer_provider:

--- a/schema/opentelemetry_configuration.json
+++ b/schema/opentelemetry_configuration.json
@@ -20,11 +20,8 @@
         "meter_provider": {
             "$ref": "meter_provider.json"
         },
-        "propagators": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
+        "propagator": {
+            "$ref": "propagator.json"
         },
         "tracer_provider": {
             "$ref": "tracer_provider.json"

--- a/schema/propagator.json
+++ b/schema/propagator.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://opentelemetry.io/otelconfig/propagator.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Propagator",
+    "type": "object",
+    "minProperties": 1,
+    "maxProperties": 1,
+    "additionalProperties": true,
+    "properties": {
+        "composite": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The `propagators` key currently accepts an array of text map propagator keys. The intent is that those propagators are used in the composite text map propagator. 

This simplistic scheme doesn't reflect that there can be alternatives to the composite propagator. Updating to allow for custom propagators and additional future spec defined text map propagators.