### PR TITLE
Refactor otlp exporter

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -68,9 +68,9 @@ logger_provider:
             # Configure max time (in milliseconds) to wait for each export.
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
-            # If omitted or null, proto is used.
-            encoding: proto
+            # Configure the encoding used for messages. Values include: protobuf, json. Implementations may not support json.
+            # If omitted or null, protobuf is used.
+            encoding: protobuf
     - # Configure a batch log record processor.
       batch:
         # Configure exporter.
@@ -206,9 +206,9 @@ meter_provider:
             # Configure max time (in milliseconds) to wait for each export.
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
-            # If omitted or null, proto is used.
-            encoding: proto
+            # Configure the encoding used for messages. Values include: protobuf, json. Implementations may not support json.
+            # If omitted or null, protobuf is used.
+            encoding: protobuf
             # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
             # If omitted or null, cumulative is used.
             temporality_preference: delta
@@ -390,9 +390,9 @@ tracer_provider:
             # Configure max time (in milliseconds) to wait for each export.
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
-            # If omitted or null, proto is used.
-            encoding: proto
+            # Configure the encoding used for messages. Values include: protobuf, json. Implementations may not support json.
+            # If omitted or null, protobuf is used.
+            encoding: protobuf
     - # Configure a batch span processor.
       batch:
         # Configure exporter.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -41,12 +41,8 @@ logger_provider:
         max_export_batch_size: 512
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: http/protobuf
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
             endpoint: http://localhost:4318/v1/logs
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.
@@ -72,7 +68,43 @@ logger_provider:
             # Configure max time (in milliseconds) to wait for each export.
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure client transport security for the exporter's connection. Only applicable when .protocol is grpc and .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+            # Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
+            # If omitted or null, proto is used.
+            encoding: proto
+    - # Configure a batch log record processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with gRPC transport.
+          otlp_grpc:
+            # Configure endpoint.
+            # If omitted or null, http://localhost:4317 is used.
+            endpoint: http://localhost:4317
+            # Configure certificate. Absolute path to certificate file.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate: /app/cert.pem
+            # Configure mTLS private client key. Absolute path to client key in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key: /app/cert.pem
+            # Configure mTLS client certificate. Absolute path to certificate file. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression. Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export.
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
             # If omitted or null, false is used.
             insecure: false
     - # Configure a simple log record processor.
@@ -145,12 +177,10 @@ meter_provider:
         timeout: 30000
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: http/protobuf
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the metric specific path.
+            # If omitted or null, http://localhost:4318/v1/metrics is used.
             endpoint: http://localhost:4318/v1/metrics
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.
@@ -176,7 +206,49 @@ meter_provider:
             # Configure max time (in milliseconds) to wait for each export.
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure client transport security for the exporter's connection. Only applicable when .protocol is grpc and .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+            # Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
+            # If omitted or null, proto is used.
+            encoding: proto
+            # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with gRPC transport.
+          otlp_grpc:
+            # Configure endpoint.
+            # If omitted or null, http://localhost:4317 is used.
+            endpoint: http://localhost:4317
+            # Configure certificate. Absolute path to certificate file.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate: /app/cert.pem
+            # Configure mTLS private client key. Absolute path to client key in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key: /app/cert.pem
+            # Configure mTLS client certificate. Absolute path to certificate file. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression. Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export.
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
             # If omitted or null, false is used.
             insecure: false
             # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
@@ -185,10 +257,6 @@ meter_provider:
             # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
             # If omitted or null, explicit_bucket_histogram is used.
             default_histogram_aggregation: base2_exponential_bucket_histogram
-      # Configure metric producers.
-      producers:
-        - # Configure metric producer to be prometheus.
-          prometheus:
     - # Configure a periodic metric reader.
       periodic:
         # Configure exporter.
@@ -293,12 +361,10 @@ tracer_provider:
         max_export_batch_size: 512
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: http/protobuf
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the trace specific path.
+            # If omitted or null, http://localhost:4318/v1/traces is used.
             endpoint: http://localhost:4318/v1/traces
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.
@@ -324,7 +390,43 @@ tracer_provider:
             # Configure max time (in milliseconds) to wait for each export.
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure client transport security for the exporter's connection. Only applicable when .protocol is grpc and .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+            # Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
+            # If omitted or null, proto is used.
+            encoding: proto
+    - # Configure a batch span processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with gRPC transport.
+          otlp_grpc:
+            # Configure endpoint.
+            # If omitted or null, http://localhost:4317 is used.
+            endpoint: http://localhost:4317
+            # Configure certificate. Absolute path to certificate file.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate: /app/cert.pem
+            # Configure mTLS private client key. Absolute path to client key in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key: /app/cert.pem
+            # Configure mTLS client certificate. Absolute path to certificate file. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression. Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export.
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
             # If omitted or null, false is used.
             insecure: false
     - # Configure a batch span processor.

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -55,12 +55,10 @@ tracer_provider:
         max_export_batch_size: 512
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: http/protobuf
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the trace specific path.
+            # If omitted or null, http://localhost:4318/v1/traces is used.
             endpoint: http://localhost:4318/v1/traces
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.
@@ -145,12 +143,10 @@ meter_provider:
         timeout: 30000
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: http/protobuf
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the metric specific path.
+            # If omitted or null, http://localhost:4318/v1/metrics is used.
             endpoint: http://localhost:4318/v1/metrics
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.
@@ -200,12 +196,8 @@ logger_provider:
         max_export_batch_size: 512
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: http/protobuf
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
             endpoint: http://localhost:4318/v1/logs
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -25,7 +25,7 @@
 # - OTEL_TRACES_EXPORTER
 # - OTEL_METRICS_EXPORTER
 # - OTEL_LOGS_EXPORTER
-# - OTEL_EXPORTER_OTLP_PROTOCOL
+# - OTEL_EXPORTER_OTLP_PROTOCOL, OTEL_EXPORTER_OTLP_{SIGNAL}_PROTOCOL
 # - OTEL_EXPORTER_OTLP_ENDPOINT
 # - OTEL_EXPORTER_OTLP_INSECURE, OTEL_EXPORTER_OTLP_{SIGNAL}_INSECURE
 # - OTEL_EXPORTER_OTLP_CERTIFICATE
@@ -88,12 +88,10 @@ tracer_provider:
         max_export_batch_size: ${OTEL_BSP_MAX_EXPORT_BATCH_SIZE:-512}
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: ${OTEL_EXPORTER_OTLP_TRACES_PROTOCOL:-http/protobuf}
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the trace specific path.
+            # If omitted or null, http://localhost:4318/v1/traces is used.
             endpoint: ${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:-http://localhost:4318/v1/traces}
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.
@@ -184,12 +182,10 @@ meter_provider:
         timeout: ${OTEL_METRIC_EXPORT_TIMEOUT:-30000}
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: ${OTEL_EXPORTER_OTLP_METRICS_PROTOCOL:-http/protobuf}
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the metric specific path.
+            # If omitted or null, http://localhost:4318/v1/metrics is used.
             endpoint: ${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:-http://localhost:4318/v1/metrics}
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.
@@ -243,12 +239,8 @@ logger_provider:
         max_export_batch_size: ${OTEL_BLRP_MAX_EXPORT_BATCH_SIZE:-512}
         # Configure exporter.
         exporter:
-          # Configure exporter to be OTLP.
-          otlp:
-            # Configure protocol. Values include: http/protobuf, http/json, grpc.
-            protocol: ${OTEL_EXPORTER_OTLP_LOGS_PROTOCOL:-http/protobuf}
-            # Configure endpoint.
-            # If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
             endpoint: ${OTEL_EXPORTER_OTLP_LOGS_ENDPOINT:-http://localhost:4318/v1/logs}
             # Configure certificate. Absolute path to certificate file.
             # If omitted or null, system default certificate verification is used for secure connections.

--- a/schema/common.json
+++ b/schema/common.json
@@ -36,9 +36,10 @@
                 "name", "value"
             ]
         },
-        "BaseOtlpHttpExporter": {
-            "title": "BaseOtlpHttpExporter",
-            "type": "object",
+        "OtlpHttpExporter": {
+            "title": "OtlpHttpExporter",
+            "type": ["object", "null"],
+            "additionalProperties": false,
             "properties": {
                 "endpoint": {
                     "type": ["string", "null"]
@@ -77,9 +78,10 @@
                 }
             }
         },
-        "BaseOtlpGrpcExporter": {
-            "title": "BaseOtlpGrpcExporter",
-            "type": "object",
+        "OtlpGrpcExporter": {
+            "title": "OtlpGrpcExporter",
+            "type": ["object", "null"],
+            "additionalProperties": false,
             "properties": {
                 "endpoint": {
                     "type": ["string", "null"]
@@ -114,8 +116,9 @@
                 }
             }
         },
-        "BaseConsoleExporter": {
-            "type": ["object", "null"]
+        "ConsoleExporter": {
+            "type": ["object", "null"],
+            "additionalProperties": false
         }
     }
 }

--- a/schema/common.json
+++ b/schema/common.json
@@ -36,16 +36,53 @@
                 "name", "value"
             ]
         },
-        "Otlp": {
+        "BaseOtlpHttpExporter": {
+            "title": "BaseOtlpHttpExporter",
             "type": "object",
-            "additionalProperties": false,
             "properties": {
-                "protocol": {
-                    "type": "string",
-                    "pattern": "^(http|grpc)\\/(protobuf|json)"
-                },
                 "endpoint": {
-                    "type": "string"
+                    "type": ["string", "null"]
+                },
+                "certificate": {
+                    "type": ["string", "null"]
+                },
+                "client_key": {
+                    "type": ["string", "null"]
+                },
+                "client_certificate": {
+                    "type": ["string", "null"]
+                },
+                "headers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "common.json#/$defs/NameStringValuePair"
+                    }
+                },
+                "headers_list": {
+                    "type": ["string", "null"]
+                },
+                "compression": {
+                    "type": ["string", "null"]
+                },
+                "timeout": {
+                    "type": ["integer", "null"],
+                    "minimum": 0
+                },
+                "encoding": {
+                    "type": ["string", "null"],
+                    "enum": [
+                        "proto",
+                        "json"
+                    ]
+                }
+            }
+        },
+        "BaseOtlpGrpcExporter": {
+            "title": "BaseOtlpGrpcExporter",
+            "type": "object",
+            "properties": {
+                "endpoint": {
+                    "type": ["string", "null"]
                 },
                 "certificate": {
                     "type": ["string", "null"]
@@ -75,16 +112,10 @@
                 "insecure": {
                     "type": ["boolean", "null"]
                 }
-            },
-            "required": [
-                "endpoint",
-                "protocol"
-            ],
-            "title": "Otlp"
+            }
         },
-        "Console": {
-            "type": ["object", "null"],
-            "additionalProperties": false
+        "BaseConsoleExporter": {
+            "type": ["object", "null"]
         }
     }
 }

--- a/schema/common.json
+++ b/schema/common.json
@@ -72,7 +72,7 @@
                 "encoding": {
                     "type": ["string", "null"],
                     "enum": [
-                        "proto",
+                        "protobuf",
                         "json"
                     ]
                 }

--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -66,13 +66,13 @@
             "maxProperties": 1,
             "properties": {
                 "otlp_http": {
-                    "$ref": "#/$defs/OtlpHttpLogRecordExporter"
+                    "$ref": "common.json#/$defs/OtlpHttpExporter"
                 },
                 "otlp_grpc": {
-                    "$ref": "#/$defs/OtlpGrpcLogRecordExporter"
+                    "$ref": "common.json#/$defs/OtlpGrpcExporter"
                 },
                 "console": {
-                    "$ref": "#/$defs/ConsoleLogRecordExporter"
+                    "$ref": "common.json#/$defs/ConsoleExporter"
                 }
             },
             "patternProperties": {
@@ -113,36 +113,6 @@
                     "type": ["object"]
                 }
             }
-        },
-        "OtlpHttpLogRecordExporter": {
-            "title": "OtlpHttpLogRecordExporter",
-            "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseOtlpHttpExporter"
-                }
-            ]
-        },
-        "OtlpGrpcLogRecordExporter": {
-            "title": "OtlpGrpcLogRecordExporter",
-            "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseOtlpGrpcExporter"
-                }
-            ]
-        },
-        "ConsoleLogRecordExporter": {
-            "title": "ConsoleLogRecordExporter",
-            "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseConsoleExporter"
-                }
-            ]
         }
     }
 }

--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -65,11 +65,14 @@
             "minProperties": 1,
             "maxProperties": 1,
             "properties": {
-                "otlp": {
-                    "$ref": "common.json#/$defs/Otlp"
+                "otlp_http": {
+                    "$ref": "#/$defs/OtlpHttpLogRecordExporter"
+                },
+                "otlp_grpc": {
+                    "$ref": "#/$defs/OtlpGrpcLogRecordExporter"
                 },
                 "console": {
-                    "$ref": "common.json#/$defs/Console"
+                    "$ref": "#/$defs/ConsoleLogRecordExporter"
                 }
             },
             "patternProperties": {
@@ -110,6 +113,36 @@
                     "type": ["object"]
                 }
             }
+        },
+        "OtlpHttpLogRecordExporter": {
+            "title": "OtlpHttpLogRecordExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseOtlpHttpExporter"
+                }
+            ]
+        },
+        "OtlpGrpcLogRecordExporter": {
+            "title": "OtlpGrpcLogRecordExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseOtlpGrpcExporter"
+                }
+            ]
+        },
+        "ConsoleLogRecordExporter": {
+            "title": "ConsoleLogRecordExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseConsoleExporter"
+                }
+            ]
         }
     }
 }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -217,7 +217,7 @@
                 "encoding": {
                     "type": ["string", "null"],
                     "enum": [
-                        "proto",
+                        "protobuf",
                         "json"
                     ]
                 },

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -77,7 +77,7 @@
                     "$ref": "#/$defs/OtlpGrpcMetricExporter"
                 },
                 "console": {
-                    "$ref": "#/$defs/ConsoleMetricExporter"
+                    "$ref": "common.json#/$defs/ConsoleExporter"
                 }
             },
             "patternProperties": {
@@ -184,13 +184,43 @@
         "OtlpHttpMetricExporter": {
             "title": "OtlpHttpMetricExporter",
             "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseOtlpHttpExporter"
-                }
-            ],
+            "additionalProperties": false,
             "properties": {
+                "endpoint": {
+                    "type": ["string", "null"]
+                },
+                "certificate": {
+                    "type": ["string", "null"]
+                },
+                "client_key": {
+                    "type": ["string", "null"]
+                },
+                "client_certificate": {
+                    "type": ["string", "null"]
+                },
+                "headers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "common.json#/$defs/NameStringValuePair"
+                    }
+                },
+                "headers_list": {
+                    "type": ["string", "null"]
+                },
+                "compression": {
+                    "type": ["string", "null"]
+                },
+                "timeout": {
+                    "type": ["integer", "null"],
+                    "minimum": 0
+                },
+                "encoding": {
+                    "type": ["string", "null"],
+                    "enum": [
+                        "proto",
+                        "json"
+                    ]
+                },
                 "temporality_preference": {
                     "$ref": "#/$defs/ExporterTemporalityPreference"
                 },
@@ -202,13 +232,39 @@
         "OtlpGrpcMetricExporter": {
             "title": "OtlpGrpcMetricExporter",
             "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseOtlpGrpcExporter"
-                }
-            ],
+            "additionalProperties": false,
             "properties": {
+                "endpoint": {
+                    "type": ["string", "null"]
+                },
+                "certificate": {
+                    "type": ["string", "null"]
+                },
+                "client_key": {
+                    "type": ["string", "null"]
+                },
+                "client_certificate": {
+                    "type": ["string", "null"]
+                },
+                "headers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "common.json#/$defs/NameStringValuePair"
+                    }
+                },
+                "headers_list": {
+                    "type": ["string", "null"]
+                },
+                "compression": {
+                    "type": ["string", "null"]
+                },
+                "timeout": {
+                    "type": ["integer", "null"],
+                    "minimum": 0
+                },
+                "insecure": {
+                    "type": ["boolean", "null"]
+                },
                 "temporality_preference": {
                     "$ref": "#/$defs/ExporterTemporalityPreference"
                 },
@@ -216,16 +272,6 @@
                     "$ref": "#/$defs/ExporterDefaultHistogramAggregation"
                 }
             }
-        },
-        "ConsoleMetricExporter": {
-            "title": "ConsoleMetricExporter",
-            "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseConsoleExporter"
-                }
-            ]
         },
         "View": {
             "type": "object",

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -70,11 +70,14 @@
             "minProperties": 1,
             "maxProperties": 1,
             "properties": {
-                "otlp": {
-                    "$ref": "#/$defs/OtlpMetric"
+                "otlp_http": {
+                    "$ref": "#/$defs/OtlpHttpMetricExporter"
+                },
+                "otlp_grpc": {
+                    "$ref": "#/$defs/OtlpGrpcMetricExporter"
                 },
                 "console": {
-                    "$ref": "common.json#/$defs/Console"
+                    "$ref": "#/$defs/ConsoleMetricExporter"
                 }
             },
             "patternProperties": {
@@ -90,7 +93,7 @@
             "maxProperties": 1,
             "properties": {
                 "prometheus": {
-                    "$ref": "#/$defs/Prometheus"
+                    "$ref": "#/$defs/PrometheusMetricExporter"
                 }
             },
             "patternProperties": {
@@ -116,7 +119,8 @@
                 }
             }
         },
-        "Prometheus": {
+        "PrometheusMetricExporter": {
+            "title": "PrometheusMetricExporter",
             "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
@@ -160,66 +164,68 @@
                 }
             }
         },
-        "OtlpMetric": {
-            "type": "object",
-            "additionalProperties": false,
+        "ExporterTemporalityPreference": {
+            "title": "ExporterTemporalityPreference",
+            "type": ["string", "null"],
+            "enum": [
+                "cumulative",
+                "delta",
+                "low_memory"
+            ]
+        },
+        "ExporterDefaultHistogramAggregation": {
+            "title": "ExporterDefaultHistogramAggregation",
+            "type": ["string", "null"],
+            "enum": [
+                "explicit_bucket_histogram",
+                "base2_exponential_bucket_histogram"
+            ]
+        },
+        "OtlpHttpMetricExporter": {
+            "title": "OtlpHttpMetricExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseOtlpHttpExporter"
+                }
+            ],
             "properties": {
-                "protocol": {
-                    "type": "string",
-                    "pattern": "^(http|grpc)\\/(protobuf|json)"
-                },
-                "endpoint": {
-                    "type": "string"
-                },
-                "certificate": {
-                    "type": ["string", "null"]
-                },
-                "client_key": {
-                    "type": ["string", "null"]
-                },
-                "client_certificate": {
-                    "type": ["string", "null"]
-                },
-                "headers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "common.json#/$defs/NameStringValuePair"
-                    }
-                },
-                "headers_list": {
-                    "type": ["string", "null"]
-                },
-                "compression": {
-                    "type": ["string", "null"]
-                },
-                "timeout": {
-                    "type": ["integer", "null"],
-                    "minimum": 0
-                },
                 "temporality_preference": {
-                    "type": ["string", "null"],
-                    "enum": [
-                        "cumulative",
-                        "delta",
-                        "low_memory"
-                    ]
+                    "$ref": "#/$defs/ExporterTemporalityPreference"
                 },
                 "default_histogram_aggregation": {
-                    "type": ["string", "null"],
-                    "enum": [
-                        "explicit_bucket_histogram",
-                        "base2_exponential_bucket_histogram"
-                    ]
-                },
-                "insecure": {
-                    "type": ["boolean", "null"]
+                    "$ref": "#/$defs/ExporterDefaultHistogramAggregation"
                 }
-            },
-            "required": [
-                "endpoint",
-                "protocol"
+            }
+        },
+        "OtlpGrpcMetricExporter": {
+            "title": "OtlpGrpcMetricExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseOtlpGrpcExporter"
+                }
             ],
-            "title": "OtlpMetric"
+            "properties": {
+                "temporality_preference": {
+                    "$ref": "#/$defs/ExporterTemporalityPreference"
+                },
+                "default_histogram_aggregation": {
+                    "$ref": "#/$defs/ExporterDefaultHistogramAggregation"
+                }
+            }
+        },
+        "ConsoleMetricExporter": {
+            "title": "ConsoleMetricExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseConsoleExporter"
+                }
+            ]
         },
         "View": {
             "type": "object",

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -138,13 +138,13 @@
             "maxProperties": 1,
             "properties": {
                 "otlp_http": {
-                    "$ref": "#/$defs/OtlpHttpSpanExporter"
+                    "$ref": "common.json#/$defs/OtlpHttpExporter"
                 },
                 "otlp_grpc": {
-                    "$ref": "#/$defs/OtlpGrpcSpanExporter"
+                    "$ref": "common.json#/$defs/OtlpGrpcExporter"
                 },
                 "console": {
-                    "$ref": "#/$defs/ConsoleSpanExporter"
+                    "$ref": "common.json#/$defs/ConsoleExporter"
                 },
                 "zipkin": {
                     "$ref": "#/$defs/ZipkinSpanExporter"
@@ -218,36 +218,6 @@
                     "minimum": 0
                 }
             }
-        },
-        "OtlpHttpSpanExporter": {
-            "title": "OtlpHttpSpanExporter",
-            "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseOtlpHttpExporter"
-                }
-            ]
-        },
-        "OtlpGrpcSpanExporter": {
-            "title": "OtlpGrpcSpanExporter",
-            "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseOtlpGrpcExporter"
-                }
-            ]
-        },
-        "ConsoleSpanExporter": {
-            "title": "ConsoleSpanExporter",
-            "type": ["object", "null"],
-            "unevaluatedProperties": false,
-            "allOf": [
-                {
-                    "$ref": "common.json#/$defs/BaseConsoleExporter"
-                }
-            ]
         }
     }
 }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -137,14 +137,17 @@
             "minProperties": 1,
             "maxProperties": 1,
             "properties": {
-                "otlp": {
-                    "$ref": "common.json#/$defs/Otlp"
+                "otlp_http": {
+                    "$ref": "#/$defs/OtlpHttpSpanExporter"
+                },
+                "otlp_grpc": {
+                    "$ref": "#/$defs/OtlpGrpcSpanExporter"
                 },
                 "console": {
-                    "$ref": "common.json#/$defs/Console"
+                    "$ref": "#/$defs/ConsoleSpanExporter"
                 },
                 "zipkin": {
-                    "$ref": "#/$defs/Zipkin"
+                    "$ref": "#/$defs/ZipkinSpanExporter"
                 }
             },
             "patternProperties": {
@@ -202,7 +205,8 @@
                 }
             }
         },
-        "Zipkin": {
+        "ZipkinSpanExporter": {
+            "title": "ZipkinSpanExporter",
             "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {
@@ -213,8 +217,37 @@
                     "type": ["integer", "null"],
                     "minimum": 0
                 }
-            },
-            "title": "Zipkin"
+            }
+        },
+        "OtlpHttpSpanExporter": {
+            "title": "OtlpHttpSpanExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseOtlpHttpExporter"
+                }
+            ]
+        },
+        "OtlpGrpcSpanExporter": {
+            "title": "OtlpGrpcSpanExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseOtlpGrpcExporter"
+                }
+            ]
+        },
+        "ConsoleSpanExporter": {
+            "title": "ConsoleSpanExporter",
+            "type": ["object", "null"],
+            "unevaluatedProperties": false,
+            "allOf": [
+                {
+                    "$ref": "common.json#/$defs/BaseConsoleExporter"
+                }
+            ]
         }
     }
 }

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -161,7 +161,8 @@
 
 - type: LogRecordExporter
   property_descriptions:
-    otlp: Configure exporter to be OTLP.
+    otlp_http: Configure exporter to be OTLP with HTTP transport.
+    otlp_grpc: Configure exporter to be OTLP with gRPC transport.
     console: Configure exporter to be console.
   path_patterns:
     - .logger_provider.processors[].*.exporter
@@ -229,13 +230,14 @@
 
 - type: SpanExporter
   property_descriptions:
-    otlp: Configure exporter to be OTLP.
+    otlp_http: Configure exporter to be OTLP with HTTP transport.
+    otlp_grpc: Configure exporter to be OTLP with gRPC transport.
     zipkin: Configure exporter to be zipkin.
     console: Configure exporter to be console.
   path_patterns:
     - .tracer_provider.processors[].*.exporter
 
-- type: Zipkin
+- type: ZipkinSpanExporter
   property_descriptions:
     endpoint: >
       Configure endpoint.
@@ -362,12 +364,13 @@
 - type: MetricExporter
   property_descriptions:
     prometheus: Configure exporter to be prometheus.
-    otlp: Configure exporter to be OTLP.
+    otlp_http: Configure exporter to be OTLP with HTTP transport.
+    otlp_grpc: Configure exporter to be OTLP with gRPC transport.
     console: Configure exporter to be console.
   path_patterns:
     - .meter_provider.readers[].*.exporter
 
-- type: Prometheus
+- type: PrometheusMetricExporter
   property_descriptions:
     host: >
       Configure host.
@@ -500,14 +503,8 @@
 # END meter_provider
 
 # START common
-- type: Otlp
+- type: OtlpExporterCommon
   property_descriptions:
-    protocol: >
-      Configure protocol. Values include: http/protobuf, http/json, grpc.
-    endpoint: >
-      Configure endpoint.
-      
-      If .protocol is http/protobuf or http/json, the signal specific path must be included (i.e. http://localhost:4318/v1/{signal}). If .protocol is grpc, a path should not be included (i.e. http://localhost:4317).
     certificate: >
       Configure certificate. Absolute path to certificate file.
       
@@ -538,10 +535,6 @@
       Configure max time (in milliseconds) to wait for each export.
       
       If omitted or null, 10000 is used.
-    insecure: >
-      Configure client transport security for the exporter's connection. Only applicable when .protocol is grpc and .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
-      
-      If omitted or null, false is used.
     temporality_preference: >
       Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
       
@@ -551,9 +544,60 @@
       
       If omitted or null, explicit_bucket_histogram is used.
   path_patterns:
-    - .tracer_provider.processors[].*.exporter.otlp
-    - .logger_provider.processors[].*.exporter.otlp
-    - .meter_provider.readers[].periodic.exporter.otlp
+    - .tracer_provider.processors[].*.exporter.otlp_http
+    - .logger_provider.processors[].*.exporter.otlp_http
+    - .meter_provider.readers[].periodic.exporter.otlp_http
+    - .tracer_provider.processors[].*.exporter.otlp_grpc
+    - .logger_provider.processors[].*.exporter.otlp_grpc
+    - .meter_provider.readers[].periodic.exporter.otlp_grpc
+- type: OtlpHttpExporter
+  property_descriptions:
+    encoding: >
+      Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
+      
+      If omitted or null, proto is used.
+  path_patterns:
+    - .tracer_provider.processors[].*.exporter.otlp_http
+    - .logger_provider.processors[].*.exporter.otlp_http
+    - .meter_provider.readers[].periodic.exporter.otlp_http
+- type: OtlpHttpSpanExporter
+  property_descriptions:
+    endpoint: >
+      Configure endpoint, including the trace specific path.
+      
+      If omitted or null, http://localhost:4318/v1/traces is used.
+  path_patterns:
+    - .tracer_provider.processors[].*.exporter.otlp_http
+- type: OtlpHttpMetricExporter
+  property_descriptions:
+    endpoint: >
+      Configure endpoint, including the metric specific path.
+      
+      If omitted or null, http://localhost:4318/v1/metrics is used.
+  path_patterns:
+    - .meter_provider.readers[].periodic.exporter.otlp_http
+- type: OtlpHttpLogRecordExporter
+  property_descriptions:
+    endpoint: >
+      Configure endpoint, including the log specific path.
+      
+      If omitted or null, http://localhost:4318/v1/logs is used.
+  path_patterns:
+    - .meter_provider.readers[].periodic.exporter.otlp_http
+- type: OtlpGrpcExporter
+  property_descriptions:
+    endpoint: >
+      Configure endpoint.
+      
+      If omitted or null, http://localhost:4317 is used.
+    insecure: >
+      Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+      
+      If omitted or null, false is used.
+  path_patterns:
+    - .tracer_provider.processors[].*.exporter.otlp_grpc
+    - .logger_provider.processors[].*.exporter.otlp_grpc
+    - .meter_provider.readers[].periodic.exporter.otlp_grpc
 # END common
 
 # START Instrumentation

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -553,9 +553,9 @@
 - type: OtlpHttpExporter
   property_descriptions:
     encoding: >
-      Configure the encoding used for messages. Values include: proto, json. Implementations may not support json.
+      Configure the encoding used for messages. Values include: protobuf, json. Implementations may not support json.
       
-      If omitted or null, proto is used.
+      If omitted or null, protobuf is used.
   path_patterns:
     - .tracer_provider.processors[].*.exporter.otlp_http
     - .logger_provider.processors[].*.exporter.otlp_http

--- a/scripts/generate-descriptions.js
+++ b/scripts/generate-descriptions.js
@@ -80,13 +80,16 @@ yaml.visit(fileDoc, {
         debug("parentPath: " + parentPath );
         debug("propertyKey: " + propertyKey);
         debug("currentNodePath: " + parentPath + (parentPath === "." ? "" : ".") + propertyKey);
-        // Iterate through the rules and find the first with a matching entry in rule.path_patterns
+        // Iterate through the rules and find the first with a matching entry in rule.path_patterns and with defined property key
         const matchingRule = typeDescriptionsYaml.find((rule) => {
             const matchingPathPattern = rule['path_patterns'].find((pathPattern) => {
                 const regex = new RegExp(toRegex(pathPattern));
                 return regex.test(parentPath);
             });
-            return matchingPathPattern !== undefined;
+            if (matchingPathPattern === undefined) {
+                return false;
+            }
+            return rule['property_descriptions'][propertyKey] !== undefined;
         });
         // Exit early if no matching rule
         if (matchingRule === undefined) {
@@ -94,13 +97,8 @@ yaml.visit(fileDoc, {
             return;
         }
         debug("matched rule: " + matchingRule.type);
-        // Check if there is a description for the current propertyKey in the matching rule
-        // Exit early if none registered
+        // We already guarantee that the propertyKey is defined for the rule above
         const description = matchingRule['property_descriptions'][propertyKey];
-        if (description === undefined) {
-            debug("no matching property")
-            return;
-        }
         // Format the description
         let formattedDescription = description.replace(/\n$/, '').split('\n').map(line => ' ' + line).join('\n');
         // If we're on the first element, prefix the formatted description with the existing commentBefore to retain the comments at the top of the file


### PR DESCRIPTION
Resolves #103.

- Split `otlp` exporter into `otlp_http` for HTTP transport, and `otlp_grpc` for gRPC transport
- Remove `otlp.protocol` property
- Remove `otlp.endpoint` property from required, since there is now a reasonable default. 
- `otlp_http` and `otlp_grpc` can both be set to null. Since there are no longer any required properties, its reasonable for a user to specify `otlp_http:`, `otlp_grpc:`. 
- The `.insecure` property is only applicable to `otlp_grpc`
- Add new `encoding` property with values `proto` or `json` for `otlp_http`. Default is `proto`. 

Unrelated changes bundled in:
- Rename titles of exporter types to include `*Exporter` prefix
  - Console -> ConsoleExporter
  - Zipkin -> ZipkinExporter
  - Prometheus -> PrometheusExporter

I've prototyped this change in [opentelemetry-java here](https://github.com/jack-berg/opentelemetry-java/commit/9d0c25ea9cc769f7f95b60f08e1504d7a3a4af70).