### PR TITLE
add without_scope_info to prometheus exporter

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -120,6 +120,7 @@ meter_provider:
             port: 9464
             without_units: false
             without_type_suffix: false
+            without_scope_info: false
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -90,6 +90,9 @@
                 },
                 "without_type_suffix": {
                     "type": "boolean"
+                },
+                "without_scope_info": {
+                    "type": "boolean"
                 }
             }
         },


### PR DESCRIPTION
This follows the spec change: https://github.com/open-telemetry/opentelemetry-specification/pull/3796