### PR TITLE
adding instrumentation configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Adding Instrumentation configuration
+
 ## v0.1.0 - 2023-10-05
 
 Initial configuration schema release, including:

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ Allowable changes:
 - For major versions: All changes are permitted.
 - For minor versions: TBD
 
-## Naming guidelines
+## Schema Modeling Guidelines
 
-The following defines guidelines used to produce configuration schema:
+The following guidelines are used to model the configuration schema:
 
-1. To remove redundant information from the configuration file, prefixes for data produced by each of the providers
-will be removed from configuration options. For example, under the `meter_provider` configuration, metric readers will be
-identified by the word `readers` rather than by `metric_readers`. Similarly, the prefix `span_` will be dropped for tracer
-provider configuration, and `logrecord` for logger provider.
+* To remove redundant information from the configuration file, prefixes for data produced by each of the providers will be removed from configuration options. For example, under the `meter_provider` configuration, metric readers will be identified by the word `readers` rather than by `metric_readers`. Similarly, the prefix `span_` will be dropped for tracer provider configuration, and `logrecord` for logger provider.
+* Use wildcard `*` (match any number of any character, including none) and `?` (match any single character) instead of regex. If a single property with wildcards is likely to be insufficient, accept `included` and `excluded` properties, each with an array of strings with wildcard entries. The wildcard entries should be joined with a logical OR. If `included` is not specified, assume that all entries are included. Apply `excluded` after applying `included`. Examples:
+  * Given `excluded: ["a*"]`: Match all except values starting with `a`.
+  * Given `included: ["a*", "b*"]`, `excluded: ["ab*"]`: Match any value starting with `a` or `b`, excluding values starting with `ab`.
+  * Given `included: ["a", "b"]`, `excluded: ["a"]`: Match values equal to `b`.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -473,12 +473,21 @@ instrumentation:
         enabled: true
   # Language-specific module options
   java:
+    # Configure Java's Logback Appender instrumentation.
+    #
+    # See https://opentelemetry.io/docs/languages/java/automatic/spring-boot/#logback
     logback-appender:
+      experimental-log-attributes: true
       experimental:
+        capture-code-attributes: true
+        capture-marker-attribute: false
+        capture-key-value-pair-attributes: true
+        capture-logger-context-attributes: false
         capture-mdc-attributes:
           - attr_one
           - attr_two
   php:
+    # Configure PHP's example instrumentation.
     example_instrumentation:
       span_name: test123
       enabled: true

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -434,18 +434,23 @@ resource:
         - process.command_args
   # Configure the resource schema URL.
   schema_url: https://opentelemetry.io/schemas/1.16.0
+
 # Configure instrumentation.
 instrumentation:
   # Configure general SemConv options that may apply to multiple languages and instrumentations.
+  #
+  # Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.
   general:
     # Configure instrumentations following the peer semantic conventions.
     # 
     # See peer semantic conventions: https://opentelemetry.io/docs/specs/semconv/attributes-registry/peer/
     peer:
       # Configure the service mapping for instrumentations following peer.service semantic conventions.
+      #
+      # Each entry is a key value pair where "peer" defines the IP address and "service" defines the corresponding logical name of the service.
       # 
       # See peer.service semantic conventions: https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-remote-service-attributes
-      service-mapping:
+      service_mapping:
         - peer: 1.2.3.4
           service: FooService
         - peer: 2.3.4.5
@@ -456,46 +461,80 @@ instrumentation:
     http:
       # Configure instrumentations following the http client semantic conventions.
       client:
-        request:
-          capture-headers:
-            - X-Foo
-        response:
-          capture-headers:
-            - X-Foo
+        # Configure headers to capture for outbound http requests.
+        request_captured_headers:
+          - Content-Type
+          - Accept
+        # Configure headers to capture for outbound http responses.
+        response_captured_headers:
+          - Content-Type
+          - Content-Encoding
       # Configure instrumentations following the http server semantic conventions.
       server:
-        request:
-          capture-headers:
-            - X-Bar
-        response:
-          capture-headers:
-            - X-Bar
-    # Configure instrumentations following the db semantic conventions.
-    #
-    # See db semantic conventions: https://opentelemetry.io/docs/specs/semconv/database/
-    db:
-      # Configure database statement sanitization.
-      #
-      # See https://opentelemetry.io/docs/specs/semconv/database/database-spans/#common-attributes
-      statement-sanitizer:
-        enabled: true
-  # Language-specific module options
+        # Configure headers to capture for inbound http requests.
+        request_captured_headers:
+          - Content-Type
+          - Accept
+        # Configure headers to capture for outbound http responses.
+        response_captured_headers:
+          - Content-Type
+          - Content-Encoding
+  # Configure language-specific instrumentation libraries.
+  #
+  # Keys may refer to instrumentation libraries or collections of related configuration. Because there is no central schema defining the keys or their contents, instrumentation must carefully document their schema and avoid key collisions with other instrumentations.
+  #
+  # Configure C++ language-specific instrumentation libraries.
+  cpp:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure .NET language-specific instrumentation libraries.
+  dotnet:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure Erlang language-specific instrumentation libraries.
+  erlang:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure Go language-specific instrumentation libraries.
+  go:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure Java language-specific instrumentation libraries.
   java:
-    # Configure Java's Logback Appender instrumentation.
-    #
-    # See https://opentelemetry.io/docs/languages/java/automatic/spring-boot/#logback
-    logback-appender:
-      experimental-log-attributes: true
-      experimental:
-        capture-code-attributes: true
-        capture-marker-attribute: false
-        capture-key-value-pair-attributes: true
-        capture-logger-context-attributes: false
-        capture-mdc-attributes:
-          - attr_one
-          - attr_two
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure JavaScript language-specific instrumentation libraries.
+  js:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure PHP language-specific instrumentation libraries.
   php:
-    # Configure PHP's example instrumentation.
-    example_instrumentation:
-      span_name: test123
-      enabled: true
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure Python language-specific instrumentation libraries.
+  python:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure Ruby language-specific instrumentation libraries.
+  ruby:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure Rust language-specific instrumentation libraries.
+  rust:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"
+  # Configure Swift language-specific instrumentation libraries.
+  swift:
+    # Configure the instrumentation corresponding to key "another_example_key".
+    example:
+      property: "value"

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -485,56 +485,56 @@ instrumentation:
   #
   # Configure C++ language-specific instrumentation libraries.
   cpp:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure .NET language-specific instrumentation libraries.
   dotnet:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure Erlang language-specific instrumentation libraries.
   erlang:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure Go language-specific instrumentation libraries.
   go:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure Java language-specific instrumentation libraries.
   java:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure JavaScript language-specific instrumentation libraries.
   js:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure PHP language-specific instrumentation libraries.
   php:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure Python language-specific instrumentation libraries.
   python:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure Ruby language-specific instrumentation libraries.
   ruby:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure Rust language-specific instrumentation libraries.
   rust:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"
   # Configure Swift language-specific instrumentation libraries.
   swift:
-    # Configure the instrumentation corresponding to key "another_example_key".
+    # Configure the instrumentation corresponding to key "example".
     example:
       property: "value"

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -426,17 +426,27 @@ resource:
         - process.command_args
   # Configure the resource schema URL.
   schema_url: https://opentelemetry.io/schemas/1.16.0
-# Configure instrumentation
+# Configure instrumentation.
 instrumentation:
-  # General SemConv options that may apply to multiple languages
+  # Configure general SemConv options that may apply to multiple languages and instrumentations.
   general:
+    # Configure instrumentations following the peer semantic conventions.
+    # 
+    # See peer semantic conventions: https://opentelemetry.io/docs/specs/semconv/attributes-registry/peer/
     peer:
+      # Configure the service mapping for instrumentations following peer.service semantic conventions.
+      # 
+      # See peer.service semantic conventions: https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-remote-service-attributes
       service-mapping:
         - peer: 1.2.3.4
           service: FooService
         - peer: 2.3.4.5
           service: BarService
+    # Configure instrumentations following the http semantic conventions.
+    # 
+    # See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
     http:
+      # Configure instrumentations following the http client semantic conentions.
       client:
         request:
           capture-headers:

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -426,3 +426,37 @@ resource:
         - process.command_args
   # Configure the resource schema URL.
   schema_url: https://opentelemetry.io/schemas/1.16.0
+# Configure instrumentation
+instrumentation:
+  # Configure options common to multiple languages
+  common:
+    peer-service-mapping:
+      - peer: foo
+        service: bar
+      - peer: bar
+        service: bat
+    http-capture-headers:
+      client:
+        request:
+          - X-Foo
+        response:
+          - X-Foo-*
+      server:
+        request:
+          - X-Bar-*
+        response:
+          - X-Bar
+    db-statement-sanitizer:
+      enabled: true
+      foo: bar
+  # Configure language-specific module options
+  java:
+    logback-appender:
+      experimental:
+        capture-mdc-attributes:
+          - attr_one
+          - attr_two
+  php:
+    example_instrumentation:
+      span_name: test123
+      enabled: true

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -446,7 +446,7 @@ instrumentation:
     # 
     # See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
     http:
-      # Configure instrumentations following the http client semantic conentions.
+      # Configure instrumentations following the http client semantic conventions.
       client:
         request:
           capture-headers:
@@ -454,6 +454,7 @@ instrumentation:
         response:
           capture-headers:
             - X-Foo
+      # Configure instrumentations following the http server semantic conventions.
       server:
         request:
           capture-headers:
@@ -461,7 +462,13 @@ instrumentation:
         response:
           capture-headers:
             - X-Bar
+    # Configure instrumentations following the db semantic conventions.
+    #
+    # See db semantic conventions: https://opentelemetry.io/docs/specs/semconv/database/
     db:
+      # Configure database statement sanitization.
+      #
+      # See https://opentelemetry.io/docs/specs/semconv/database/database-spans/#common-attributes
       statement-sanitizer:
         enabled: true
   # Language-specific module options

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -432,10 +432,10 @@ instrumentation:
   general:
     peer:
       service-mapping:
-        - peer: foo
-          service: bar
-        - peer: bar
-          service: bat
+        - peer: 1.2.3.4
+          service: FooService
+        - peer: 2.3.4.5
+          service: BarService
     http:
       client:
         request:

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -428,28 +428,33 @@ resource:
   schema_url: https://opentelemetry.io/schemas/1.16.0
 # Configure instrumentation
 instrumentation:
-  # Configure options common to multiple languages
-  common:
-    peer-service-mapping:
-      - peer: foo
-        service: bar
-      - peer: bar
-        service: bat
-    http-capture-headers:
+  # General SemConv options that may apply to multiple languages
+  general:
+    peer:
+      service-mapping:
+        - peer: foo
+          service: bar
+        - peer: bar
+          service: bat
+    http:
       client:
         request:
-          - X-Foo
+          capture-headers:
+            - X-Foo
         response:
-          - X-Foo-*
+          capture-headers:
+            - X-Foo
       server:
         request:
-          - X-Bar-*
+          capture-headers:
+            - X-Bar
         response:
-          - X-Bar
-    db-statement-sanitizer:
-      enabled: true
-      foo: bar
-  # Configure language-specific module options
+          capture-headers:
+            - X-Bar
+    db:
+      statement-sanitizer:
+        enabled: true
+  # Language-specific module options
   java:
     logback-appender:
       experimental:

--- a/schema/instrumentation.json
+++ b/schema/instrumentation.json
@@ -3,34 +3,47 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Instrumentation",
     "type": "object",
-    "additionalProperties": true,
+    "additionalProperties": false,
     "properties": {
-        "common": {
+        "general": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "peer-service-mapping": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/PeerServiceMapping"
+                "peer": {
+                    "type": "object",
+                    "properties": {
+                        "service-mapping": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/PeerServiceMapping"
+                            }
+                        }
                     }
                 },
-                "http-capture-headers": {
+                "http": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "client": {
-                            "$ref": "#/$defs/RequestResponseHeaders"
+                            "$ref": "#/$defs/RequestResponseCaptureHeaders"
                         },
                         "server": {
-                            "$ref": "#/$defs/RequestResponseHeaders"
+                            "$ref": "#/$defs/RequestResponseCaptureHeaders"
                         }
-                    },
-                    "additionalProperties": false
+                    }
                 },
-                "db-statement-sanitizer": {
+                "db": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "enabled": {
-                            "type": "boolean"
+                        "statement-sanitizer": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 }
@@ -72,17 +85,26 @@
                 "type": "string"
             }
         },
-        "RequestResponseHeaders": {
+        "CaptureHeaders": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "request": {
-                    "$ref": "#/$defs/ArrayOfHeaders"
-                },
-                "response": {
+                "capture-headers": {
                     "$ref": "#/$defs/ArrayOfHeaders"
                 }
-            },
-            "additionalProperties": false
+            }
+        },
+        "RequestResponseCaptureHeaders": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "request": {
+                    "$ref": "#/$defs/CaptureHeaders"
+                },
+                "response": {
+                    "$ref": "#/$defs/CaptureHeaders"
+                }
+            }
         },
         "JavaModules": {},
         "JsModules": {},

--- a/schema/instrumentation.json
+++ b/schema/instrumentation.json
@@ -6,16 +6,73 @@
     "additionalProperties": false,
     "properties": {
         "general": {
+            "$ref": "#/$defs/GeneralInstrumentation"
+        },
+        "cpp": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "dotnet": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "erlang": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "go": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "java": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "js": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "php": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "python": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "ruby": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "rust": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        },
+        "swift": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        }
+    },
+    "patternProperties": {
+        ".*": {
+            "$ref": "#/$defs/LanguageSpecificInstrumentation"
+        }
+    },
+    "$defs": {
+        "GeneralInstrumentation": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "peer": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
-                        "service-mapping": {
+                        "service_mapping": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/$defs/PeerServiceMapping"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "peer": {
+                                        "type": "string"
+                                    },
+                                    "service": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "peer",
+                                    "service"
+                                ]
                             }
                         }
                     }
@@ -25,23 +82,38 @@
                     "additionalProperties": false,
                     "properties": {
                         "client": {
-                            "$ref": "#/$defs/RequestResponseCaptureHeaders"
-                        },
-                        "server": {
-                            "$ref": "#/$defs/RequestResponseCaptureHeaders"
-                        }
-                    }
-                },
-                "db": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "statement-sanitizer": {
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
-                                "enabled": {
-                                    "type": "boolean"
+                                "request_captured_headers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "response_captured_headers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "server": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "request_captured_headers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "response_captured_headers": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
                                 }
                             }
                         }
@@ -49,98 +121,14 @@
                 }
             }
         },
-        "android": {
-            "$ref": "#/$defs/AndroidModules"
-        },
-        "cpp": {
-            "$ref": "#/$defs/CppModules"
-        },
-        "dotnet": {
-            "$ref": "#/$defs/DotnetModules"
-        },
-        "erlang": {
-            "$ref": "#/$defs/ErlangModules"
-        },
-        "go": {
-            "$ref": "#/$defs/GoModules"
-        },
-        "java": {
-            "$ref": "#/$defs/JavaModules"
-        },
-        "js": {
-            "$ref": "#/$defs/JsModules"
-        },
-        "php": {
-            "$ref": "#/$defs/PhpModules"
-        },
-        "python": {
-            "$ref": "#/$defs/PythonModules"
-        },
-        "ruby": {
-            "$ref": "#/$defs/RubyModules"
-        },
-        "rust": {
-            "$ref": "#/$defs/RustModules"
-        },
-        "swift": {
-            "$ref": "#/$defs/SwiftModules"
+        "LanguageSpecificInstrumentation": {
+            "type": "object",
+            "additionalProperties": true,
+            "patternProperties": {
+                ".*": {
+                    "type": "object"
+                }
+            }
         }
-    },
-    "$defs": {
-        "PeerServiceMapping": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "peer": {
-                    "type": "string"
-                },
-                "service": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "peer",
-                "service"
-            ]
-        },
-        "ArrayOfHeaders": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
-        },
-        "CaptureHeaders": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "capture-headers": {
-                    "$ref": "#/$defs/ArrayOfHeaders"
-                }
-            }
-        },
-        "RequestResponseCaptureHeaders": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "request": {
-                    "$ref": "#/$defs/CaptureHeaders"
-                },
-                "response": {
-                    "$ref": "#/$defs/CaptureHeaders"
-                }
-            }
-        },
-        "AndroidModules": {},
-        "CppModules": {},
-        "DotnetModules": {},
-        "ErlangModules": {},
-        "GoModules": {},
-        "JavaModules": {},
-        "JsModules": {},
-        "PhpModules": {},
-        "PythonModules": {},
-        "RubyModules": {},
-        "RustModules": {},
-        "SwiftModules": {}
     }
 }

--- a/schema/instrumentation.json
+++ b/schema/instrumentation.json
@@ -1,0 +1,92 @@
+{
+    "$id": "https://opentelemetry.io/otelconfig/instrumentation.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Instrumentation",
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "common": {
+            "type": "object",
+            "properties": {
+                "peer-service-mapping": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/PeerServiceMapping"
+                    }
+                },
+                "http-capture-headers": {
+                    "type": "object",
+                    "properties": {
+                        "client": {
+                            "$ref": "#/$defs/RequestResponseHeaders"
+                        },
+                        "server": {
+                            "$ref": "#/$defs/RequestResponseHeaders"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "db-statement-sanitizer": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "java": {
+            "$ref": "#/$defs/JavaModules"
+        },
+        "js": {
+            "$ref": "#/$defs/JsModules"
+        },
+        "php": {
+            "$ref": "#/$defs/PhpModules"
+        },
+        "python": {
+            "$ref": "#/$defs/PythonModules"
+        }
+    },
+    "$defs": {
+        "PeerServiceMapping": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "peer": {
+                    "type": "string"
+                },
+                "service": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "peer",
+                "service"
+            ]
+        },
+        "ArrayOfHeaders": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "RequestResponseHeaders": {
+            "type": "object",
+            "properties": {
+                "request": {
+                    "$ref": "#/$defs/ArrayOfHeaders"
+                },
+                "response": {
+                    "$ref": "#/$defs/ArrayOfHeaders"
+                }
+            },
+            "additionalProperties": false
+        },
+        "JavaModules": {},
+        "JsModules": {},
+        "PhpModules": {},
+        "PythonModules": {}
+    }
+}

--- a/schema/instrumentation.json
+++ b/schema/instrumentation.json
@@ -49,6 +49,21 @@
                 }
             }
         },
+        "android": {
+            "$ref": "#/$defs/AndroidModules"
+        },
+        "cpp": {
+            "$ref": "#/$defs/CppModules"
+        },
+        "dotnet": {
+            "$ref": "#/$defs/DotnetModules"
+        },
+        "erlang": {
+            "$ref": "#/$defs/ErlangModules"
+        },
+        "go": {
+            "$ref": "#/$defs/GoModules"
+        },
         "java": {
             "$ref": "#/$defs/JavaModules"
         },
@@ -60,6 +75,15 @@
         },
         "python": {
             "$ref": "#/$defs/PythonModules"
+        },
+        "ruby": {
+            "$ref": "#/$defs/RubyModules"
+        },
+        "rust": {
+            "$ref": "#/$defs/RustModules"
+        },
+        "swift": {
+            "$ref": "#/$defs/SwiftModules"
         }
     },
     "$defs": {
@@ -106,9 +130,17 @@
                 }
             }
         },
+        "AndroidModules": {},
+        "CppModules": {},
+        "DotnetModules": {},
+        "ErlangModules": {},
+        "GoModules": {},
         "JavaModules": {},
         "JsModules": {},
         "PhpModules": {},
-        "PythonModules": {}
+        "PythonModules": {},
+        "RubyModules": {},
+        "RustModules": {},
+        "SwiftModules": {}
     }
 }

--- a/schema/opentelemetry_configuration.json
+++ b/schema/opentelemetry_configuration.json
@@ -28,6 +28,9 @@
         },
         "resource": {
             "$ref": "resource.json"
+        },
+        "instrumentation": {
+            "$ref": "instrumentation.json"
         }
     },
     "required": [


### PR DESCRIPTION
Initial draft of adding instrumentation configuration.
- added all of the instrumentation-specific examples I found in https://github.com/MrAlias/otel-schema/issues/8
- a `common` property for settings that are common to multiple instrumentations (ie, `otel.instrumentation.common.*`), and added schema for the ones I know about
- a series of language-specific properties, which are deliberately vague

Closes: #87 