### PR TITLE
[exporter/prometheus] add with_resource_constant_labels

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -134,6 +134,8 @@ meter_provider:
             without_type_suffix: false
             # Configure Prometheus Exporter to produce metrics without a scope info metric.
             without_scope_info: false
+            # Configure Prometheus Exporter to add resource attributes as metrics attributes.
+            with_resource_constant_labels: "service\\.[.]*"
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -135,7 +135,11 @@ meter_provider:
             # Configure Prometheus Exporter to produce metrics without a scope info metric.
             without_scope_info: false
             # Configure Prometheus Exporter to add resource attributes as metrics attributes.
-            with_resource_constant_labels: "service\\.[.]*"
+            with_resource_constant_labels:
+              included:
+                - "service.*"
+              excluded:
+                - "otherattribute"
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -136,10 +136,12 @@ meter_provider:
             without_scope_info: false
             # Configure Prometheus Exporter to add resource attributes as metrics attributes.
             with_resource_constant_labels:
+              # Configure resource attributes to be included, in this example attributes starting with service.
               included:
-                - "service.*"
+                - "service*"
+              # Configure resource attributes to be excluded, in this example attribute service.attr1.
               excluded:
-                - "otherattribute"
+                - "service.attr1"
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.

--- a/schema/common.json
+++ b/schema/common.json
@@ -13,6 +13,24 @@
                 }
             }
         },
+        "IncludeExclude": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "included": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "excluded": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "Otlp": {
             "type": "object",
             "additionalProperties": false,

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -93,6 +93,9 @@
                 },
                 "without_scope_info": {
                     "type": "boolean"
+                },
+                "with_resource_constant_labels": {
+                    "type": "string"
                 }
             }
         },

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -95,7 +95,7 @@
                     "type": "boolean"
                 },
                 "with_resource_constant_labels": {
-                    "type": "string"
+                    "$ref": "common.json#/$defs/IncludeExclude"
                 }
             }
         },


### PR DESCRIPTION
This add support for the following from the spec:

> A Prometheus Exporter MAY offer configuration to add
> resource attributes as metric attributes. By default,
> it MUST NOT add any resource attributes as metric
> attributes. The configuration SHOULD allow the user
> to select which resource attributes to copy (e.g.
> include / exclude or regular expression based). Copied
> Resource attributes MUST NOT be excluded from target_info.

See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/prometheus.md 