### PR TITLE
Remove unnecessary MetricProducer in pull metric reader

### DIFF
--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -46,12 +46,6 @@
             "properties": {
                 "exporter": {
                     "$ref": "#/$defs/MetricExporter"
-                },
-                "producers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/MetricProducer"
-                    }
                 }
             },
             "required": [


### PR DESCRIPTION
Oversight from https://github.com/open-telemetry/opentelemetry-configuration/pull/90

Addresses https://github.com/open-telemetry/opentelemetry-configuration/pull/90/files#r1613176195