### PR TITLE
Add Default Histogram Aggregation in prometheus schema

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -142,6 +142,7 @@ meter_provider:
               # Configure resource attributes to be excluded, in this example attribute service.attr1.
               excluded:
                 - "service.attr1"
+            default_histogram_aggregation: "base2_exponential_bucket_histogram"
       # Configure metric producers.
       producers:
         # Configure metric producer to be opencensus
@@ -442,13 +443,13 @@ instrumentation:
   # Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.
   general:
     # Configure instrumentations following the peer semantic conventions.
-    # 
+    #
     # See peer semantic conventions: https://opentelemetry.io/docs/specs/semconv/attributes-registry/peer/
     peer:
       # Configure the service mapping for instrumentations following peer.service semantic conventions.
       #
       # Each entry is a key value pair where "peer" defines the IP address and "service" defines the corresponding logical name of the service.
-      # 
+      #
       # See peer.service semantic conventions: https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-remote-service-attributes
       service_mapping:
         - peer: 1.2.3.4
@@ -456,7 +457,7 @@ instrumentation:
         - peer: 2.3.4.5
           service: BarService
     # Configure instrumentations following the http semantic conventions.
-    # 
+    #
     # See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
     http:
       # Configure instrumentations following the http client semantic conventions.

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -114,7 +114,7 @@
                 "with_resource_constant_labels": {
                     "$ref": "common.json#/$defs/IncludeExclude"
                 },
-								"default_histogram_aggregation": {
+							  "default_histogram_aggregation": {
                     "type": "string",
                     "enum": [
                         "explicit_bucket_histogram",

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -114,7 +114,7 @@
                 "with_resource_constant_labels": {
                     "$ref": "common.json#/$defs/IncludeExclude"
                 },
-							  "default_histogram_aggregation": {
+	        "default_histogram_aggregation": {
                     "type": "string",
                     "enum": [
                         "explicit_bucket_histogram",

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -113,6 +113,13 @@
                 },
                 "with_resource_constant_labels": {
                     "$ref": "common.json#/$defs/IncludeExclude"
+                },
+								"default_histogram_aggregation": {
+                    "type": "string",
+                    "enum": [
+                        "explicit_bucket_histogram",
+                        "base2_exponential_bucket_histogram"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
Adds support for providing default_histogram_aggregation via a config file for Prometheus Metric Exporter. 
Support for configuring Default Histogram Aggregation for Prometheus exporter is added in this PR: https://github.com/open-telemetry/opentelemetry-java/pull/6541.