### PR TITLE
Add modeling rule for property name case

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Only properties which are described in [opentelemetry-specification](https://git
 
 To remove redundant information from the configuration file, prefixes for data produced by each of the providers will be removed from configuration options. For example, under the `meter_provider` configuration, metric readers are identified by the word `readers` rather than by `metric_readers`. Similarly, the prefix `span_` will be dropped for tracer provider configuration, and `logrecord` for logger provider.
 
+### Property name case
+
+Properties defined in the schema should be lower [snake case](https://en.wikipedia.org/wiki/Snake_case).
+
 ### Properties which pattern matching
 
 When a property requires pattern matching, use wildcard `*` (match any number of any character, including none) and `?` (match any single character) instead of regex. If a single property with wildcards is likely to be insufficient to model the configuration requirements, accept `included` and `excluded` properties, each with an array of strings with wildcard entries. The wildcard entries should be joined with a logical OR. If `included` is not specified, assume that all entries are included. Apply `excluded` after applying `included`. Examples:


### PR DESCRIPTION
Properties should be lowe_snake_case. Adding this a modeling rule promotes consistency within the schema. The choice of lower_snake_case is consistent with collector YAML.

Originally discussed in [this comment](https://github.com/open-telemetry/opentelemetry-configuration/pull/91/#pullrequestreview-2085817043)