### PR TITLE
stream: update stream configuration to include/exclude

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -254,6 +254,8 @@ meter_provider:
           included:
             - key1
             - key2
+          excluded:
+            - key3
 
 # Configure text map context propagators.
 #

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -143,7 +143,7 @@ meter_provider:
               # Configure resource attributes to be included, in this example attributes starting with service.
               included:
                 - "service*"
-              # Configure resource attributes to be excluded, in this example attribute service.attr1.
+              # Configure resource attributes to be excluded, in this example attribute service.attr1. Applies after .with_resource_constant_labels.included (i.e. excluded has higher priority than included).
               excluded:
                 - "service.attr1"
       # Configure metric producers.
@@ -262,6 +262,7 @@ meter_provider:
           included:
             - key1
             - key2
+          # Configure resource attributes to be excluded, in this example attribute service.attr1.
           excluded:
             - key3
 

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -262,7 +262,7 @@ meter_provider:
           included:
             - key1
             - key2
-          # Configure resource attributes to be excluded, in this example attribute service.attr1.
+          # Configure list of attribute keys that are excluded in the resulting stream(s), in this example attribute key3. Applies after .attribute_keys.included (i.e. excluded has higher priority than included).
           excluded:
             - key3
 

--- a/schema/common.json
+++ b/schema/common.json
@@ -31,18 +31,6 @@
                 }
             }
         },
-        "Include": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "included": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
         "Otlp": {
             "type": ["object", "null"],
             "additionalProperties": false,

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -302,7 +302,7 @@
                             }
                         },
                         "attribute_keys": {
-                            "$ref": "common.json#/$defs/Include"
+                            "$ref": "common.json#/$defs/IncludeExclude"
                         }
                     }
                 }


### PR DESCRIPTION
This follows https://github.com/open-telemetry/opentelemetry-specification/pull/4188 to add support to exclude attribute keys from stream configuration.

Fixes https://github.com/open-telemetry/opentelemetry-configuration/issues/112