### PR TITLE
Add sdk-config.yaml starter template w/ references to env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 # Node.js files for tools (e.g. markdown-toc)
 node_modules/
 package-lock.json
+
+# Output directory after applying env substitution
+out

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SCHEMA_FILES := $(shell find . -path './schema/*.json' -exec basename {} \; | sort)
-EXAMPLE_FILES := $(shell find . -path './examples/*.yaml' | sort)
+EXAMPLE_FILES := $(shell find . -path './examples/*.yaml' -exec basename {} \; | sort)
+$(shell mkdir -p out)
 
 .PHONY: all
 all: install-tools compile-schema validate-examples
@@ -16,7 +17,8 @@ compile-schema:
 validate-examples:
 	@if ! npm ls ajv-cli; then npm install; fi
 	@for f in $(EXAMPLE_FILES); do \
-		npx --no ajv-cli validate --spec=draft2020 --allow-matching-properties --errors=text -s ./schema/opentelemetry_configuration.json -r "./schema/!(opentelemetry_configuration.json)" -d $$f \
+	    npx envsub ./examples/$$f ./out/$$f || exit 1; \
+		npx --no ajv-cli validate --spec=draft2020 --allow-matching-properties --errors=text -s ./schema/opentelemetry_configuration.json -r "./schema/!(opentelemetry_configuration.json)" -d ./out/$$f \
 		    || exit 1; \
 	done
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ This repository contains the JSON schema that defines the OpenTelemetry configur
 - code generation
 - broad support across languages
 
+## Starter templates
+
+The [examples](./examples) repository contains a variety of sample configuration files to help get started and illustrate useful patterns. The following are noteworthy:
+
+- [sdk-migration-config.yaml](./examples/sdk-migration-config.yaml): Includes env var substitution references to all [standard environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md) which map cleanly to file configuration (see notes in the example for the set of env vars which are not referenced). Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][]. This is a great starting point for transitioning from env var based configuration to file based configuration.
+- [sdk-config.yaml](./examples/sdk-config.yaml): Represents the typical default configuration. This is a good starting point if you are not using env var based configuration or wish to transition fully to file baed configuration. Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][].
+
+[env var substitution]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution
+
 ## Code generation
 
 There are [several tools](https://json-schema.org/implementations.html) available to generate code from a JSON schema. The following shows an example for generating code from the JSON schema in Go:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the JSON schema that defines the OpenTelemetry configur
 The [examples](./examples) repository contains a variety of sample configuration files to help get started and illustrate useful patterns. The following are noteworthy:
 
 - [sdk-migration-config.yaml](./examples/sdk-migration-config.yaml): Includes env var substitution references to all [standard environment variables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md) which map cleanly to file configuration (see notes in the example for the set of env vars which are not referenced). Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][]. This is a great starting point for transitioning from env var based configuration to file based configuration.
-- [sdk-config.yaml](./examples/sdk-config.yaml): Represents the typical default configuration. This is a good starting point if you are not using env var based configuration or wish to transition fully to file baed configuration. Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][].
+- [sdk-config.yaml](./examples/sdk-config.yaml): Represents the typical default configuration. This is a good starting point if you are not using env var based configuration or wish to transition fully to file based configuration. Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][].
 
 [env var substitution]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution
 

--- a/examples/anchors.yaml
+++ b/examples/anchors.yaml
@@ -4,7 +4,6 @@ file_format: "0.1"
 exporters:
   otlp: &otlp-exporter
     protocol: http/protobuf
-    endpoint: http://localhost:4318
     certificate: /app/cert.pem
     client_key: /app/cert.pem
     client_certificate: /app/cert.pem
@@ -20,6 +19,7 @@ logger_provider:
           otlp:
             # expand the otlp-exporter anchor
             <<: *otlp-exporter
+            endpoint: http://localhost:4318/v1/logs
 
 meter_provider:
   readers:
@@ -30,6 +30,7 @@ meter_provider:
           otlp:
             # expand the otlp-exporter anchor and add metric specific configuration
             <<: *otlp-exporter
+            endpoint: http://localhost:4318/v1/metrics
             temporality_preference: delta
             default_histogram_aggregation: base2_exponential_bucket_histogram
 
@@ -40,3 +41,4 @@ tracer_provider:
           otlp:
             # expand the otlp-exporter anchor
             <<: *otlp-exporter
+            endpoint: http://localhost:4318/v1/traces

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -122,8 +122,11 @@ meter_provider:
             #
             # Environment variable: OTEL_EXPORTER_PROMETHEUS_PORT
             port: 9464
+            # Configure Prometheus Exporter to produce metrics without a unit suffix or UNIT metadata.
             without_units: false
+            # Configure Prometheus Exporter to produce metrics without a type suffix.
             without_type_suffix: false
+            # Configure Prometheus Exporter to produce metrics without a scope info metric.
             without_scope_info: false
     # Configure a periodic metric reader.
     - periodic:

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -87,6 +87,10 @@ logger_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
             timeout: 10000
+            # Configure client transport security for the exporter's connection.
+            #
+            # Environment variable: OTEL_EXPORTER_OTLP_INSECURE, OTEL_EXPORTER_OTLP_LOGS_INSECURE
+            insecure: false
   # Configure log record limits. See also attribute_limits.
   limits:
     # Configure max log record attribute value size. Overrides attribute_limits.attribute_value_length_limit.
@@ -170,6 +174,10 @@ meter_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
             timeout: 10000
+            # Configure client transport security for the exporter's connection.
+            #
+            # Environment variable: OTEL_EXPORTER_OTLP_INSECURE, OTEL_EXPORTER_OTLP_METRICS_INSECURE
+            insecure: false
             # Configure temporality preference.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
@@ -286,6 +294,10 @@ tracer_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_TIMEOUT, OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
             timeout: 10000
+            # Configure client transport security for the exporter's connection.
+            #
+            # Environment variable: OTEL_EXPORTER_OTLP_INSECURE, OTEL_EXPORTER_OTLP_TRACES_INSECURE
+            insecure: false
     # Configure a batch span processor.
     - batch:
         # Configure exporter.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -61,7 +61,7 @@ logger_provider:
             # Configure endpoint.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-            endpoint: http://localhost:4318
+            endpoint: http://localhost:4318/v1/logs
             # Configure certificate.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE
@@ -169,7 +169,7 @@ meter_provider:
             # Configure endpoint.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-            endpoint: http://localhost:4318
+            endpoint: http://localhost:4318/v1/metrics
             # Configure certificate.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE
@@ -293,7 +293,7 @@ tracer_provider:
             # Configure endpoint.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            endpoint: http://localhost:4318
+            endpoint: http://localhost:4318/v1/traces
             # Configure certificate.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -50,7 +50,7 @@ tracer_provider:
             # Configure protocol.
             protocol: http/protobuf
             # Configure endpoint.
-            endpoint: http://localhost:-4318
+            endpoint: http://localhost:4318
             # Configure certificate.
             certificate:
             # Configure mTLS private client key.
@@ -117,7 +117,7 @@ meter_provider:
             # Configure protocol.
             protocol: http/protobuf
             # Configure endpoint.
-            endpoint: http://localhost:-4318
+            endpoint: http://localhost:4318
             # Configure certificate.
             certificate:
             # Configure mTLS private client key.

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -1,0 +1,206 @@
+# sdk-config.yaml is a typical starting point for configuring the SDK, including exporting to
+# localhost via OTLP.
+
+# NOTE: With the exception of env var substitution syntax, SDKs ignore environment variables
+# when interpreting config files.
+#
+# This template includes env var substitution references (i.e. ${MY_ENV}) for all spec defined
+# env vars (https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+# which map cleanly to file configuration. For example, OTEL_SDK_DISABLED is referenced below,
+# but OTEL_TRACES_EXPORTER is not since it does not map well to the hierarchical structure of
+# file configuration.
+#
+# Because env vars are ignored except for env var substitution, if "disabled: ${OTEL_SDK_DISABLED:-false}"
+# is replaced with "disabled: false", setting OTEL_SDK_DISALBED env var will not have any effect.
+# See https://opentelemetry.io/docs/specs/otel/configuration/file-configuration/ for more information.
+# The following spec defined env vars are NOT referenced and are thus ignored:
+#
+# - OTEL_RESOURCE_ATTRIBUTES
+# - OTEL_LOG_LEVEL
+# - OTEL_PROPAGATORS
+# - OTEL_TRACES_SAMPLER
+# - OTEL_TRACES_SAMPLER_ARG
+# - OTEL_EXPORTER_ZIPKIN_ENDPOINT
+# - OTEL_EXPORTER_ZIPKIN_TIMEOUT
+# - OTEL_EXPORTER_PROMETHEUS_HOST
+# - OTEL_EXPORTER_PROMETHEUS_PORT
+# - OTEL_TRACES_EXPORTER
+# - OTEL_METRICS_EXPORTER
+# - OTEL_LOGS_EXPORTER
+# - OTEL_METRICS_EXEMPLAR_FILTER
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_ENDPOINT
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_INSECURE
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_CERTIFICATE
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_KEY
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_CERTIFICATE
+# - OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_{SIGNAL}_HEADERS
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_COMPRESSION
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_TIMEOUT
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL
+
+# The file format version
+file_format: "0.1"
+
+# Configure if the SDK is disabled or not.
+disabled: ${OTEL_SDK_DISABLED:-false}
+
+# Configure resource for all signals.
+resource:
+  # Configure resource attributes.
+  attributes:
+    # Configure `service.name` resource attribute
+    service.name: ${OTEL_SERVICE_NAME:-unknown_service}
+
+# Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
+attribute_limits:
+  # Configure max attribute value size.
+  attribute_value_length_limit: ${OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+  # Configure max attribute count.
+  attribute_count_limit: ${OTEL_ATTRIBUTE_COUNT_LIMIT:-128}
+
+# Configure text map context propagators.
+propagator:
+  composite: [tracecontext, baggage]
+
+# Configure tracer provider.
+tracer_provider:
+  # Configure span processors.
+  processors:
+    # Configure a batch span processor.
+    - batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports.
+        schedule_delay: ${OTEL_BSP_SCHEDULE_DELAY:-5000}
+        # Configure maximum allowed time (in milliseconds) to export data.
+        export_timeout: ${OTEL_BSP_EXPORT_TIMEOUT:-30000}
+        # Configure maximum queue size.
+        max_queue_size: ${OTEL_BSP_MAX_QUEUE_SIZE:-2048}
+        # Configure maximum batch size.
+        max_export_batch_size: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE:-512}
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP.
+          otlp:
+            # Configure protocol.
+            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            # Configure endpoint.
+            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            # Configure certificate.
+            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            # Configure mTLS private client key.
+            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            # Configure mTLS client certificate.
+            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            # Configure compression.
+            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            # Configure max time (in milliseconds) to wait for each export.
+            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+  # Configure span limits. See also attribute_limits.
+  limits:
+    # Configure max span attribute value size. Overrides attribute_limits.attribute_value_length_limit.
+    attribute_value_length_limit: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+    # Configure max span attribute count. Overrides attribute_limits.attribute_count_limit.
+    attribute_count_limit: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT:-128}
+    # Configure max span event count.
+    event_count_limit: ${OTEL_SPAN_EVENT_COUNT_LIMIT:-128}
+    # Configure max span link count.
+    link_count_limit: ${OTEL_SPAN_LINK_COUNT_LIMIT:-128}
+    # Configure max attributes per span event.
+    event_attribute_count_limit: ${OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT:-128}
+    # Configure max attributes per span link.
+    link_attribute_count_limit: ${OTEL_LINK_ATTRIBUTE_COUNT_LIMIT:-128}
+  # Configure the sampler.
+  sampler:
+    # Configure sampler to be parent_based. Known values include: always_off, always_on, jaeger_remote, parent_based, trace_id_ratio_based.
+    parent_based:
+      # Configure root sampler.
+      root:
+        # Configure sampler to be always_on.
+        always_on: {}
+      # Configure remote_parent_sampled sampler.
+      remote_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on: {}
+      # Configure remote_parent_not_sampled sampler.
+      remote_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off: {}
+      # Configure local_parent_sampled sampler.
+      local_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on: {}
+      # Configure local_parent_not_sampled sampler.
+      local_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off: {}
+
+# Configure meter provider.
+meter_provider:
+  # Configure metric readers.
+  readers:
+    # Configure a periodic metric reader.
+    - periodic:
+        # Configure delay interval (in milliseconds) between start of two consecutive exports.
+        interval: ${OTEL_METRIC_EXPORT_INTERVAL:-60000}
+        # Configure maximum allowed time (in milliseconds) to export data.
+        timeout: ${OTEL_METRIC_EXPORT_TIMEOUT:-30000}
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP.
+          otlp:
+            # Configure protocol.
+            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            # Configure endpoint.
+            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            # Configure certificate.
+            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            # Configure mTLS private client key.
+            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            # Configure mTLS client certificate.
+            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            # Configure compression.
+            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            # Configure max time (in milliseconds) to wait for each export.
+            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            # Configure temporality preference.
+            temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+            # Configure default histogram aggregation.
+            default_histogram_aggregation: ${OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION:-explicit_bucket_histogram}
+
+# Configure logger provider.
+logger_provider:
+  # Configure log record processors.
+  processors:
+    # Configure a batch log record processor.
+    - batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports.
+        schedule_delay: ${OTEL_BLRP_SCHEDULE_DELAY:-1000}
+        # Configure maximum allowed time (in milliseconds) to export data.
+        export_timeout: ${OTEL_BLRP_EXPORT_TIMEOUT:-30000}
+        # Configure maximum queue size.
+        max_queue_size: ${OTEL_BLRP_MAX_QUEUE_SIZE:-2048}
+        # Configure maximum batch size.
+        max_export_batch_size: ${OTEL_BLRP_MAX_EXPORT_BATCH_SIZE:-512}
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP.
+          otlp:
+            # Configure protocol.
+            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            # Configure endpoint.
+            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            # Configure certificate.
+            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            # Configure mTLS private client key.
+            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            # Configure mTLS client certificate.
+            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            # Configure compression.
+            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            # Configure max time (in milliseconds) to wait for each export.
+            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+  # Configure log record limits. See also attribute_limits.
+  limits:
+    # Configure max log record attribute value size. Overrides attribute_limits.attribute_value_length_limit.
+    attribute_value_length_limit: ${OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+    # Configure max log record attribute count. Overrides attribute_limits.attribute_count_limit.
+    attribute_count_limit: ${OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT:-128}

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -1,62 +1,29 @@
 # sdk-config.yaml is a typical starting point for configuring the SDK, including exporting to
 # localhost via OTLP.
 
-# NOTE: With the exception of env var substitution syntax, SDKs ignore environment variables
-# when interpreting config files.
-#
-# This template includes env var substitution references (i.e. ${MY_ENV}) for all spec defined
-# env vars (https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
-# which map cleanly to file configuration. For example, OTEL_SDK_DISABLED is referenced below,
-# but OTEL_TRACES_EXPORTER is not since it does not map well to the hierarchical structure of
-# file configuration.
-#
-# Because env vars are ignored except for env var substitution, if "disabled: ${OTEL_SDK_DISABLED:-false}"
-# is replaced with "disabled: false", setting OTEL_SDK_DISALBED env var will not have any effect.
-# See https://opentelemetry.io/docs/specs/otel/configuration/file-configuration/ for more information.
-# The following spec defined env vars are NOT referenced and are thus ignored:
-#
-# - OTEL_RESOURCE_ATTRIBUTES
-# - OTEL_LOG_LEVEL
-# - OTEL_PROPAGATORS
-# - OTEL_TRACES_SAMPLER
-# - OTEL_TRACES_SAMPLER_ARG
-# - OTEL_EXPORTER_ZIPKIN_ENDPOINT
-# - OTEL_EXPORTER_ZIPKIN_TIMEOUT
-# - OTEL_EXPORTER_PROMETHEUS_HOST
-# - OTEL_EXPORTER_PROMETHEUS_PORT
-# - OTEL_TRACES_EXPORTER
-# - OTEL_METRICS_EXPORTER
-# - OTEL_LOGS_EXPORTER
-# - OTEL_METRICS_EXEMPLAR_FILTER
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_ENDPOINT
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_INSECURE
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_CERTIFICATE
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_KEY
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_CERTIFICATE
-# - OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_{SIGNAL}_HEADERS
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_COMPRESSION
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_TIMEOUT
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL
+# NOTE: With the exception of env var substitution syntax (i.e. ${MY_ENV}) , SDKs ignore
+# environment variables when interpreting config files. This including ignoring all env
+# vars defined in https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
 
 # The file format version
 file_format: "0.1"
 
 # Configure if the SDK is disabled or not.
-disabled: ${OTEL_SDK_DISABLED:-false}
+disabled: false
 
 # Configure resource for all signals.
 resource:
   # Configure resource attributes.
   attributes:
     # Configure `service.name` resource attribute
-    service.name: ${OTEL_SERVICE_NAME:-unknown_service}
+    service.name: unknown_service
 
 # Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
 attribute_limits:
   # Configure max attribute value size.
-  attribute_value_length_limit: ${OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+  attribute_value_length_limit:
   # Configure max attribute count.
-  attribute_count_limit: ${OTEL_ATTRIBUTE_COUNT_LIMIT:-128}
+  attribute_count_limit: 128
 
 # Configure text map context propagators.
 propagator:
@@ -69,45 +36,45 @@ tracer_provider:
     # Configure a batch span processor.
     - batch:
         # Configure delay interval (in milliseconds) between two consecutive exports.
-        schedule_delay: ${OTEL_BSP_SCHEDULE_DELAY:-5000}
+        schedule_delay: 5000
         # Configure maximum allowed time (in milliseconds) to export data.
-        export_timeout: ${OTEL_BSP_EXPORT_TIMEOUT:-30000}
+        export_timeout: 30000
         # Configure maximum queue size.
-        max_queue_size: ${OTEL_BSP_MAX_QUEUE_SIZE:-2048}
+        max_queue_size: 2048
         # Configure maximum batch size.
-        max_export_batch_size: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE:-512}
+        max_export_batch_size: 512
         # Configure exporter.
         exporter:
           # Configure exporter to be OTLP.
           otlp:
             # Configure protocol.
-            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            protocol: http/protobuf
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            endpoint: http://localhost:-4318
             # Configure certificate.
-            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            certificate:
             # Configure mTLS private client key.
-            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            client_key:
             # Configure mTLS client certificate.
-            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            client_certificate:
             # Configure compression.
-            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            compression: gzip
             # Configure max time (in milliseconds) to wait for each export.
-            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            timeout: 10000
   # Configure span limits. See also attribute_limits.
   limits:
     # Configure max span attribute value size. Overrides attribute_limits.attribute_value_length_limit.
-    attribute_value_length_limit: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+    attribute_value_length_limit:
     # Configure max span attribute count. Overrides attribute_limits.attribute_count_limit.
-    attribute_count_limit: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT:-128}
+    attribute_count_limit: 128
     # Configure max span event count.
-    event_count_limit: ${OTEL_SPAN_EVENT_COUNT_LIMIT:-128}
+    event_count_limit: 128
     # Configure max span link count.
-    link_count_limit: ${OTEL_SPAN_LINK_COUNT_LIMIT:-128}
+    link_count_limit: 128
     # Configure max attributes per span event.
-    event_attribute_count_limit: ${OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT:-128}
+    event_attribute_count_limit: 128
     # Configure max attributes per span link.
-    link_attribute_count_limit: ${OTEL_LINK_ATTRIBUTE_COUNT_LIMIT:-128}
+    link_attribute_count_limit: 128
   # Configure the sampler.
   sampler:
     # Configure sampler to be parent_based. Known values include: always_off, always_on, jaeger_remote, parent_based, trace_id_ratio_based.
@@ -140,31 +107,31 @@ meter_provider:
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.
-        interval: ${OTEL_METRIC_EXPORT_INTERVAL:-60000}
+        interval: 60000
         # Configure maximum allowed time (in milliseconds) to export data.
-        timeout: ${OTEL_METRIC_EXPORT_TIMEOUT:-30000}
+        timeout: 30000
         # Configure exporter.
         exporter:
           # Configure exporter to be OTLP.
           otlp:
             # Configure protocol.
-            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            protocol: http/protobuf
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            endpoint: http://localhost:-4318
             # Configure certificate.
-            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            certificate:
             # Configure mTLS private client key.
-            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            client_key:
             # Configure mTLS client certificate.
-            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            client_certificate:
             # Configure compression.
-            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            compression: gzip
             # Configure max time (in milliseconds) to wait for each export.
-            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            timeout: 10000
             # Configure temporality preference.
-            temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+            temporality_preference: cumulative
             # Configure default histogram aggregation.
-            default_histogram_aggregation: ${OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION:-explicit_bucket_histogram}
+            default_histogram_aggregation: explicit_bucket_histogram
 
 # Configure logger provider.
 logger_provider:
@@ -173,34 +140,34 @@ logger_provider:
     # Configure a batch log record processor.
     - batch:
         # Configure delay interval (in milliseconds) between two consecutive exports.
-        schedule_delay: ${OTEL_BLRP_SCHEDULE_DELAY:-1000}
+        schedule_delay: 1000
         # Configure maximum allowed time (in milliseconds) to export data.
-        export_timeout: ${OTEL_BLRP_EXPORT_TIMEOUT:-30000}
+        export_timeout: 30000
         # Configure maximum queue size.
-        max_queue_size: ${OTEL_BLRP_MAX_QUEUE_SIZE:-2048}
+        max_queue_size: 2048
         # Configure maximum batch size.
-        max_export_batch_size: ${OTEL_BLRP_MAX_EXPORT_BATCH_SIZE:-512}
+        max_export_batch_size: 512
         # Configure exporter.
         exporter:
           # Configure exporter to be OTLP.
           otlp:
             # Configure protocol.
-            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            protocol: http/protobuf
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            endpoint: http://localhost:4318
             # Configure certificate.
-            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            certificate:
             # Configure mTLS private client key.
-            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            client_key:
             # Configure mTLS client certificate.
-            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            client_certificate:
             # Configure compression.
-            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            compression: gzip
             # Configure max time (in milliseconds) to wait for each export.
-            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            timeout: 10000
   # Configure log record limits. See also attribute_limits.
   limits:
     # Configure max log record attribute value size. Overrides attribute_limits.attribute_value_length_limit.
-    attribute_value_length_limit: ${OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+    attribute_value_length_limit:
     # Configure max log record attribute count. Overrides attribute_limits.attribute_count_limit.
-    attribute_count_limit: ${OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT:-128}
+    attribute_count_limit: 128

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -50,7 +50,7 @@ tracer_provider:
             # Configure protocol.
             protocol: http/protobuf
             # Configure endpoint.
-            endpoint: http://localhost:4318
+            endpoint: http://localhost:4318/v1/traces
             # Configure certificate.
             certificate:
             # Configure mTLS private client key.
@@ -61,6 +61,8 @@ tracer_provider:
             compression: gzip
             # Configure max time (in milliseconds) to wait for each export.
             timeout: 10000
+            # Configure headers:
+            headers: {}
   # Configure span limits. See also attribute_limits.
   limits:
     # Configure max span attribute value size. Overrides attribute_limits.attribute_value_length_limit.
@@ -117,7 +119,7 @@ meter_provider:
             # Configure protocol.
             protocol: http/protobuf
             # Configure endpoint.
-            endpoint: http://localhost:4318
+            endpoint: http://localhost:4318/v1/metrics
             # Configure certificate.
             certificate:
             # Configure mTLS private client key.
@@ -128,6 +130,8 @@ meter_provider:
             compression: gzip
             # Configure max time (in milliseconds) to wait for each export.
             timeout: 10000
+            # Configure headers:
+            headers: {}
             # Configure temporality preference.
             temporality_preference: cumulative
             # Configure default histogram aggregation.
@@ -154,7 +158,7 @@ logger_provider:
             # Configure protocol.
             protocol: http/protobuf
             # Configure endpoint.
-            endpoint: http://localhost:4318
+            endpoint: http://localhost:4318/v1/logs
             # Configure certificate.
             certificate:
             # Configure mTLS private client key.
@@ -165,6 +169,8 @@ logger_provider:
             compression: gzip
             # Configure max time (in milliseconds) to wait for each export.
             timeout: 10000
+            # Configure headers:
+            headers: {}
   # Configure log record limits. See also attribute_limits.
   limits:
     # Configure max log record attribute value size. Overrides attribute_limits.attribute_value_length_limit.

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -1,7 +1,7 @@
 # sdk-config.yaml is a typical starting point for configuring the SDK, including exporting to
 # localhost via OTLP.
 
-# NOTE: With the exception of env var substitution syntax (i.e. ${MY_ENV}) , SDKs ignore
+# NOTE: With the exception of env var substitution syntax (i.e. ${MY_ENV}), SDKs ignore
 # environment variables when interpreting config files. This including ignoring all env
 # vars defined in https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/.
 

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -83,7 +83,7 @@ tracer_provider:
             # Configure protocol.
             protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}
             # Configure certificate.
             certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
             # Configure mTLS private client key.
@@ -150,7 +150,7 @@ meter_provider:
             # Configure protocol.
             protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}
             # Configure certificate.
             certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
             # Configure mTLS private client key.
@@ -187,7 +187,7 @@ logger_provider:
             # Configure protocol.
             protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:4318}
+            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318/v1/logs}
             # Configure certificate.
             certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
             # Configure mTLS private client key.

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -9,8 +9,8 @@
 #
 # NOTE: With the exception of env var substitution syntax, SDKs ignore environment variables
 # when interpreting config files. For example, if "disabled: ${OTEL_SDK_DISABLED:-false}"
-# is replaced with "disabled: false", then setting the env var OTEL_SDK_DISABLED will not have
-# any effect. See https://opentelemetry.io/docs/specs/otel/configuration/file-configuration/
+# is replaced with "disabled: false", then setting the env var OTEL_SDK_DISABLED will have
+# no effect. See https://opentelemetry.io/docs/specs/otel/configuration/file-configuration/
 # for more information. The following spec defined env vars are NOT referenced and are thus
 # ignored:
 #
@@ -27,15 +27,15 @@
 # - OTEL_METRICS_EXPORTER
 # - OTEL_LOGS_EXPORTER
 # - OTEL_METRICS_EXEMPLAR_FILTER
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_ENDPOINT
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_INSECURE
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_CERTIFICATE
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_KEY
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_CERTIFICATE
+# - OTEL_EXPORTER_OTLP_PROTOCOL
+# - OTEL_EXPORTER_OTLP_ENDPOINT
+# - OTEL_EXPORTER_OTLP_INSECURE, OTEL_EXPORTER_OTLP_{SIGNAL}_INSECURE
+# - OTEL_EXPORTER_OTLP_CERTIFICATE
+# - OTEL_EXPORTER_OTLP_CLIENT_KEY
+# - OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
 # - OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_{SIGNAL}_HEADERS
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_COMPRESSION
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_TIMEOUT
-# - OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL
+# - OTEL_EXPORTER_OTLP_COMPRESSION
+# - OTEL_EXPORTER_OTLP_TIMEOUT
 
 # The file format version
 file_format: "0.1"
@@ -80,19 +80,21 @@ tracer_provider:
           # Configure exporter to be OTLP.
           otlp:
             # Configure protocol.
-            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            protocol: ${OTEL_EXPORTER_OTLP_TRACES_PROTOCOL:-http/protobuf}
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}
+            endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://localhost:4318/v1/traces}
             # Configure certificate.
-            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            certificate: ${OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE}
             # Configure mTLS private client key.
-            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            client_key: ${OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY}
             # Configure mTLS client certificate.
-            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            client_certificate: ${OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE}
             # Configure compression.
-            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            compression: ${OTEL_EXPORTER_OTLP_TRACES_COMPRESSION:-gzip}
             # Configure max time (in milliseconds) to wait for each export.
-            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            timeout: ${OTEL_EXPORTER_OTLP_TRACES_TIMEOUT:-10000}
+            # Configure headers:
+            headers: {}
   # Configure span limits. See also attribute_limits.
   limits:
     # Configure max span attribute value size. Overrides attribute_limits.attribute_value_length_limit.
@@ -147,19 +149,21 @@ meter_provider:
           # Configure exporter to be OTLP.
           otlp:
             # Configure protocol.
-            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            protocol: ${OTEL_EXPORTER_OTLP_METRICS_PROTOCOL:-http/protobuf}
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318}
+            endpoint: ${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:-http://localhost:4318/v1/metrics}
             # Configure certificate.
-            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            certificate: ${OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE}
             # Configure mTLS private client key.
-            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            client_key: ${OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY}
             # Configure mTLS client certificate.
-            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            client_certificate: ${OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE}
             # Configure compression.
-            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            compression: ${OTEL_EXPORTER_OTLP_METRICS_COMPRESSION:-gzip}
             # Configure max time (in milliseconds) to wait for each export.
-            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            timeout: ${OTEL_EXPORTER_OTLP_METRICS_TIMEOUT:-10000}
+            # Configure headers:
+            headers: {}
             # Configure temporality preference.
             temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
             # Configure default histogram aggregation.
@@ -184,19 +188,21 @@ logger_provider:
           # Configure exporter to be OTLP.
           otlp:
             # Configure protocol.
-            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            protocol: ${OTEL_EXPORTER_OTLP_LOGS_PROTOCOL:-http/protobuf}
             # Configure endpoint.
-            endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4318/v1/logs}
+            endpoint: ${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT:-http://localhost:4318/v1/logs}
             # Configure certificate.
-            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            certificate: ${OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE}
             # Configure mTLS private client key.
-            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            client_key: ${OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY}
             # Configure mTLS client certificate.
-            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            client_certificate: ${OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE}
             # Configure compression.
-            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            compression: ${OTEL_EXPORTER_OTLP_LOGS_COMPRESSION:-gzip}
             # Configure max time (in milliseconds) to wait for each export.
-            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            timeout: ${OTEL_EXPORTER_OTLP_LOGS_TIMEOUT:-10000}
+            # Configure headers:
+            headers: {}
   # Configure log record limits. See also attribute_limits.
   limits:
     # Configure max log record attribute value size. Overrides attribute_limits.attribute_value_length_limit.

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -1,0 +1,206 @@
+# sdk-migration-config.yaml is a typical starting point for configuring the SDK when migrating
+# from environment variable based configuration.
+#
+# This template includes env var substitution references (i.e. ${MY_ENV}) for all spec defined
+# env vars (https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
+# which map cleanly to file configuration. For example, OTEL_SDK_DISABLED is referenced below,
+# but OTEL_TRACES_EXPORTER is not since it does not map well to the hierarchical structure of
+# file configuration.
+#
+# NOTE: With the exception of env var substitution syntax, SDKs ignore environment variables
+# when interpreting config files.
+#
+# Because env vars are ignored except for env var substitution, if "disabled: ${OTEL_SDK_DISABLED:-false}"
+# is replaced with "disabled: false", setting OTEL_SDK_DISALBED env var will not have any effect.
+# See https://opentelemetry.io/docs/specs/otel/configuration/file-configuration/ for more information.
+# The following spec defined env vars are NOT referenced and are thus ignored:
+#
+# - OTEL_RESOURCE_ATTRIBUTES
+# - OTEL_LOG_LEVEL
+# - OTEL_PROPAGATORS
+# - OTEL_TRACES_SAMPLER
+# - OTEL_TRACES_SAMPLER_ARG
+# - OTEL_EXPORTER_ZIPKIN_ENDPOINT
+# - OTEL_EXPORTER_ZIPKIN_TIMEOUT
+# - OTEL_EXPORTER_PROMETHEUS_HOST
+# - OTEL_EXPORTER_PROMETHEUS_PORT
+# - OTEL_TRACES_EXPORTER
+# - OTEL_METRICS_EXPORTER
+# - OTEL_LOGS_EXPORTER
+# - OTEL_METRICS_EXEMPLAR_FILTER
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_ENDPOINT
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_INSECURE
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_CERTIFICATE
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_KEY
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_CLIENT_CERTIFICATE
+# - OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_{SIGNAL}_HEADERS
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_COMPRESSION
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_TIMEOUT
+# - OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL
+
+# The file format version
+file_format: "0.1"
+
+# Configure if the SDK is disabled or not.
+disabled: ${OTEL_SDK_DISABLED:-false}
+
+# Configure resource for all signals.
+resource:
+  # Configure resource attributes.
+  attributes:
+    # Configure `service.name` resource attribute
+    service.name: ${OTEL_SERVICE_NAME:-unknown_service}
+
+# Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
+attribute_limits:
+  # Configure max attribute value size.
+  attribute_value_length_limit: ${OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+  # Configure max attribute count.
+  attribute_count_limit: ${OTEL_ATTRIBUTE_COUNT_LIMIT:-128}
+
+# Configure text map context propagators.
+propagator:
+  composite: [tracecontext, baggage]
+
+# Configure tracer provider.
+tracer_provider:
+  # Configure span processors.
+  processors:
+    # Configure a batch span processor.
+    - batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports.
+        schedule_delay: ${OTEL_BSP_SCHEDULE_DELAY:-5000}
+        # Configure maximum allowed time (in milliseconds) to export data.
+        export_timeout: ${OTEL_BSP_EXPORT_TIMEOUT:-30000}
+        # Configure maximum queue size.
+        max_queue_size: ${OTEL_BSP_MAX_QUEUE_SIZE:-2048}
+        # Configure maximum batch size.
+        max_export_batch_size: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE:-512}
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP.
+          otlp:
+            # Configure protocol.
+            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            # Configure endpoint.
+            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            # Configure certificate.
+            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            # Configure mTLS private client key.
+            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            # Configure mTLS client certificate.
+            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            # Configure compression.
+            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            # Configure max time (in milliseconds) to wait for each export.
+            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+  # Configure span limits. See also attribute_limits.
+  limits:
+    # Configure max span attribute value size. Overrides attribute_limits.attribute_value_length_limit.
+    attribute_value_length_limit: ${OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+    # Configure max span attribute count. Overrides attribute_limits.attribute_count_limit.
+    attribute_count_limit: ${OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT:-128}
+    # Configure max span event count.
+    event_count_limit: ${OTEL_SPAN_EVENT_COUNT_LIMIT:-128}
+    # Configure max span link count.
+    link_count_limit: ${OTEL_SPAN_LINK_COUNT_LIMIT:-128}
+    # Configure max attributes per span event.
+    event_attribute_count_limit: ${OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT:-128}
+    # Configure max attributes per span link.
+    link_attribute_count_limit: ${OTEL_LINK_ATTRIBUTE_COUNT_LIMIT:-128}
+  # Configure the sampler.
+  sampler:
+    # Configure sampler to be parent_based. Known values include: always_off, always_on, jaeger_remote, parent_based, trace_id_ratio_based.
+    parent_based:
+      # Configure root sampler.
+      root:
+        # Configure sampler to be always_on.
+        always_on: {}
+      # Configure remote_parent_sampled sampler.
+      remote_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on: {}
+      # Configure remote_parent_not_sampled sampler.
+      remote_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off: {}
+      # Configure local_parent_sampled sampler.
+      local_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on: {}
+      # Configure local_parent_not_sampled sampler.
+      local_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off: {}
+
+# Configure meter provider.
+meter_provider:
+  # Configure metric readers.
+  readers:
+    # Configure a periodic metric reader.
+    - periodic:
+        # Configure delay interval (in milliseconds) between start of two consecutive exports.
+        interval: ${OTEL_METRIC_EXPORT_INTERVAL:-60000}
+        # Configure maximum allowed time (in milliseconds) to export data.
+        timeout: ${OTEL_METRIC_EXPORT_TIMEOUT:-30000}
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP.
+          otlp:
+            # Configure protocol.
+            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            # Configure endpoint.
+            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:-4318}
+            # Configure certificate.
+            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            # Configure mTLS private client key.
+            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            # Configure mTLS client certificate.
+            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            # Configure compression.
+            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            # Configure max time (in milliseconds) to wait for each export.
+            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+            # Configure temporality preference.
+            temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
+            # Configure default histogram aggregation.
+            default_histogram_aggregation: ${OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION:-explicit_bucket_histogram}
+
+# Configure logger provider.
+logger_provider:
+  # Configure log record processors.
+  processors:
+    # Configure a batch log record processor.
+    - batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports.
+        schedule_delay: ${OTEL_BLRP_SCHEDULE_DELAY:-1000}
+        # Configure maximum allowed time (in milliseconds) to export data.
+        export_timeout: ${OTEL_BLRP_EXPORT_TIMEOUT:-30000}
+        # Configure maximum queue size.
+        max_queue_size: ${OTEL_BLRP_MAX_QUEUE_SIZE:-2048}
+        # Configure maximum batch size.
+        max_export_batch_size: ${OTEL_BLRP_MAX_EXPORT_BATCH_SIZE:-512}
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP.
+          otlp:
+            # Configure protocol.
+            protocol: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http/protobuf}
+            # Configure endpoint.
+            endpoint: ${OTEL_EXPORTER_OTLP_PROTOCOL:-http://localhost:4318}
+            # Configure certificate.
+            certificate: ${OTEL_EXPORTER_OTLP_CERTIFICATE}
+            # Configure mTLS private client key.
+            client_key: ${OTEL_EXPORTER_OTLP_CLIENT_KEY}
+            # Configure mTLS client certificate.
+            client_certificate: ${OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}
+            # Configure compression.
+            compression: ${OTEL_EXPORTER_OTLP_COMPRESSION:-gzip}
+            # Configure max time (in milliseconds) to wait for each export.
+            timeout: ${OTEL_EXPORTER_OTLP_TIMEOUT:-10000}
+  # Configure log record limits. See also attribute_limits.
+  limits:
+    # Configure max log record attribute value size. Overrides attribute_limits.attribute_value_length_limit.
+    attribute_value_length_limit: ${OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT}
+    # Configure max log record attribute count. Overrides attribute_limits.attribute_count_limit.
+    attribute_count_limit: ${OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT:-128}

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -8,12 +8,11 @@
 # file configuration.
 #
 # NOTE: With the exception of env var substitution syntax, SDKs ignore environment variables
-# when interpreting config files.
-#
-# Because env vars are ignored except for env var substitution, if "disabled: ${OTEL_SDK_DISABLED:-false}"
-# is replaced with "disabled: false", setting OTEL_SDK_DISALBED env var will not have any effect.
-# See https://opentelemetry.io/docs/specs/otel/configuration/file-configuration/ for more information.
-# The following spec defined env vars are NOT referenced and are thus ignored:
+# when interpreting config files. For example, if "disabled: ${OTEL_SDK_DISABLED:-false}"
+# is replaced with "disabled: false", then setting the env var OTEL_SDK_DISABLED will not have
+# any effect. See https://opentelemetry.io/docs/specs/otel/configuration/file-configuration/
+# for more information. The following spec defined env vars are NOT referenced and are thus
+# ignored:
 #
 # - OTEL_RESOURCE_ATTRIBUTES
 # - OTEL_LOG_LEVEL

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "ajv-cli": "^5.0.0"
+  },
+  "dependencies": {
+    "envsub": "^4.1.0"
   }
 }

--- a/schema/common.json
+++ b/schema/common.json
@@ -42,6 +42,9 @@
                 "timeout": {
                     "type": "integer",
                     "minimum": 0
+                },
+                "insecure": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/schema/common.json
+++ b/schema/common.json
@@ -2,49 +2,49 @@
     "$id": "https://opentelemetry.io/otelconfig/common.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Common",
-    "type": "object",
+    "type": ["object", "null"],
     "$defs": {
         "Headers": {
-            "type": "object",
+            "type": ["object", "null"],
             "title": "Headers",
             "patternProperties": {
                 ".*": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 }
             }
         },
         "Otlp": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "protocol": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "pattern": "^(http|grpc)\\/(protobuf|json)"
                 },
                 "endpoint": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "certificate": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "client_key": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "client_certificate": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "headers": {
                     "$ref": "#/$defs/Headers"
                 },
                 "compression": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "timeout": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "insecure": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 }
             },
             "required": [
@@ -54,7 +54,7 @@
             "title": "Otlp"
         },
         "Console": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false
         }
     }

--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -2,7 +2,7 @@
     "$id": "https://opentelemetry.io/otelconfig/logger_provider.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "LoggerProvider",
-    "type": "object",
+    "type": ["object", "null"],
     "additionalProperties": false,
     "properties": {
         "processors": {
@@ -17,7 +17,7 @@
     },
     "$defs": {
         "SimpleLogRecordProcessor": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "exporter": {
@@ -29,23 +29,23 @@
             ]
         },
         "BatchLogRecordProcessor": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "schedule_delay": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "export_timeout": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "max_queue_size": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "max_export_batch_size": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "exporter": {
@@ -57,7 +57,7 @@
             ]
         },
         "LogRecordExporter": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true,
             "minProperties": 1,
             "maxProperties": 1,
@@ -68,26 +68,26 @@
             },
             "patternProperties": {
                 ".*": {
-                    "type": "object"
+                    "type": ["object", "null"]
                 }
             }
         },
         "LogRecordLimits": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "attribute_value_length_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "attribute_count_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 }
             }
         },
         "LogRecordProcessor": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true,
             "minProperties": 1,
             "maxProperties": 1,
@@ -101,7 +101,7 @@
             },
             "patternProperties": {
                 ".*": {
-                    "type": "object"
+                    "type": ["object", "null"]
                 }
             }
         }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -2,7 +2,7 @@
     "$id": "https://opentelemetry.io/otelconfig/meter_provider.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "MeterProvider",
-    "type": "object",
+    "type": ["object", "null"],
     "additionalProperties": false,
     "properties": {
         "readers": {
@@ -20,15 +20,15 @@
     },
     "$defs": {
         "PeriodicMetricReader": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "interval": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "timeout": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "exporter": {
@@ -41,7 +41,7 @@
             "title": "PeriodicMetricReader"
         },
         "PullMetricReader": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "exporter": {
@@ -54,7 +54,7 @@
             "title": "PullMetricReader"
         },
         "MetricExporter": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true,
             "minProperties": 1,
             "maxProperties": 1,
@@ -71,33 +71,33 @@
             },
             "patternProperties": {
                 ".*": {
-                    "type": "object"
+                    "type": ["object", "null"]
                 }
             }
         },
         "Prometheus": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "host": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "port": {
-                    "type": "integer"
+                    "type": ["integer", "null"]
                 },
                 "without_units": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 },
                 "without_type_suffix": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 },
                 "without_scope_info": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 }
             }
         },
         "MetricReader": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "minProperties": 1,
             "maxProperties": 1,
@@ -111,47 +111,47 @@
             }
         },
         "OtlpMetric": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "protocol": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "pattern": "^(http|grpc)\\/(protobuf|json)"
                 },
                 "endpoint": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "certificate": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "client_key": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "client_certificate": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "headers": {
                     "$ref": "common.json#/$defs/Headers"
                 },
                 "compression": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "timeout": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "temporality_preference": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "default_histogram_aggregation": {
-                    "type": "string",
+                    "type": ["string", "null"],
                     "enum": [
                         "explicit_bucket_histogram",
                         "base2_exponential_bucket_histogram"
                     ]
                 },
                 "insecure": {
-                    "type": "boolean"
+                    "type": ["boolean", "null"]
                 }
             },
             "required": [
@@ -161,19 +161,19 @@
             "title": "OtlpMetric"
         },
         "View": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "selector": {
                     "title": "Selector",
-                    "type": "object",
+                    "type": ["object", "null"],
                     "additionalProperties": false,
                     "properties": {
                         "instrument_name": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "instrument_type": {
-                            "type": "string",
+                            "type": ["string", "null"],
                             "enum": [
                                 "counter",
                                 "histogram",
@@ -184,46 +184,46 @@
                             ]
                         },
                         "unit": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "meter_name": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "meter_version": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "meter_schema_url": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         }
                     }
                 },
                 "stream": {
                     "title": "Stream",
-                    "type": "object",
+                    "type": ["object", "null"],
                     "additionalProperties": false,
                     "properties": {
                         "name": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "description": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "aggregation": {
-                            "type": "object",
+                            "type": ["object", "null"],
                             "additionalProperties": false,
                             "minProperties": 1,
                             "maxProperties": 1,
                             "properties": {
                                 "default": {
-                                    "type": "object",
+                                    "type": ["object", "null"],
                                     "additionalProperties": false
                                 },
                                 "drop": {
-                                    "type": "object",
+                                    "type": ["object", "null"],
                                     "additionalProperties": false
                                 },
                                 "explicit_bucket_histogram": {
-                                    "type": "object",
+                                    "type": ["object", "null"],
                                     "additionalProperties": false,
                                     "properties": {
                                         "boundaries": {
@@ -233,31 +233,31 @@
                                             }
                                         },
                                         "record_min_max": {
-                                            "type": "boolean"
+                                            "type": ["boolean", "null"]
                                         }
                                     }
                                 },
                                 "base2_exponential_bucket_histogram": {
-                                    "type": "object",
+                                    "type": ["object", "null"],
                                     "additionalProperties": false,
                                     "properties": {
                                         "max_scale": {
-                                            "type": "integer"
+                                            "type": ["integer", "null"]
                                         },
                                         "max_size": {
-                                            "type": "integer"
+                                            "type": ["integer", "null"]
                                         },
                                         "record_min_max": {
-                                            "type": "boolean"
+                                            "type": ["boolean", "null"]
                                         }
                                     }
                                 },
                                 "last_value": {
-                                    "type": "object",
+                                    "type": ["object", "null"],
                                     "additionalProperties": false
                                 },
                                 "sum": {
-                                    "type": "object",
+                                    "type": ["object", "null"],
                                     "additionalProperties": false
                                 }
                             }
@@ -265,7 +265,7 @@
                         "attribute_keys": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": ["string", "null"]
                             }
                         }
                     }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -149,6 +149,9 @@
                         "explicit_bucket_histogram",
                         "base2_exponential_bucket_histogram"
                     ]
+                },
+                "insecure": {
+                    "type": "boolean"
                 }
             },
             "required": [

--- a/schema/opentelemetry_configuration.json
+++ b/schema/opentelemetry_configuration.json
@@ -2,14 +2,14 @@
     "$id": "https://opentelemetry.io/otelconfig/opentelemetry_configuration.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "OpenTelemetryConfiguration",
-    "type": "object",
+    "type": ["object", "null"],
     "additionalProperties": true,
     "properties": {
         "file_format": {
-            "type": "string"
+            "type": ["string", "null"]
         },
         "disabled": {
-            "type": "boolean"
+            "type": ["boolean", "null"]
         },
         "attribute_limits": {
             "$ref": "#/$defs/AttributeLimits"
@@ -35,14 +35,14 @@
     ],
     "$defs": {
         "AttributeLimits": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true,
             "properties": {
                 "attribute_value_length_limit": {
-                    "type": "integer"
+                    "type": ["integer", "null"]
                 },
                 "attribute_count_limit": {
-                    "type": "integer"
+                    "type": ["integer", "null"]
                 }
             }
         }

--- a/schema/propagator.json
+++ b/schema/propagator.json
@@ -2,7 +2,7 @@
     "$id": "https://opentelemetry.io/otelconfig/propagator.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Propagator",
-    "type": "object",
+    "type": ["object", "null"],
     "minProperties": 1,
     "maxProperties": 1,
     "additionalProperties": true,
@@ -10,7 +10,7 @@
         "composite": {
             "type": "array",
             "items": {
-                "type": "string"
+                "type": ["string", "null"]
             }
         }
     }

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -2,20 +2,20 @@
     "$id": "https://opentelemetry.io/otelconfig/resource.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Resource",
-    "type": "object",
+    "type": ["object", "null"],
     "additionalProperties": false,
     "properties": {
         "attributes": {
             "$ref": "#/$defs/Attributes"
         },
         "schema_url": {
-            "type": "string"
+            "type": ["string", "null"]
         }
     },
     "$defs": {
         "Attributes": {
             "title": "Attributes",
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true
         }
     }

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -16,12 +16,7 @@
         "Attributes": {
             "title": "Attributes",
             "type": "object",
-            "additionalProperties": true,
-            "properties": {
-                "service.name": {
-                    "type": "string"
-                }
-            }
+            "additionalProperties": true
         }
     }
 }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -2,7 +2,7 @@
     "$id": "https://opentelemetry.io/otelconfig/tracer_provider.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "TracerProvider",
-    "type": "object",
+    "type": ["object", "null"],
     "additionalProperties": false,
     "properties": {
         "processors": {
@@ -20,24 +20,24 @@
     },
     "$defs": {
         "BatchSpanProcessor": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "title": "BatchSpanProcessor",
             "properties": {
                 "schedule_delay": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "export_timeout": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "max_queue_size": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "max_export_batch_size": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "exporter": {
@@ -49,28 +49,28 @@
             ]
         },
         "Sampler": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true,
             "minProperties": 1,
             "maxProperties": 1,
             "properties": {
                 "always_off": {
-                    "type": "object",
+                    "type": ["object", "null"],
                     "additionalProperties": false
                 },
                 "always_on": {
-                    "type": "object",
+                    "type": ["object", "null"],
                     "additionalProperties": false
                 },
                 "jaeger_remote": {
-                    "type": "object",
+                    "type": ["object", "null"],
                     "additionalProperties": false,
                     "properties": {
                         "endpoint": {
-                            "type": "string"
+                            "type": ["string", "null"]
                         },
                         "interval": {
-                            "type": "integer",
+                            "type": ["integer", "null"],
                             "minimum": 0
                         },
                         "initial_sampler": {
@@ -79,7 +79,7 @@
                     }
                 },
                 "parent_based": {
-                    "type": "object",
+                    "type": ["object", "null"],
                     "additionalProperties": false,
                     "properties": {
                         "root": {
@@ -100,7 +100,7 @@
                     }
                 },
                 "trace_id_ratio_based": {
-                    "type": "object",
+                    "type": ["object", "null"],
                     "additionalProperties": false,
                     "properties": {
                         "ratio": {
@@ -111,12 +111,12 @@
             },
             "patternProperties": {
                 ".*": {
-                    "type": "object"
+                    "type": ["object", "null"]
                 }
             }
         },
         "SimpleSpanProcessor": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "title": "SimpleSpanProcessor",
             "properties": {
@@ -129,7 +129,7 @@
             ]
         },
         "SpanExporter": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true,
             "minProperties": 1,
             "maxProperties": 1,
@@ -146,42 +146,42 @@
             },
             "patternProperties": {
                 ".*": {
-                    "type": "object"
+                    "type": ["object", "null"]
                 }
             }
         },
         "SpanLimits": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "attribute_value_length_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "attribute_count_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "event_count_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "link_count_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "event_attribute_count_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 },
                 "link_attribute_count_limit": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 }
             }
         },
         "SpanProcessor": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": true,
             "minProperties": 1,
             "maxProperties": 1,
@@ -195,19 +195,19 @@
             },
             "patternProperties": {
                 ".*": {
-                    "type": "object"
+                    "type": ["object", "null"]
                 }
             }
         },
         "Zipkin": {
-            "type": "object",
+            "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
                 "endpoint": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "timeout": {
-                    "type": "integer",
+                    "type": ["integer", "null"],
                     "minimum": 0
                 }
             },


### PR DESCRIPTION
Resolves #55.

Part of the configuration working group recommendation on how to move forward with [#3752](https://github.com/open-telemetry/opentelemetry-specification/issues/3752) as [described here](https://github.com/open-telemetry/opentelemetry-specification/issues/3752#issuecomment-1995582317).

- Part of https://github.com/open-telemetry/opentelemetry-specification/pull/3948
- Adds a new `sdk-migration-config.yaml` to the examples directory, which includes env var substitution references to all env vars which map cleanly to file config
- Adds a new `sdk-config.yaml` to the example directory, which is identical to `sdk-migration-config.yaml`, but without env var substitution references
- Adds a new step to the makefile build which performs env var substitution using [js envsub](https://github.com/danday74/envsub) which allows validation to take place after substitution
- Updates the schema so all types can be null. This ensures a config file is still valid after performing env var substitution with an undefined env var.