### PR TITLE
Fix MetricReader invalid configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Improved file_format documentation. [#137](https://github.com/open-telemetry/opentelemetry-configuration/pull/137)
 * Periodic exporter interval default value is inconsistent [#143](https://github.com/open-telemetry/opentelemetry-configuration/pull/143)
+* Fix MetricReader invalid configurations [#148](https://github.com/open-telemetry/opentelemetry-configuration/pull/148)
 
 ## [v0.3.0] - 2024-05-08
 

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -131,10 +131,9 @@ meter_provider:
               # If omitted, .included resource attributes are included.
               excluded:
                 - "service.attr1"
-      # Configure metric producers.
-      producers:
-        - # Configure metric producer to be opencensus.
-          opencensus:
+        # Configure metric producers.
+        producers:
+          - opencensus:
     - # Configure a periodic metric reader.
       periodic:
         # Configure delay interval (in milliseconds) between start of two consecutive exports.
@@ -185,10 +184,9 @@ meter_provider:
             # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
             # If omitted or null, explicit_bucket_histogram is used.
             default_histogram_aggregation: base2_exponential_bucket_histogram
-      # Configure metric producers.
-      producers:
-        - # Configure metric producer to be prometheus.
-          prometheus:
+        # Configure metric producers.
+        producers:
+          - prometheus:
     - # Configure a periodic metric reader.
       periodic:
         # Configure exporter.

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -156,7 +156,7 @@
             "type": "object",
             "additionalProperties": false,
             "minProperties": 1,
-            "maxProperties": 2,
+            "maxProperties": 1,
             "properties": {
                 "periodic": {
                     "$ref": "#/$defs/PeriodicMetricReader"

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -44,6 +44,12 @@
                 },
                 "exporter": {
                     "$ref": "#/$defs/PushMetricExporter"
+                },
+                "producers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/MetricProducer"
+                    }
                 }
             },
             "required": [
@@ -57,6 +63,12 @@
             "properties": {
                 "exporter": {
                     "$ref": "#/$defs/PullMetricExporter"
+                },
+                "producers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/MetricProducer"
+                    }
                 }
             },
             "required": [
@@ -151,12 +163,6 @@
                 },
                 "pull": {
                     "$ref": "#/$defs/PullMetricReader"
-                },
-                "producers": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/MetricProducer"
-                    }
                 }
             }
         },

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -328,13 +328,13 @@
   property_descriptions:
     pull: Configure a pull based metric reader.
     periodic: Configure a periodic metric reader.
-    producers: Configure metric producers.
   path_patterns:
     - .meter_provider.readers[]
 
 - type: PullMetricReader
   property_descriptions:
     exporter: Configure exporter.
+    producers: Configure metric producers.
   path_patterns:
     - .meter_provider.readers[].pull
 
@@ -349,6 +349,7 @@
       
       If omitted or null, 30000 is used.
     exporter: Configure exporter.
+    producers: Configure metric producers.
   path_patterns:
     - .meter_provider.readers[].periodic
 
@@ -357,7 +358,8 @@
     opencensus: Configure metric producer to be opencensus.
     prometheus: Configure metric producer to be prometheus.
   path_patterns:
-    - .meter_provider.readers[].producers[]
+    - .meter_provider.readers[].producers[].pull
+    - .meter_provider.readers[].producers[].periodic
 
 - type: MetricExporter
   property_descriptions:


### PR DESCRIPTION
Fixes #138

* Move `producers` from `MetricReader` to `PeriodicMetricReader`
* Move `producers` from `MetricReader` to `PullMetricReader`

