### PR TITLE
add prometheus without units & type suffix options

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -118,6 +118,8 @@ meter_provider:
             #
             # Environment variable: OTEL_EXPORTER_PROMETHEUS_PORT
             port: 9464
+            without_units: false
+            without_type_suffix: false
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -84,6 +84,12 @@
                 },
                 "port": {
                     "type": "integer"
+                },
+                "without_units": {
+                    "type": "boolean"
+                },
+                "without_type_suffix": {
+                    "type": "boolean"
                 }
             }
         },


### PR DESCRIPTION
Brings us closer in alignment with https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/prometheus.md