### PR TITLE
add exporter retry configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+ * Add exporter `retry` configuration.
+
 ## [v0.2.0] - 2024-05-08
 
 * Document time value units in kitchen-sink example. [#51](https://github.com/open-telemetry/opentelemetry-configuration/pull/51)

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -91,6 +91,12 @@ logger_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_INSECURE, OTEL_EXPORTER_OTLP_LOGS_INSECURE
             insecure: false
+            # Configure retry policy
+            retry:
+              # Configure maximum number of retries before failing.
+              max_attempts: 3
+              # Configure initial delay (in milliseconds) to be used for exponential backoff with jitter.
+              initial_delay: 100
     # Configure a simple span processor.
     - simple:
         # Configure exporter.

--- a/schema/common.json
+++ b/schema/common.json
@@ -63,6 +63,9 @@
                 },
                 "insecure": {
                     "type": "boolean"
+                },
+                "retry": {
+                    "$ref": "#/$defs/Retry"
                 }
             },
             "required": [
@@ -74,6 +77,19 @@
         "Console": {
             "type": "object",
             "additionalProperties": false
+        },
+        "Retry": {
+            "type": "object",
+            "properties": {
+                "max_attempts": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "initial_delay": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
https://opentelemetry.io/docs/specs/otlp/#otlphttp-throttling and https://opentelemetry.io/docs/specs/otlp/#otlpgrpc-throttling describe how a client SHOULD implement an exponential backoff strategy (with jitter) in case of retryable export failures. The inputs to this strategy are usually the initial delay, and max attempts.