### PR TITLE
[SCHEMA] The MetricExporter schema is unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Adding initial instrumentation configuration schema
+* [SCHEMA] The MetricExporter schema is unsafe [#110](https://github.com/open-telemetry/opentelemetry-configuration/pull/110)
 
 ## [v0.2.0] - 2024-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Adding initial instrumentation configuration schema
-* [SCHEMA] The MetricExporter schema is unsafe [#110](https://github.com/open-telemetry/opentelemetry-configuration/pull/110)
+* Split MetricExporter into PullMetricExporter and PushMetricExporter and ensure only PushMetricExporters can be associated with PeriodicMetricReader [#110](https://github.com/open-telemetry/opentelemetry-configuration/pull/110)
 
 ## [v0.2.0] - 2024-05-08
 

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -32,7 +32,7 @@
                     "minimum": 0
                 },
                 "exporter": {
-                    "$ref": "#/$defs/MetricExporter"
+                    "$ref": "#/$defs/PushMetricExporter"
                 }
             },
             "required": [
@@ -45,7 +45,7 @@
             "additionalProperties": false,
             "properties": {
                 "exporter": {
-                    "$ref": "#/$defs/MetricExporter"
+                    "$ref": "#/$defs/PullMetricExporter"
                 }
             },
             "required": [
@@ -53,7 +53,7 @@
             ],
             "title": "PullMetricReader"
         },
-        "MetricExporter": {
+        "PushMetricExporter": {
             "type": ["object", "null"],
             "additionalProperties": true,
             "minProperties": 1,
@@ -64,7 +64,20 @@
                 },
                 "console": {
                     "$ref": "common.json#/$defs/Console"
-                },
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "type": ["object", "null"]
+                }
+            }
+        },
+        "PullMetricExporter": {
+            "type": ["object", "null"],
+            "additionalProperties": true,
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
                 "prometheus": {
                     "$ref": "#/$defs/Prometheus"
                 }


### PR DESCRIPTION
Fixes #109

## Changes

Split `MetricExporter` into:

* `PushMetricExporter`, which can represent `otlp`, `console`, or an extension point,
* `PullMetricExporter`, which can represent `prometheus`, or an extension point,

This is to enforce that:

* `PeriodicMetricReader` can only use a `PushMetricExporter`
* `PullMetricReader` can only use a `PullMetricExporter`
