### PR TITLE
remove specification for service.name

### DIFF
--- a/schema/resource.json
+++ b/schema/resource.json
@@ -16,12 +16,7 @@
         "Attributes": {
             "title": "Attributes",
             "type": "object",
-            "additionalProperties": true,
-            "properties": {
-                "service.name": {
-                    "type": "string"
-                }
-            }
+            "additionalProperties": true
         }
     }
 }


### PR DESCRIPTION
The attributes should really just be treated like a map of values. Specifying the service name here doesn't provide much value. Additionally, this is preventing the go-jsonschema library from generating the code for attributes as a map. With the service name specification, the generated code looks like this:

```
type Attributes struct {
	// ServiceName corresponds to the JSON schema field "service.name".
	ServiceName *string `mapstructure:"service.name,omitempty"`
}

```

Without the service name property specified:

```
type Attributes map[string]interface{}
```

I understand this appears to be a bug in go-jsonschema, but after thinking about this, i decided to open this PR as a proposal to work around the issue. Defining the service name property made sense when we wanted to require it, but since it's not required, i dont see much benefit to having it.