### PR TITLE
Rebrand file configuration to declarative configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JSON Schema Definitions for OpenTelemetry File Configuration
+# JSON Schema Definitions for OpenTelemetry Declarative Configuration
 
 [![Build Check](https://github.com/open-telemetry/opentelemetry-configuration/actions/workflows/build-check.yaml/badge.svg?branch=main)](https://github.com/open-telemetry/opentelemetry-configuration/actions/workflows/build-check.yaml)
 
@@ -12,7 +12,7 @@ This repository contains the JSON schema that defines the OpenTelemetry configur
 
 The [examples](./examples) repository contains a variety of sample configuration files to help get started and illustrate useful patterns. The following are noteworthy:
 
-- [sdk-migration-config.yaml](./examples/sdk-migration-config.yaml): Includes env var substitution references to all [standard env vars](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md) which map cleanly to file configuration (see notes in the example for the set of env vars which are not referenced). Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][]. This is a great starting point for transitioning from env var based configuration to file based configuration.
+- [sdk-migration-config.yaml](./examples/sdk-migration-config.yaml): Includes env var substitution references to all [standard env vars](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md) which map cleanly to declarative configuration (see notes in the example for the set of env vars which are not referenced). Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][]. This is a great starting point for transitioning from env var based configuration to file based configuration.
 - [sdk-config.yaml](./examples/sdk-config.yaml): Represents the typical default configuration. This is a good starting point if you are not using env var based configuration or wish to transition fully to file based configuration. Note, SDKs parsing configuration files ignore all env vars besides those referenced via [env var substitution][].
 
 ## Code generation

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -3,9 +3,9 @@
 #
 # This template includes env var substitution references (i.e. ${MY_ENV}) for all spec defined
 # env vars (https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
-# which map cleanly to file configuration. For example, OTEL_SDK_DISABLED is referenced below,
-# but OTEL_TRACES_EXPORTER is not since it does not map well to the hierarchical structure of
-# file configuration.
+# which map cleanly to declarative configuration. For example, OTEL_SDK_DISABLED is referenced
+# below, but OTEL_TRACES_EXPORTER is not since it does not map well to the hierarchical
+# structure of declarative configuration.
 #
 # NOTE: With the exception of env var substitution syntax, SDKs ignore environment variables
 # when interpreting config files. For example, if "disabled: ${OTEL_SDK_DISABLED:-false}"


### PR DESCRIPTION
Reflects the naming of this project in the spec: https://opentelemetry.io/docs/specs/otel/configuration/#declarative-configuration