### PR TITLE
Define resource.detectors.attributes.included/excluded 

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -377,15 +377,23 @@ resource:
     #
     # Environment variable: OTEL_SERVICE_NAME
     service.name: !!str "unknown_service"
+  # Configure resource detectors.
+  detectors:
+    # Configure attributes provided by resource detectors.
+    attributes:
+      # Configure list of attribute key patterns to include from resource detectors. If not set, all attributes are included.
+      #
+      # Attribute keys from resource detectors are evaluated to match as follows:
+      #   * If the value of the attribute key exactly matches.
+      #   * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+      included:
+        - process.*
+      # Configure list of attribute key patterns to exclude from resource detectors. Applies after .resource.detectors.attributes.included (i.e. excluded has higher priority than included).
+      #
+      # Attribute keys from resource detectors are evaluated to match as follows:
+      #   * If the value of the attribute key exactly matches.
+      #   * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+      excluded:
+        - process.command_args
   # Configure the resource schema URL.
   schema_url: https://opentelemetry.io/schemas/1.16.0
-  # Configure disabled resource attribute keys provided by resource detectors.
-  #
-  # Attribute keys are evaluated to match disabled_attribute_keys in the following manner:
-  #   * If the value of the attribute key exactly matches.
-  #   * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
-  disabled_attribute_keys:
-    # Configure exact match disabled attribute key.
-    - process.command_args
-    # Configure wildcard match disabled attribute key(s).
-    - process.*

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -379,3 +379,15 @@ resource:
     service.name: !!str "unknown_service"
   # Configure the resource schema URL.
   schema_url: https://opentelemetry.io/schemas/1.16.0
+  # Configure resource detectors.
+  detectors:
+    # Configure disabled resource attribute keys provided by resource detectors.
+    #
+    # Attribute keys are evaluated to match disabled_attribute_keys in the following manner:
+    #   * If the value of the attribute key exactly matches.
+    #   * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+    disabled_attribute_keys:
+      # Configure exact match disabled attribute key.
+      - process.command_args
+      # Configure wildcard match disabled attribute key(s).
+      - process.*

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -379,15 +379,13 @@ resource:
     service.name: !!str "unknown_service"
   # Configure the resource schema URL.
   schema_url: https://opentelemetry.io/schemas/1.16.0
-  # Configure resource detectors.
-  detectors:
-    # Configure disabled resource attribute keys provided by resource detectors.
-    #
-    # Attribute keys are evaluated to match disabled_attribute_keys in the following manner:
-    #   * If the value of the attribute key exactly matches.
-    #   * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
-    disabled_attribute_keys:
-      # Configure exact match disabled attribute key.
-      - process.command_args
-      # Configure wildcard match disabled attribute key(s).
-      - process.*
+  # Configure disabled resource attribute keys provided by resource detectors.
+  #
+  # Attribute keys are evaluated to match disabled_attribute_keys in the following manner:
+  #   * If the value of the attribute key exactly matches.
+  #   * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+  disabled_attribute_keys:
+    # Configure exact match disabled attribute key.
+    - process.command_args
+    # Configure wildcard match disabled attribute key(s).
+    - process.*

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -8,14 +8,11 @@
         "attributes": {
             "$ref": "#/$defs/Attributes"
         },
+        "detectors": {
+            "$ref": "#/$defs/Detectors"
+        },
         "schema_url": {
             "type": "string"
-        },
-        "disabled_attribute_keys": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
         }
     },
     "$defs": {
@@ -26,6 +23,32 @@
             "properties": {
                 "service.name": {
                     "type": "string"
+                }
+            }
+        },
+        "Detectors": {
+            "title": "Detectors",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attributes": {
+                    "title": "DetectorAttributes",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "included": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "excluded": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -10,6 +10,9 @@
         },
         "schema_url": {
             "type": "string"
+        },
+        "detectors": {
+            "$ref": "#/$defs/Detectors"
         }
     },
     "$defs": {
@@ -20,6 +23,19 @@
             "properties": {
                 "service.name": {
                     "type": "string"
+                }
+            }
+        },
+        "Detectors": {
+            "title": "Detectors",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "disabled_attribute_keys": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         }

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -11,8 +11,11 @@
         "schema_url": {
             "type": "string"
         },
-        "detectors": {
-            "$ref": "#/$defs/Detectors"
+        "disabled_attribute_keys": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     },
     "$defs": {
@@ -23,19 +26,6 @@
             "properties": {
                 "service.name": {
                     "type": "string"
-                }
-            }
-        },
-        "Detectors": {
-            "title": "Detectors",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "disabled_attribute_keys": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         }


### PR DESCRIPTION
The specification defines the concept of [resource detectors](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#detecting-resource-information-from-the-environment), which automatically provide resource information based on the environment. 

We need to give the user the ability to disable these keys, as they can contain sensitive information (i.e. `process.command_line` often contains secrets for java) or just not be valuable to the user.

This PR introduces `resource.disabled_attribute_keys`, an array of strings defining attribute keys from resource detectors that should be disabled. Entries in the array can exactly match an attribute key, or can use a basic pattern matching syntax (inherited from metrics view [instrument selection criteria](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria)) supporting `?` single character any match, and `*` any number of character any match including none.

The effect is that `disabled_attribute_keys` acts as a disallow list. We may wish to add an allow list variant in the future, but disabling keys is much more common so let's start there.  