### PR TITLE
Add schema modeling guidance to use wildcard syntax instead of regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,14 @@ Allowable changes:
 - For major versions: All changes are permitted.
 - For minor versions: TBD
 
-## Naming guidelines
+## Schema Modeling Guidelines
 
-The following defines guidelines used to produce configuration schema:
+The following guidelines are used to model the configuration schema:
 
-1. To remove redundant information from the configuration file, prefixes for data produced by each of the providers
+* To remove redundant information from the configuration file, prefixes for data produced by each of the providers
 will be removed from configuration options. For example, under the `meter_provider` configuration, metric readers will be
 identified by the word `readers` rather than by `metric_readers`. Similarly, the prefix `span_` will be dropped for tracer
 provider configuration, and `logrecord` for logger provider.
+* Use wildcard `*` (match any number of any character, including none) and `?` (match any single character) instead of regex. If a single property with
+  wildcards is likely to be insufficient, accept an array of strings with wildcard with entries joined with a logical OR. For example, given `["foo*", "bar*"]`,
+  match on any value that starts with `foo` OR `bar`.


### PR DESCRIPTION
Related to #64 and #67, which each add properties with pattern matching semantics.

This PR codifies a modeling policy in which we prefer wildcard syntax to regex, which ensures compatibility across language ecosystems with varying levels of support for regex.