### PR TITLE
Add metric producers to meter_provider configuration

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -142,10 +142,10 @@ meter_provider:
               # Configure resource attributes to be excluded, in this example attribute service.attr1.
               excluded:
                 - "service.attr1"
-        # Configure metric producers.
-        producers:
-          # Configure metric producer to be opencensus
-          - opencensus: {}
+      # Configure metric producers.
+      producers:
+        # Configure metric producer to be opencensus
+        - opencensus: {}
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.
@@ -207,10 +207,10 @@ meter_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
             default_histogram_aggregation: base2_exponential_bucket_histogram
-        # Configure metric producers.
-        producers:
-          # Configure metric producer to be prometheus
-          - prometheus: {}
+      # Configure metric producers.
+      producers:
+        # Configure metric producer to be prometheus
+        - prometheus: {}
     # Configure a periodic metric reader.
     - periodic:
         # Configure exporter.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -142,6 +142,10 @@ meter_provider:
               # Configure resource attributes to be excluded, in this example attribute service.attr1.
               excluded:
                 - "service.attr1"
+        # Configure metric producers.
+        producers:
+          # Configure metric producer to be opencensus
+          - opencensus: {}
     # Configure a periodic metric reader.
     - periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.
@@ -203,6 +207,10 @@ meter_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
             default_histogram_aggregation: base2_exponential_bucket_histogram
+        # Configure metric producers.
+        producers:
+          # Configure metric producer to be prometheus
+          - prometheus: {}
     # Configure a periodic metric reader.
     - periodic:
         # Configure exporter.

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -33,6 +33,12 @@
                 },
                 "exporter": {
                     "$ref": "#/$defs/MetricExporter"
+                },
+                "producers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/MetricProducer"
+                    }
                 }
             },
             "required": [
@@ -46,6 +52,12 @@
             "properties": {
                 "exporter": {
                     "$ref": "#/$defs/MetricExporter"
+                },
+                "producers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/MetricProducer"
+                    }
                 }
             },
             "required": [
@@ -67,6 +79,27 @@
                 },
                 "prometheus": {
                     "$ref": "#/$defs/Prometheus"
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "type": "object"
+                }
+            }
+        },
+        "MetricProducer": {
+            "type": "object",
+            "additionalProperties": true,
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+                "opencensus": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "prometheus": {
+                    "type": "object",
+                    "additionalProperties": false
                 }
             },
             "patternProperties": {

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -126,7 +126,6 @@
             "type": "object",
             "additionalProperties": false,
             "minProperties": 1,
-            "maxProperties": 1,
             "properties": {
                 "periodic": {
                     "$ref": "#/$defs/PeriodicMetricReader"

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -126,6 +126,7 @@
             "type": "object",
             "additionalProperties": false,
             "minProperties": 1,
+            "maxProperties": 2,
             "properties": {
                 "periodic": {
                     "$ref": "#/$defs/PeriodicMetricReader"

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -33,12 +33,6 @@
                 },
                 "exporter": {
                     "$ref": "#/$defs/MetricExporter"
-                },
-                "producers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/MetricProducer"
-                    }
                 }
             },
             "required": [
@@ -96,10 +90,6 @@
                 "opencensus": {
                     "type": "object",
                     "additionalProperties": false
-                },
-                "prometheus": {
-                    "type": "object",
-                    "additionalProperties": false
                 }
             },
             "patternProperties": {
@@ -143,6 +133,12 @@
                 },
                 "pull": {
                     "$ref": "#/$defs/PullMetricReader"
+                },
+                "producers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/MetricProducer"
+                    }
                 }
             }
         },


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/4015

Metric producers are registered to metric readers, so i've nested it under the periodic and manual readers.

@gouthamve @jack-berg 