### PR TITLE
fix: update attribute_keys to include type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Adding initial instrumentation configuration schema
 * Split MetricExporter into PullMetricExporter and PushMetricExporter and ensure only PushMetricExporters can be associated with PeriodicMetricReader [#110](https://github.com/open-telemetry/opentelemetry-configuration/pull/110)
-* Update `attribute_keys` from array to to Include type
+* Update `attribute_keys` from array to to Include type [#111](https://github.com/open-telemetry/opentelemetry-configuration/pull/111)
 
 ## [v0.2.0] - 2024-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Adding initial instrumentation configuration schema
 * Split MetricExporter into PullMetricExporter and PushMetricExporter and ensure only PushMetricExporters can be associated with PeriodicMetricReader [#110](https://github.com/open-telemetry/opentelemetry-configuration/pull/110)
+* Update `attribute_keys` from array to to Include type
 
 ## [v0.2.0] - 2024-05-08
 

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -249,8 +249,10 @@ meter_provider:
             record_min_max: true
         # Configure attribute keys retained in the resulting stream(s).
         attribute_keys:
-          - key1
-          - key2
+          # Configure list of attribute key patterns attribute keys retained in the resulting stream(s).
+          included:
+            - key1
+            - key2
 
 # Configure text map context propagators.
 #

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -249,7 +249,7 @@ meter_provider:
             record_min_max: true
         # Configure attribute keys retained in the resulting stream(s).
         attribute_keys:
-          # Configure list of attribute key patterns that are retained in the resulting stream(s).
+          # Configure list of attribute keys that are retained in the resulting stream(s).
           # All other attributes not matching will be dropped.
           included:
             - key1

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -249,7 +249,8 @@ meter_provider:
             record_min_max: true
         # Configure attribute keys retained in the resulting stream(s).
         attribute_keys:
-          # Configure list of attribute key patterns attribute keys retained in the resulting stream(s).
+          # Configure list of attribute key patterns that are retained in the resulting stream(s).
+          # All other attributes not matching will be dropped.
           included:
             - key1
             - key2

--- a/schema/common.json
+++ b/schema/common.json
@@ -31,6 +31,18 @@
                 }
             }
         },
+        "Include": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "included": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "Otlp": {
             "type": ["object", "null"],
             "additionalProperties": false,

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -302,10 +302,7 @@
                             }
                         },
                         "attribute_keys": {
-                            "type": "array",
-                            "items": {
-                                "type": ["string", "null"]
-                            }
+                            "$ref": "common.json#/$defs/Include"
                         }
                     }
                 }


### PR DESCRIPTION
This updates the stream's `attribute_keys` configuration to an include/exclude style object that currently only supports `included`. This is in hope to support `excluded` in the future once the specification allows it.

Fixes #98