### PR TITLE
Update CODEOWNERS to include configuration-approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/configuration-maintainers
+* @open-telemetry/configuration-approvers


### PR DESCRIPTION
I noticed that https://github.com/open-telemetry/opentelemetry-configuration/pull/122 has required approvals but is still blocked from merging. Realized that we never updated `CODEOWNERS` to include the new @open-telemetry/configuration-approvers team.