### PR TITLE
Document time value units in kitchen-sink example

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -32,11 +32,11 @@ logger_provider:
   processors:
     # Configure a batch log record processor.
     - batch:
-        # Configure delay interval between two consecutive exports.
+        # Configure delay interval (in milliseconds) between two consecutive exports.
         #
         # Environment variable: OTEL_BLRP_SCHEDULE_DELAY
         schedule_delay: 5000
-        # Configure maximum allowed time to export data.
+        # Configure maximum allowed time (in milliseconds) to export data.
         #
         # Environment variable: OTEL_BLRP_EXPORT_TIMEOUT
         export_timeout: 30000
@@ -83,7 +83,7 @@ logger_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_LOGS_COMPRESSION
             compression: gzip
-            # Configure max time to wait for each export.
+            # Configure max time (in milliseconds) to wait for each export.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
             timeout: 10000
@@ -120,11 +120,11 @@ meter_provider:
             port: 9464
     # Configure a periodic metric reader.
     - periodic:
-        # Configure delay interval between start of two consecutive exports.
+        # Configure delay interval (in milliseconds) between start of two consecutive exports.
         #
         # Environment variable: OTEL_METRIC_EXPORT_INTERVAL
         interval: 5000
-        # Configure maximum allowed time to export data.
+        # Configure maximum allowed time (in milliseconds) to export data.
         #
         # Environment variable: OTEL_METRIC_EXPORT_TIMEOUT
         timeout: 30000
@@ -163,7 +163,7 @@ meter_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_METRICS_COMPRESSION
             compression: gzip
-            # Configure max time to wait for each export.
+            # Configure max time (in milliseconds) to wait for each export.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
             timeout: 10000
@@ -228,11 +228,11 @@ tracer_provider:
   processors:
     # Configure a batch span processor.
     - batch:
-        # Configure delay interval between two consecutive exports.
+        # Configure delay interval (in milliseconds) between two consecutive exports.
         #
         # Environment variable: OTEL_BSP_SCHEDULE_DELAY
         schedule_delay: 5000
-        # Configure maximum allowed time to export data.
+        # Configure maximum allowed time (in milliseconds) to export data.
         #
         # Environment variable: OTEL_BSP_EXPORT_TIMEOUT
         export_timeout: 30000
@@ -279,7 +279,7 @@ tracer_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_COMPRESSION, OTEL_EXPORTER_OTLP_TRACES_COMPRESSION
             compression: gzip
-            # Configure max time to wait for each export.
+            # Configure max time (in milliseconds) to wait for each export.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
             timeout: 10000
@@ -295,7 +295,7 @@ tracer_provider:
             #
             # Environment variable: OTEL_EXPORTER_ZIPKIN_ENDPOINT
             endpoint: http://localhost:9411/api/v2/spans
-            # Configure max time to wait for each export.
+            # Configure max time (in milliseconds) to wait for each export.
             #
             # Environment variable: OTEL_EXPORTER_ZIPKIN_TIMEOUT
             timeout: 10000


### PR DESCRIPTION
Closes #29 

Sources:
* [OTEL_BLRP_SCHEDULE_DELAY](https://github.com/open-telemetry/opentelemetry-specification/blob/3b028689f338e19b89432a4876cd4ddc11471b54/specification/configuration/sdk-environment-variables.md?plain=1#L136)
* [OTEL_BLRP_EXPORT_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/3b028689f338e19b89432a4876cd4ddc11471b54/specification/configuration/sdk-environment-variables.md?plain=1#L137)
* [OTEL_EXPORTER_OTLP_TIMEOUT](https://github.com/open-telemetry/opentelemetry.io/blob/61653887032b90d9b3d8222b79db9ebd7bc65855/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md?plain=1#L132)
* [OTEL_METRIC_EXPORT_INTERVAL](https://github.com/open-telemetry/opentelemetry-specification/blob/3b028689f338e19b89432a4876cd4ddc11471b54/specification/configuration/sdk-environment-variables.md?plain=1#L268)
* [OTEL_METRIC_EXPORT_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/3b028689f338e19b89432a4876cd4ddc11471b54/specification/configuration/sdk-environment-variables.md?plain=1#L269)
* [OTEL_BSP_SCHEDULE_DELAY](https://github.com/open-telemetry/opentelemetry-specification/blob/3b028689f338e19b89432a4876cd4ddc11471b54/specification/configuration/sdk-environment-variables.md?plain=1#L125)
* [OTEL_BSP_EXPORT_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/3b028689f338e19b89432a4876cd4ddc11471b54/specification/configuration/sdk-environment-variables.md?plain=1#L126C3-L126C26)
* [OTEL_EXPORTER_OTLP_TRACES_TIMEOUT](https://github.com/open-telemetry/opentelemetry.io/blob/61653887032b90d9b3d8222b79db9ebd7bc65855/content/en/docs/concepts/sdk-configuration/otlp-exporter-configuration.md?plain=1#L141)
* [OTEL_EXPORTER_ZIPKIN_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/3b028689f338e19b89432a4876cd4ddc11471b54/specification/configuration/sdk-environment-variables.md?plain=1#L190)