### PR TITLE
Configure exporter default aggregation and temporality preference

### DIFF
--- a/examples/anchors.yaml
+++ b/examples/anchors.yaml
@@ -32,7 +32,9 @@ meter_provider:
             <<: *otlp-exporter
             endpoint: http://localhost:4318/v1/metrics
             temporality_preference: delta
-            default_histogram_aggregation: base2_exponential_bucket_histogram
+            default_aggregation_by_instrument_kind:
+              histogram:
+                base2_exponential_bucket_histogram:
 
 tracer_provider:
   processors:

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -142,6 +142,8 @@ meter_provider:
               # Configure resource attributes to be excluded, in this example attribute service.attr1.
               excluded:
                 - "service.attr1"
+            # Configure default aggregation as a function of instrument kind.
+            default_aggregation_by_instrument_kind:
       # Configure metric producers.
       producers:
         # Configure metric producer to be opencensus
@@ -203,10 +205,13 @@ meter_provider:
             #
             # Environment variable: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
             temporality_preference: delta
-            # Configure default histogram aggregation.
+            # Configure default aggregation as a function of instrument kind.
             #
             # Environment variable: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
-            default_histogram_aggregation: base2_exponential_bucket_histogram
+            default_aggregation_by_instrument_kind:
+              # Configure default aggregation for histograms.
+              histogram:
+                base2_exponential_bucket_histogram:
       # Configure metric producers.
       producers:
         # Configure metric producer to be prometheus
@@ -216,7 +221,29 @@ meter_provider:
         # Configure exporter.
         exporter:
           # Configure exporter to be console.
-          console: {}
+          console:
+            # Configure temporality preference.
+            temporality_preference: delta
+            # Configure default aggregation as a function of instrument kind.
+            default_aggregation_by_instrument_kind:
+              # Configure default aggregation for counters.
+              counter:
+                sum:
+              # Configure default aggregation for histograms.
+              histogram:
+                base2_exponential_bucket_histogram:
+              # Configure default aggregation for observable counters.
+              observable_counter:
+                sum:
+              # Configure default aggregation for observable gauges.
+              observable_gauge:
+                last_value:
+              # Configure default aggregation for observable up down counters.
+              observable_up_down_counter:
+                sum:
+              # Configure default aggregation for up down counters.
+              up_down_counter:
+                sum:
   # Configure views. Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s).
   views:
     # Configure a view.
@@ -442,13 +469,13 @@ instrumentation:
   # Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.
   general:
     # Configure instrumentations following the peer semantic conventions.
-    # 
+    #
     # See peer semantic conventions: https://opentelemetry.io/docs/specs/semconv/attributes-registry/peer/
     peer:
       # Configure the service mapping for instrumentations following peer.service semantic conventions.
       #
       # Each entry is a key value pair where "peer" defines the IP address and "service" defines the corresponding logical name of the service.
-      # 
+      #
       # See peer.service semantic conventions: https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-remote-service-attributes
       service_mapping:
         - peer: 1.2.3.4
@@ -456,7 +483,7 @@ instrumentation:
         - peer: 2.3.4.5
           service: BarService
     # Configure instrumentations following the http semantic conventions.
-    # 
+    #
     # See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
     http:
       # Configure instrumentations following the http client semantic conventions.

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -134,8 +134,8 @@ meter_provider:
             headers: {}
             # Configure temporality preference.
             temporality_preference: cumulative
-            # Configure default histogram aggregation.
-            default_histogram_aggregation: explicit_bucket_histogram
+            # Configure default aggregation by instrument kind.
+            default_aggregation_by_instrument_kind:
 
 # Configure logger provider.
 logger_provider:

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -36,6 +36,7 @@
 # - OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_{SIGNAL}_HEADERS
 # - OTEL_EXPORTER_OTLP_COMPRESSION
 # - OTEL_EXPORTER_OTLP_TIMEOUT
+# - OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
 
 # The file format version
 file_format: "0.1"
@@ -166,8 +167,8 @@ meter_provider:
             headers: {}
             # Configure temporality preference.
             temporality_preference: ${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
-            # Configure default histogram aggregation.
-            default_histogram_aggregation: ${OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION:-explicit_bucket_histogram}
+            # Configure default aggregation by instrument kind.
+            default_aggregation_by_instrument_kind:
 
 # Configure logger provider.
 logger_provider:

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -63,7 +63,7 @@
                     "$ref": "#/$defs/OtlpMetric"
                 },
                 "console": {
-                    "$ref": "common.json#/$defs/Console"
+                    "$ref": "#/$defs/ConsoleMetric"
                 },
                 "prometheus": {
                     "$ref": "#/$defs/Prometheus"
@@ -113,6 +113,9 @@
                 },
                 "with_resource_constant_labels": {
                     "$ref": "common.json#/$defs/IncludeExclude"
+                },
+                "default_aggregation_by_instrument_kind": {
+                    "$ref": "#/$defs/DefaultAggregationByInstrumentKind"
                 }
             }
         },
@@ -167,14 +170,10 @@
                     "minimum": 0
                 },
                 "temporality_preference": {
-                    "type": ["string", "null"]
+                    "$ref": "#/$defs/AggregationTemporalityPreference"
                 },
-                "default_histogram_aggregation": {
-                    "type": ["string", "null"],
-                    "enum": [
-                        "explicit_bucket_histogram",
-                        "base2_exponential_bucket_histogram"
-                    ]
+                "default_aggregation_by_instrument_kind": {
+                    "$ref": "#/$defs/DefaultAggregationByInstrumentKind"
                 },
                 "insecure": {
                     "type": ["boolean", "null"]
@@ -185,6 +184,116 @@
                 "protocol"
             ],
             "title": "OtlpMetric"
+        },
+        "AggregationTemporalityPreferenceByInstrumentKind": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "counter": {
+                    "$ref": "#/$defs/AggregationTemporality"
+                },
+                "histogram": {
+                    "$ref": "#/$defs/AggregationTemporality"
+                },
+                "observable_counter": {
+                    "$ref": "#/$defs/AggregationTemporality"
+                },
+                "observable_gauge": {
+                    "$ref": "#/$defs/AggregationTemporality"
+                },
+                "observable_up_down_counter": {
+                    "$ref": "#/$defs/AggregationTemporality"
+                },
+                "up_down_counter": {
+                    "$ref": "#/$defs/AggregationTemporality"
+                }
+            }
+        },
+        "AggregationTemporalityPreference": {
+            "type": ["string", "null"],
+            "enum": [
+                "delta",
+                "cumulative",
+                "low_memory"
+            ]
+        },
+        "DefaultAggregationByInstrumentKind": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "counter": {
+                    "$ref": "#/$defs/Aggregation"
+                },
+                "histogram": {
+                    "$ref": "#/$defs/Aggregation"
+                },
+                "observable_counter": {
+                    "$ref": "#/$defs/Aggregation"
+                },
+                "observable_gauge": {
+                    "$ref": "#/$defs/Aggregation"
+                },
+                "observable_up_down_counter": {
+                    "$ref": "#/$defs/Aggregation"
+                },
+                "up_down_counter": {
+                    "$ref": "#/$defs/Aggregation"
+                }
+            }
+        },
+        "Aggregation": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+                "default": {
+                    "type": ["object", "null"],
+                    "additionalProperties": false
+                },
+                "drop": {
+                    "type": ["object", "null"],
+                    "additionalProperties": false
+                },
+                "explicit_bucket_histogram": {
+                    "type": ["object", "null"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "boundaries": {
+                            "type": "array",
+                            "items": {
+                                "type": "number"
+                            }
+                        },
+                        "record_min_max": {
+                            "type": ["boolean", "null"]
+                        }
+                    }
+                },
+                "base2_exponential_bucket_histogram": {
+                    "type": ["object", "null"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "max_scale": {
+                            "type": ["integer", "null"]
+                        },
+                        "max_size": {
+                            "type": ["integer", "null"]
+                        },
+                        "record_min_max": {
+                            "type": ["boolean", "null"]
+                        }
+                    }
+                },
+                "last_value": {
+                    "type": ["object", "null"],
+                    "additionalProperties": false
+                },
+                "sum": {
+                    "type": ["object", "null"],
+                    "additionalProperties": false
+                }
+            }
         },
         "View": {
             "type": ["object", "null"],
@@ -235,58 +344,7 @@
                             "type": ["string", "null"]
                         },
                         "aggregation": {
-                            "type": ["object", "null"],
-                            "additionalProperties": false,
-                            "minProperties": 1,
-                            "maxProperties": 1,
-                            "properties": {
-                                "default": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                },
-                                "drop": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                },
-                                "explicit_bucket_histogram": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "boundaries": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "record_min_max": {
-                                            "type": ["boolean", "null"]
-                                        }
-                                    }
-                                },
-                                "base2_exponential_bucket_histogram": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "max_scale": {
-                                            "type": ["integer", "null"]
-                                        },
-                                        "max_size": {
-                                            "type": ["integer", "null"]
-                                        },
-                                        "record_min_max": {
-                                            "type": ["boolean", "null"]
-                                        }
-                                    }
-                                },
-                                "last_value": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                },
-                                "sum": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                }
-                            }
+                            "$ref": "#/$defs/Aggregation"
                         },
                         "attribute_keys": {
                             "type": "array",
@@ -295,6 +353,18 @@
                             }
                         }
                     }
+                }
+            }
+        },
+        "ConsoleMetric": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "temporality_preference": {
+                    "$ref": "#/$defs/AggregationTemporalityPreference"
+                },
+                "default_aggregation_by_instrument_kind": {
+                    "$ref": "#/$defs/DefaultAggregationByInstrumentKind"
                 }
             }
         }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -185,30 +185,6 @@
             ],
             "title": "OtlpMetric"
         },
-        "AggregationTemporalityPreferenceByInstrumentKind": {
-            "type": ["object", "null"],
-            "additionalProperties": false,
-            "properties": {
-                "counter": {
-                    "$ref": "#/$defs/AggregationTemporality"
-                },
-                "histogram": {
-                    "$ref": "#/$defs/AggregationTemporality"
-                },
-                "observable_counter": {
-                    "$ref": "#/$defs/AggregationTemporality"
-                },
-                "observable_gauge": {
-                    "$ref": "#/$defs/AggregationTemporality"
-                },
-                "observable_up_down_counter": {
-                    "$ref": "#/$defs/AggregationTemporality"
-                },
-                "up_down_counter": {
-                    "$ref": "#/$defs/AggregationTemporality"
-                }
-            }
-        },
         "AggregationTemporalityPreference": {
             "type": ["string", "null"],
             "enum": [


### PR DESCRIPTION
With https://github.com/open-telemetry/opentelemetry-specification/pull/4142 merged, the spec now has explicit configuration options for each metric exporter's temporality preference and default temporality.

This PR extends the metric exporters with new properties:

- console exporter has new `temporality_preference` and `default_aggregation_by_instrument_kind` properties
- prometheus exporter has new `default_aggregation_by_instrument_kind` property
- otlp exporter's `default_histogram_aggregation` property migrates to new more expressive `default_aggregation_by_instrument_kind` property

This supersedes #99.