### PR TITLE
Add otlp_file exporter

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -113,9 +113,18 @@ logger_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream.
+            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
-            output_stream: logs.jsonl
+            output_stream: file:///var/log/logs.jsonl
+    - # Configure a batch log record processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          otlp_file:
+            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: stdout
     - # Configure a simple log record processor.
       simple:
         # Configure exporter.
@@ -276,9 +285,30 @@ meter_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream.
+            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
-            output_stream: metrics.jsonl
+            output_stream: file:///var/log/metrics.jsonl
+            # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          otlp_file:
+            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: stdout
+            # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
     - # Configure a periodic metric reader.
       periodic:
         # Configure exporter.
@@ -457,9 +487,18 @@ tracer_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream.
+            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
-            output_stream: traces.jsonl
+            output_stream: file:///var/log/traces.jsonl
+    - # Configure a batch span processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          otlp_file:
+            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: stdout
     - # Configure a batch span processor.
       batch:
         # Configure exporter.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -107,6 +107,15 @@ logger_provider:
             # Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
             # If omitted or null, false is used.
             insecure: false
+    - # Configure a batch log record processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          otlp_file:
+            # Configure output stream.
+            # If omitted or null, stdout is used.
+            output_stream: logs.jsonl
     - # Configure a simple log record processor.
       simple:
         # Configure exporter.
@@ -261,6 +270,15 @@ meter_provider:
             # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
             # If omitted or null, explicit_bucket_histogram is used.
             default_histogram_aggregation: base2_exponential_bucket_histogram
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          otlp_file:
+            # Configure output stream.
+            # If omitted or null, stdout is used.
+            output_stream: metrics.jsonl
     - # Configure a periodic metric reader.
       periodic:
         # Configure exporter.
@@ -433,6 +451,15 @@ tracer_provider:
             # Configure client transport security for the exporter's connection. Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
             # If omitted or null, false is used.
             insecure: false
+    - # Configure a batch span processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          otlp_file:
+            # Configure output stream.
+            # If omitted or null, stdout is used.
+            output_stream: traces.jsonl
     - # Configure a batch span processor.
       batch:
         # Configure exporter.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -129,7 +129,8 @@ logger_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
             output_stream: file:///var/log/logs.jsonl
     - # Configure a batch log record processor.
@@ -138,7 +139,8 @@ logger_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
             output_stream: stdout
     - # Configure a simple log record processor.
@@ -321,7 +323,8 @@ meter_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
             output_stream: file:///var/log/metrics.jsonl
             # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
@@ -336,7 +339,8 @@ meter_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
             output_stream: stdout
             # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
@@ -542,7 +546,8 @@ tracer_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
             output_stream: file:///var/log/traces.jsonl
     - # Configure a batch span processor.
@@ -551,7 +556,8 @@ tracer_provider:
         exporter:
           # Configure exporter to be OTLP with file transport.
           otlp_file:
-            # Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
             output_stream: stdout
     - # Configure a batch span processor.

--- a/schema/common.json
+++ b/schema/common.json
@@ -117,7 +117,6 @@
             }
         },
         "OtlpFileExporter": {
-            "title": "OtlpFileExporter",
             "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {

--- a/schema/common.json
+++ b/schema/common.json
@@ -116,6 +116,16 @@
                 }
             }
         },
+        "OtlpFileExporter": {
+            "title": "OtlpFileExporter",
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "output_stream": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
         "ConsoleExporter": {
             "type": ["object", "null"],
             "additionalProperties": false

--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -71,6 +71,9 @@
                 "otlp_grpc": {
                     "$ref": "common.json#/$defs/OtlpGrpcExporter"
                 },
+                "otlp_file": {
+                    "$ref": "common.json#/$defs/OtlpFileExporter"
+                },
                 "console": {
                     "$ref": "common.json#/$defs/ConsoleExporter"
                 }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -88,6 +88,9 @@
                 "otlp_grpc": {
                     "$ref": "#/$defs/OtlpGrpcMetricExporter"
                 },
+                "otlp_file": {
+                    "$ref": "#/$defs/OtlpFileMetricExporter"
+                },
                 "console": {
                     "$ref": "common.json#/$defs/ConsoleExporter"
                 }
@@ -270,6 +273,22 @@
                 },
                 "insecure": {
                     "type": ["boolean", "null"]
+                },
+                "temporality_preference": {
+                    "$ref": "#/$defs/ExporterTemporalityPreference"
+                },
+                "default_histogram_aggregation": {
+                    "$ref": "#/$defs/ExporterDefaultHistogramAggregation"
+                }
+            }
+        },
+        "OtlpFileMetricExporter": {
+            "title": "OtlpFileMetricExporter",
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "output_stream": {
+                    "type": ["string", "null"]
                 },
                 "temporality_preference": {
                     "$ref": "#/$defs/ExporterTemporalityPreference"

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -283,7 +283,6 @@
             }
         },
         "OtlpFileMetricExporter": {
-            "title": "OtlpFileMetricExporter",
             "type": ["object", "null"],
             "additionalProperties": false,
             "properties": {

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -143,6 +143,9 @@
                 "otlp_grpc": {
                     "$ref": "common.json#/$defs/OtlpGrpcExporter"
                 },
+                "otlp_file": {
+                    "$ref": "common.json#/$defs/OtlpFileExporter"
+                },
                 "console": {
                     "$ref": "common.json#/$defs/ConsoleExporter"
                 },

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -606,7 +606,7 @@
 - type: OtlpFileExporter
   property_descriptions:
     output_stream: >
-      Configure output stream.
+      Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
 
       If omitted or null, stdout is used.
   path_patterns:

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -670,7 +670,9 @@
 - type: OtlpFileExporter
   property_descriptions:
     output_stream: >
-      Configure output stream. Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+      Configure output stream. 
+      
+      Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
 
       If omitted or null, stdout is used.
   path_patterns:

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -163,6 +163,7 @@
   property_descriptions:
     otlp_http: Configure exporter to be OTLP with HTTP transport.
     otlp_grpc: Configure exporter to be OTLP with gRPC transport.
+    otlp_file: Configure exporter to be OTLP with file transport.
     console: Configure exporter to be console.
   path_patterns:
     - .logger_provider.processors[].*.exporter
@@ -232,6 +233,7 @@
   property_descriptions:
     otlp_http: Configure exporter to be OTLP with HTTP transport.
     otlp_grpc: Configure exporter to be OTLP with gRPC transport.
+    otlp_file: Configure exporter to be OTLP with file transport.
     zipkin: Configure exporter to be zipkin.
     console: Configure exporter to be console.
   path_patterns:
@@ -368,6 +370,7 @@
     prometheus: Configure exporter to be prometheus.
     otlp_http: Configure exporter to be OTLP with HTTP transport.
     otlp_grpc: Configure exporter to be OTLP with gRPC transport.
+    otlp_file: Configure exporter to be OTLP with file transport.
     console: Configure exporter to be console.
   path_patterns:
     - .meter_provider.readers[].*.exporter
@@ -600,6 +603,16 @@
     - .tracer_provider.processors[].*.exporter.otlp_grpc
     - .logger_provider.processors[].*.exporter.otlp_grpc
     - .meter_provider.readers[].periodic.exporter.otlp_grpc
+- type: OtlpFileExporter
+  property_descriptions:
+    output_stream: >
+      Configure output stream.
+
+      If omitted or null, stdout is used.
+  path_patterns:
+    - .tracer_provider.processors[].*.exporter.otlp_file
+    - .logger_provider.processors[].*.exporter.otlp_file
+    - .meter_provider.readers[].periodic.exporter.otlp_file
 # END common
 
 # START Instrumentation


### PR DESCRIPTION
Adding the in-development otlp_file exporter from https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/protocol/file-exporter.md

- I chose `output_stream` as the field name to match https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/protocol/file-exporter.md#programmatic-configuration
- I chose `stdout` as the default output stream based on https://github.com/open-telemetry/opentelemetry-specification/pull/4183
