### PR TITLE
Add scope configuration properties

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -163,8 +163,9 @@ logger_provider:
     # If omitted or null, 128 is used.
     attribute_count_limit: 128
   # Configure loggers.
-  logger_configurator:
-    # Configure the default logger config used there is no matching entry in .logger_configurator.loggers.
+  # This type is in development and subject to breaking changes in minor versions.
+  logger_configurator/development:
+    # Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.
     default_config:
       # Configure if the logger is enabled or not.
       disabled: true
@@ -452,8 +453,9 @@ meter_provider:
   # If omitted or null, trace_based is used.
   exemplar_filter: trace_based
   # Configure meters.
-  meter_configurator:
-    # Configure the default meter config used there is no matching entry in .meter_configurator.meters.
+  # This type is in development and subject to breaking changes in minor versions.
+  meter_configurator/development:
+    # Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.
     default_config:
       # Configure if the meter is enabled or not.
       disabled: true
@@ -676,8 +678,9 @@ tracer_provider:
         # Configure sampler to be always_off.
         always_off:
   # Configure tracers.
-  tracer_configurator:
-    # Configure the default tracer config used there is no matching entry in .tracer_configurator.tracers.
+  # This type is in development and subject to breaking changes in minor versions.
+  tracer_configurator/development:
+    # Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.
     default_config:
       # Configure if the tracer is enabled or not.
       disabled: true

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -73,6 +73,23 @@ logger_provider:
     attribute_value_length_limit: 4096
     # Configure max attribute count. Overrides .attribute_limits.attribute_count_limit.
     attribute_count_limit: 128
+  # Configure loggers.
+  logger_configurator:
+    # Configure the default logger config used there is no matching entry in .logger_configurator.loggers.
+    default_config:
+      # Configure if the logger is enabled or not.
+      disabled: true
+    # Configure loggers.
+    loggers:
+      - # Configure logger names to match, evaluated as follows:
+        #
+        #  * If the logger name exactly matches.
+        #  * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+        name: io.opentelemetry.contrib.*
+        # The logger config.
+        config:
+          # Configure if the logger is enabled or not.
+          disabled: false
 
 # Configure meter provider.
 meter_provider:
@@ -217,6 +234,23 @@ meter_provider:
             - key3
   # Configure the exemplar filter. Known values include: trace_based, always_on, always_off.
   exemplar_filter: trace_based
+  # Configure meters.
+  meter_configurator:
+    # Configure the default meter config used there is no matching entry in .meter_configurator.meters.
+    default_config:
+      # Configure if the meter is enabled or not.
+      disabled: true
+    # Configure meters.
+    meters:
+      - # Configure meter names to match, evaluated as follows:
+        #
+        #  * If the meter name exactly matches.
+        #  * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+        name: io.opentelemetry.contrib.*
+        # The meter config.
+        config:
+          # Configure if the meter is enabled or not.
+          disabled: false
 
 # Configure text map context propagators.
 propagator:
@@ -320,7 +354,23 @@ tracer_provider:
       local_parent_not_sampled:
         # Configure sampler to be always_off.
         always_off:
-
+  # Configure tracers.
+  tracer_configurator:
+    # Configure the default tracer config used there is no matching entry in .tracer_configurator.tracers.
+    default_config:
+      # Configure if the tracer is enabled or not.
+      disabled: true
+    # Configure tracers.
+    tracers:
+      - # Configure tracer names to match, evaluated as follows:
+        #
+        #  * If the tracer name exactly matches.
+        #  * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+        name: io.opentelemetry.contrib.*
+        # The tracer config.
+        config:
+          # Configure if the tracer is enabled or not.
+          disabled: false
 
 # Configure resource for all signals.
 resource:

--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -13,8 +13,8 @@
         "limits": {
             "$ref": "#/$defs/LogRecordLimits"
         },
-        "logger_configurator": {
-            "$ref": "#/$defs/LoggerConfigurator"
+        "logger_configurator/development": {
+            "$ref": "#/$defs/ExperimentalLoggerConfigurator"
         }
     },
     "required": [
@@ -119,37 +119,37 @@
                 }
             }
         },
-        "LoggerConfigurator": {
-            "type": ["object", "null"],
+        "ExperimentalLoggerConfigurator": {
+            "type": ["object"],
             "additionalProperties": false,
             "title": "LoggerConfigurator",
             "properties": {
                 "default_config": {
-                    "$ref": "#/$defs/LoggerConfig"
+                    "$ref": "#/$defs/ExperimentalLoggerConfig"
                 },
                 "loggers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/LoggerMatcherAndConfig"
+                        "$ref": "#/$defs/ExperimentalLoggerMatcherAndConfig"
                     }
                 }
             }
         },
-        "LoggerMatcherAndConfig": {
-            "type": ["object", "null"],
+        "ExperimentalLoggerMatcherAndConfig": {
+            "type": ["object"],
             "additionalProperties": false,
             "title": "LoggerMatcherAndConfig",
             "properties": {
                 "name": {
-                    "type": ["string", "null"]
+                    "type": ["string"]
                 },
                 "config": {
-                    "$ref": "#/$defs/LoggerConfig"
+                    "$ref": "#/$defs/ExperimentalLoggerConfig"
                 }
             }
         },
-        "LoggerConfig": {
-            "type": ["object", "null"],
+        "ExperimentalLoggerConfig": {
+            "type": ["object"],
             "additionalProperties": false,
             "title": "LoggerConfig",
             "properties": {

--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -154,7 +154,7 @@
             "title": "LoggerConfig",
             "properties": {
                 "disabled": {
-                    "type": ["boolean", "null"]
+                    "type": ["boolean"]
                 }
             }
         }

--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -13,6 +13,9 @@
         },
         "limits": {
             "$ref": "#/$defs/LogRecordLimits"
+        },
+        "logger_configurator": {
+            "$ref": "#/$defs/LoggerConfigurator"
         }
     },
     "$defs": {
@@ -105,6 +108,45 @@
             "patternProperties": {
                 ".*": {
                     "type": ["object", "null"]
+                }
+            }
+        },
+        "LoggerConfigurator": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "LoggerConfigurator",
+            "properties": {
+                "default_config": {
+                    "$ref": "#/$defs/LoggerConfig"
+                },
+                "loggers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/LoggerMatcherAndConfig"
+                    }
+                }
+            }
+        },
+        "LoggerMatcherAndConfig": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "LoggerMatcherAndConfig",
+            "properties": {
+                "name": {
+                    "type": ["string", "null"]
+                },
+                "config": {
+                    "$ref": "#/$defs/LoggerConfig"
+                }
+            }
+        },
+        "LoggerConfig": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "LoggerConfig",
+            "properties": {
+                "disabled": {
+                    "type": ["boolean", "null"]
                 }
             }
         }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -463,7 +463,7 @@
             "additionalProperties": false,
             "properties": {
                 "disabled": {
-                    "type": ["boolean", "null"]
+                    "type": ["boolean"]
                 }
             }
         }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -19,8 +19,8 @@
         "exemplar_filter": {
             "$ref": "#/$defs/ExemplarFilter"
         },
-        "meter_configurator": {
-            "$ref": "#/$defs/MeterConfigurator"
+        "meter_configurator/development": {
+            "$ref": "#/$defs/ExperimentalMeterConfigurator"
         }
     },
     "required": [
@@ -431,35 +431,35 @@
             "type": ["object", "null"],
             "additionalProperties": false
         },
-        "MeterConfigurator": {
-            "type": ["object", "null"],
+        "ExperimentalMeterConfigurator": {
+            "type": ["object"],
             "additionalProperties": false,
             "properties": {
                 "default_config": {
-                    "$ref": "#/$defs/MeterConfig"
+                    "$ref": "#/$defs/ExperimentalMeterConfig"
                 },
                 "meters": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/MeterMatcherAndConfig"
+                        "$ref": "#/$defs/ExperimentalMeterMatcherAndConfig"
                     }
                 }
             }
         },
-        "MeterMatcherAndConfig": {
-            "type": ["object", "null"],
+        "ExperimentalMeterMatcherAndConfig": {
+            "type": ["object"],
             "additionalProperties": false,
             "properties": {
                 "name": {
-                    "type": ["string", "null"]
+                    "type": ["string"]
                 },
                 "config": {
-                    "$ref": "#/$defs/MeterConfig"
+                    "$ref": "#/$defs/ExperimentalMeterConfig"
                 }
             }
         },
-        "MeterConfig": {
-            "type": ["object", "null"],
+        "ExperimentalMeterConfig": {
+            "type": ["object"],
             "additionalProperties": false,
             "properties": {
                 "disabled": {

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -24,6 +24,9 @@
                 "always_off",
                 "trace_based"
             ]
+        },
+        "meter_configurator": {
+            "$ref": "#/$defs/MeterConfigurator"
         }
     },
     "$defs": {
@@ -319,6 +322,45 @@
                             "$ref": "common.json#/$defs/IncludeExclude"
                         }
                     }
+                }
+            }
+        },
+        "MeterConfigurator": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "MeterConfigurator",
+            "properties": {
+                "default_config": {
+                    "$ref": "#/$defs/MeterConfig"
+                },
+                "meters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/MeterMatcherAndConfig"
+                    }
+                }
+            }
+        },
+        "MeterMatcherAndConfig": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "MeterMatcherAndConfig",
+            "properties": {
+                "name": {
+                    "type": ["string", "null"]
+                },
+                "config": {
+                    "$ref": "#/$defs/MeterConfig"
+                }
+            }
+        },
+        "MeterConfig": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "MeterConfig",
+            "properties": {
+                "disabled": {
+                    "type": ["boolean", "null"]
                 }
             }
         }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -238,10 +238,10 @@
         "TracerMatcherAndConfig": {
             "type": ["object", "null"],
             "additionalProperties": false,
-            "title": "MeterMatcherAndConfig",
+            "title": "TracerMatcherAndConfig",
             "properties": {
                 "name": {
-                    "type": ["string", "null"]
+                    "type": ["string"]
                 },
                 "config": {
                     "$ref": "#/$defs/TracerConfig"
@@ -249,7 +249,7 @@
             }
         },
         "TracerConfig": {
-            "type": ["object", "null"],
+            "type": ["object"],
             "additionalProperties": false,
             "title": "TracerConfig",
             "properties": {

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -246,17 +246,24 @@
                 "config": {
                     "$ref": "#/$defs/TracerConfig"
                 }
-            }
+            },
+            "required": [
+                "name",
+                "config"
+            ]
         },
         "TracerConfig": {
-            "type": ["object"],
+            "type": ["object", "null"],
             "additionalProperties": false,
             "title": "TracerConfig",
             "properties": {
                 "disabled": {
-                    "type": ["boolean", "null"]
+                    "type": ["boolean"]
                 }
-            }
+            },
+            "required": [
+                "disabled"
+            ]
         }
     }
 }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -16,8 +16,8 @@
         "sampler": {
             "$ref": "#/$defs/Sampler"
         },
-        "tracer_configurator": {
-            "$ref": "#/$defs/TracerConfigurator"
+        "tracer_configurator/development": {
+            "$ref": "#/$defs/ExperimentalTracerConfigurator"
         }
     },
     "required": [
@@ -236,30 +236,30 @@
                 }
             }
         },
-        "TracerConfigurator": {
-            "type": ["object", "null"],
+        "ExperimentalTracerConfigurator": {
+            "type": ["object"],
             "additionalProperties": false,
             "properties": {
                 "default_config": {
-                    "$ref": "#/$defs/TracerConfig"
+                    "$ref": "#/$defs/ExperimentalTracerConfig"
                 },
                 "tracers": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/TracerMatcherAndConfig"
+                        "$ref": "#/$defs/ExperimentalTracerMatcherAndConfig"
                     }
                 }
             }
         },
-        "TracerMatcherAndConfig": {
-            "type": ["object", "null"],
+        "ExperimentalTracerMatcherAndConfig": {
+            "type": ["object"],
             "additionalProperties": false,
             "properties": {
                 "name": {
                     "type": ["string"]
                 },
                 "config": {
-                    "$ref": "#/$defs/TracerConfig"
+                    "$ref": "#/$defs/ExperimentalTracerConfig"
                 }
             },
             "required": [
@@ -267,8 +267,8 @@
                 "config"
             ]
         },
-        "TracerConfig": {
-            "type": ["object", "null"],
+        "ExperimentalTracerConfig": {
+            "type": ["object"],
             "additionalProperties": false,
             "properties": {
                 "disabled": {

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -16,6 +16,9 @@
         },
         "sampler": {
             "$ref": "#/$defs/Sampler"
+        },
+        "tracer_configurator": {
+            "$ref": "#/$defs/TracerConfigurator"
         }
     },
     "$defs": {
@@ -215,6 +218,45 @@
                 "endpoint"
             ],
             "title": "Zipkin"
+        },
+        "TracerConfigurator": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "TracerConfigurator",
+            "properties": {
+                "default_config": {
+                    "$ref": "#/$defs/TracerConfig"
+                },
+                "tracers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/TracerMatcherAndConfig"
+                    }
+                }
+            }
+        },
+        "TracerMatcherAndConfig": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "MeterMatcherAndConfig",
+            "properties": {
+                "name": {
+                    "type": ["string", "null"]
+                },
+                "config": {
+                    "$ref": "#/$defs/TracerConfig"
+                }
+            }
+        },
+        "TracerConfig": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "title": "TracerConfig",
+            "properties": {
+                "disabled": {
+                    "type": ["boolean", "null"]
+                }
+            }
         }
     }
 }

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -87,6 +87,7 @@
   property_descriptions:
     processors: Configure log record processors.
     limits: Configure log record limits. See also attribute_limits.
+    logger_configurator: Configure loggers.
   path_patterns:
     - .logger_provider
 
@@ -126,6 +127,31 @@
     attribute_count_limit:  Configure max attribute count. Overrides .attribute_limits.attribute_count_limit.
   path_patterns:
     - .logger_provider.limits
+
+- type: LoggerConfigurator
+  property_descriptions:
+    default_config: Configure the default logger config used there is no matching entry in .logger_configurator.loggers.
+    loggers: Configure loggers.
+  path_patterns:
+    - .logger_provider.logger_configurator
+
+- type: LoggerConfigAndMatcher
+  property_descriptions:
+    name: >
+      Configure logger names to match, evaluated as follows:
+
+       * If the logger name exactly matches.
+       * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+    config: The logger config.
+  path_patterns:
+    - .logger_provider.logger_configurator.loggers[]
+
+- type: LoggerConfig
+  property_descriptions:
+    disabled: Configure if the logger is enabled or not.
+  path_patterns:
+    - .logger_provider.logger_configurator.default_config
+    - .logger_provider.logger_configurator.loggers[].config
 # END LoggerProvider
 
 # START TracerProvider
@@ -134,6 +160,7 @@
     processors: Configure span processors.
     limits: Configure span limits. See also attribute_limits.
     sampler: Configure the sampler.
+    tracer_configurator: Configure tracers.
   path_patterns:
     - .tracer_provider
 
@@ -201,6 +228,31 @@
   path_patterns:
     - .tracer_provider.sampler
     - .tracer_provider.sampler.*
+
+- type: TracerConfigurator
+  property_descriptions:
+    default_config: Configure the default tracer config used there is no matching entry in .tracer_configurator.tracers.
+    tracers: Configure tracers.
+  path_patterns:
+    - .tracer_provider.tracer_configurator
+
+- type: TracerConfigAndMatcher
+  property_descriptions:
+    name: >
+      Configure tracer names to match, evaluated as follows:
+
+       * If the tracer name exactly matches.
+       * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+    config: The tracer config.
+  path_patterns:
+    - .tracer_provider.tracer_configurator.tracers[]
+
+- type: TracerConfig
+  property_descriptions:
+    disabled: Configure if the tracer is enabled or not.
+  path_patterns:
+    - .tracer_provider.tracer_configurator.default_config
+    - .tracer_provider.tracer_configurator.tracers[].config
 # END TracerProvider
 
 # START MeterProvider
@@ -209,6 +261,7 @@
     readers: Configure metric readers.
     views: Configure views. Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s).
     exemplar_filter: "Configure the exemplar filter. Known values include: trace_based, always_on, always_off."
+    meter_configurator: Configure meters.
   path_patterns:
     - .meter_provider
 
@@ -325,6 +378,31 @@
     record_min_max: Configure record min and max.
   path_patterns:
     - .meter_provider.views[].stream.aggregation.explicit_bucket_histogram
+
+- type: MeterConfigurator
+  property_descriptions:
+    default_config: Configure the default meter config used there is no matching entry in .meter_configurator.meters.
+    meters: Configure meters.
+  path_patterns:
+    - .meter_provider.meter_configurator
+
+- type: MeterConfigAndMatcher
+  property_descriptions:
+    name: >
+      Configure meter names to match, evaluated as follows:
+
+       * If the meter name exactly matches.
+       * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+    config: The meter config.
+  path_patterns:
+    - .meter_provider.meter_configurator.meters[]
+
+- type: MeterConfig
+  property_descriptions:
+    disabled: Configure if the meter is enabled or not.
+  path_patterns:
+    - .meter_provider.meter_configurator.default_config
+    - .meter_provider.meter_configurator.meters[].config
 # END meter_provider
 
 # START common

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -131,7 +131,10 @@
   property_descriptions:
     processors: Configure log record processors.
     limits: Configure log record limits. See also attribute_limits.
-    logger_configurator: Configure loggers.
+    logger_configurator/development: >
+      Configure loggers.
+      
+      This type is in development and subject to breaking changes in minor versions.
   path_patterns:
     - .logger_provider
 
@@ -202,10 +205,10 @@
 
 - type: LoggerConfigurator
   property_descriptions:
-    default_config: Configure the default logger config used there is no matching entry in .logger_configurator.loggers.
+    default_config: Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.
     loggers: Configure loggers.
   path_patterns:
-    - .logger_provider.logger_configurator
+    - .logger_provider.logger_configurator/development
 
 - type: LoggerConfigAndMatcher
   property_descriptions:
@@ -216,14 +219,14 @@
        * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
     config: The logger config.
   path_patterns:
-    - .logger_provider.logger_configurator.loggers[]
+    - .logger_provider.logger_configurator/development.loggers[]
 
 - type: LoggerConfig
   property_descriptions:
     disabled: Configure if the logger is enabled or not.
   path_patterns:
-    - .logger_provider.logger_configurator.default_config
-    - .logger_provider.logger_configurator.loggers[].config
+    - .logger_provider.logger_configurator/development.default_config
+    - .logger_provider.logger_configurator/development.loggers[].config
 # END LoggerProvider
 
 # START TracerProvider
@@ -235,7 +238,10 @@
       Configure the sampler.
       
       If omitted, parent based sampler with a root of always_on is used.
-    tracer_configurator: Configure tracers.
+    tracer_configurator/development: >
+      Configure tracers.
+      
+      This type is in development and subject to breaking changes in minor versions.
   path_patterns:
     - .tracer_provider
 
@@ -380,10 +386,10 @@
 
 - type: TracerConfigurator
   property_descriptions:
-    default_config: Configure the default tracer config used there is no matching entry in .tracer_configurator.tracers.
+    default_config: Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.
     tracers: Configure tracers.
   path_patterns:
-    - .tracer_provider.tracer_configurator
+    - .tracer_provider.tracer_configurator/development
 
 - type: TracerConfigAndMatcher
   property_descriptions:
@@ -394,14 +400,14 @@
        * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
     config: The tracer config.
   path_patterns:
-    - .tracer_provider.tracer_configurator.tracers[]
+    - .tracer_provider.tracer_configurator/development.tracers[]
 
 - type: TracerConfig
   property_descriptions:
     disabled: Configure if the tracer is enabled or not.
   path_patterns:
-    - .tracer_provider.tracer_configurator.default_config
-    - .tracer_provider.tracer_configurator.tracers[].config
+    - .tracer_provider.tracer_configurator/development.default_config
+    - .tracer_provider.tracer_configurator/development.tracers[].config
 # END TracerProvider
 
 # START MeterProvider
@@ -418,7 +424,10 @@
       Values include: trace_based, always_on, always_off. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#metrics-sdk-configuration.
       
       If omitted or null, trace_based is used.
-    meter_configurator: Configure meters.
+    meter_configurator/development: >
+      Configure meters.
+      
+      This type is in development and subject to breaking changes in minor versions.
   path_patterns:
     - .meter_provider
 
@@ -611,10 +620,10 @@
 
 - type: MeterConfigurator
   property_descriptions:
-    default_config: Configure the default meter config used there is no matching entry in .meter_configurator.meters.
+    default_config: Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.
     meters: Configure meters.
   path_patterns:
-    - .meter_provider.meter_configurator
+    - .meter_provider.meter_configurator/development
 
 - type: MeterConfigAndMatcher
   property_descriptions:
@@ -625,14 +634,14 @@
        * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
     config: The meter config.
   path_patterns:
-    - .meter_provider.meter_configurator.meters[]
+    - .meter_provider.meter_configurator/development.meters[]
 
 - type: MeterConfig
   property_descriptions:
     disabled: Configure if the meter is enabled or not.
   path_patterns:
-    - .meter_provider.meter_configurator.default_config
-    - .meter_provider.meter_configurator.meters[].config
+    - .meter_provider.meter_configurator/development.default_config
+    - .meter_provider.meter_configurator/development.meters[].config
 # END meter_provider
 
 # START common


### PR DESCRIPTION
Related to #128.

Corresponding to the following spec sections:

- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#tracerconfigurator
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#meterconfigurator
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#loggerconfigurator

I believe this is the first time we've discussed adding properties which are experimental in the spec. And I want to use this as an opportunity to work out the details on how experimental properties work and their intersection with stability guarantees we still need to work out (#89).

The content in this PR needs review independent of the experimental conversation, and I'd like to find a way to separate the two issues.

One way we could proceed is to evaluate this PR ignoring the fact that the corresponding spec if experimental. Open an issue to find a resolution to experimental config properties, and indicate that the issue is blocking the next release (0.4.0). I would then tackle that issue as a followup to this, which I'm quite motivated to do because its a critical task on the path to stabilizing.