### PR TITLE
Object and enum types should be defined in $defs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,18 +172,74 @@ Another example:
         ]
       },
       "type": {
-        "type": ["string", "null"],
-        "enum": [null, "string", "bool", "int", "double", "string_array", "bool_array", "int_array", "double_array"]
+        "$ref": "#/$defs/AttributeType"
       }
     },
     "required": [
       "name", "value"
+    ]
+  },
+  "AttributeType": {
+    "type": ["string", "null"],
+    "enum": [
+      null,
+      "string",
+      "bool",
+      "int",
+      "double",
+      "string_array",
+      "bool_array",
+      "int_array",
+      "double_array"
     ]
   }
 }
 ```
 
 `oneOf` is used to specify that the `value` property matches the [standard attribute](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/common#standard-attribute) definition, and is either a primitive or array of primitives. This type of use is acceptable but should be used judiciously.
+
+## Schemas and subschemas
+
+In JSON Schema, a [schema](https://json-schema.org/learn/glossary#schema) is a document, and a [subschema](https://json-schema.org/learn/glossary#subschema) is contained in surrounding parent schema. Subschemas can be nested in various ways:
+
+A property can directly describe a complex set of requirements including nested structures:
+
+```json
+{
+  "properties": {
+    "shape": {
+      "type": "object",
+      "properties": {
+        "color": { "type": "string" },
+        "sides": { "type": "int" }
+      }
+    }
+  }
+}
+```
+
+Or a property can reference a subschema residing in a schema document's [$defs](https://json-schema.org/understanding-json-schema/structuring#defs):
+
+```json
+{
+  "properties": {
+    "shape": {
+      "$ref": "#/$defs/Sampler"
+    }
+  },
+  "$defs": {
+    "Shape": {
+      "type": "object",
+      "properties": {
+        "color": { "type": "string" },
+        "sides": { "type": "int" }
+      }
+    }
+  }
+}
+```
+
+In order to promote stylistic consistency and allow for reuse of concepts, `object` and `enum` types should be defined in either as a top level schema document or as a subschema in a schema document's `$defs`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Or a property can reference a subschema residing in a schema document's [$defs](
 {
   "properties": {
     "shape": {
-      "$ref": "#/$defs/Sampler"
+      "$ref": "#/$defs/Shape"
     }
   },
   "$defs": {

--- a/schema/common.json
+++ b/schema/common.json
@@ -56,7 +56,7 @@
                 "headers": {
                     "type": "array",
                     "items": {
-                        "$ref": "common.json#/$defs/NameStringValuePair"
+                        "$ref": "#/$defs/NameStringValuePair"
                     }
                 },
                 "headers_list": {
@@ -70,13 +70,16 @@
                     "minimum": 0
                 },
                 "encoding": {
-                    "type": ["string", "null"],
-                    "enum": [
-                        "protobuf",
-                        "json"
-                    ]
+                    "$ref": "#/$defs/OtlpHttpEncoding"
                 }
             }
+        },
+        "OtlpHttpEncoding": {
+            "type": ["string", "null"],
+            "enum": [
+                "protobuf",
+                "json"
+            ]
         },
         "OtlpGrpcExporter": {
             "title": "OtlpGrpcExporter",

--- a/schema/instrumentation.json
+++ b/schema/instrumentation.json
@@ -53,68 +53,74 @@
             "additionalProperties": false,
             "properties": {
                 "peer": {
+                    "$ref": "#/$defs/PeerInstrumentation"
+                },
+                "http": {
+                    "$ref": "#/$defs/HttpInstrumentation"
+                }
+            }
+        },
+        "PeerInstrumentation": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "service_mapping": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "peer": {
+                                "type": "string"
+                            },
+                            "service": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "peer",
+                            "service"
+                        ]
+                    }
+                }
+            }
+        },
+        "HttpInstrumentation": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "client": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                        "service_mapping": {
+                        "request_captured_headers": {
                             "type": "array",
                             "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "peer": {
-                                        "type": "string"
-                                    },
-                                    "service": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "peer",
-                                    "service"
-                                ]
+                                "type": "string"
+                            }
+                        },
+                        "response_captured_headers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
                             }
                         }
                     }
                 },
-                "http": {
+                "server": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                        "client": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "request_captured_headers": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "response_captured_headers": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
+                        "request_captured_headers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
                             }
                         },
-                        "server": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "request_captured_headers": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "response_captured_headers": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
+                        "response_captured_headers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
                             }
                         }
                     }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -18,18 +18,21 @@
             }
         },
         "exemplar_filter": {
-            "type": ["string", "null"],
-            "enum": [
-                "always_on",
-                "always_off",
-                "trace_based"
-            ]
+            "$ref": "#/$defs/ExemplarFilter"
         }
     },
     "required": [
         "readers"
     ],
     "$defs": {
+        "ExemplarFilter": {
+            "type": ["string", "null"],
+            "enum": [
+                "always_on",
+                "always_off",
+                "trace_based"
+            ]
+        },
         "PeriodicMetricReader": {
             "type": "object",
             "additionalProperties": false,
@@ -121,8 +124,7 @@
             "maxProperties": 1,
             "properties": {
                 "opencensus": {
-                    "type": ["object", "null"],
-                    "additionalProperties": false
+                    "$ref": "#/$defs/OpenCensusMetricProducer"
                 }
             },
             "patternProperties": {
@@ -130,6 +132,10 @@
                     "type": ["object", "null"]
                 }
             }
+        },
+        "OpenCensusMetricProducer": {
+            "type": ["object", "null"],
+            "additionalProperties": false
         },
         "PrometheusMetricExporter": {
             "title": "PrometheusMetricExporter",
@@ -221,11 +227,7 @@
                     "minimum": 0
                 },
                 "encoding": {
-                    "type": ["string", "null"],
-                    "enum": [
-                        "protobuf",
-                        "json"
-                    ]
+                    "$ref": "common.json#/$defs/OtlpHttpEncoding"
                 },
                 "temporality_preference": {
                     "$ref": "#/$defs/ExporterTemporalityPreference"
@@ -284,109 +286,139 @@
             "additionalProperties": false,
             "properties": {
                 "selector": {
-                    "title": "Selector",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "instrument_name": {
-                            "type": ["string", "null"]
-                        },
-                        "instrument_type": {
-                            "type": ["string", "null"],
-                            "enum": [
-                                "counter",
-                                "histogram",
-                                "observable_counter",
-                                "observable_gauge",
-                                "observable_up_down_counter",
-                                "up_down_counter"
-                            ]
-                        },
-                        "unit": {
-                            "type": ["string", "null"]
-                        },
-                        "meter_name": {
-                            "type": ["string", "null"]
-                        },
-                        "meter_version": {
-                            "type": ["string", "null"]
-                        },
-                        "meter_schema_url": {
-                            "type": ["string", "null"]
-                        }
-                    }
+                    "$ref": "#/$defs/ViewSelector"
                 },
                 "stream": {
-                    "title": "Stream",
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "name": {
-                            "type": ["string", "null"]
-                        },
-                        "description": {
-                            "type": ["string", "null"]
-                        },
-                        "aggregation": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "minProperties": 1,
-                            "maxProperties": 1,
-                            "properties": {
-                                "default": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                },
-                                "drop": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                },
-                                "explicit_bucket_histogram": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "boundaries": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "record_min_max": {
-                                            "type": ["boolean", "null"]
-                                        }
-                                    }
-                                },
-                                "base2_exponential_bucket_histogram": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "max_scale": {
-                                            "type": ["integer", "null"]
-                                        },
-                                        "max_size": {
-                                            "type": ["integer", "null"]
-                                        },
-                                        "record_min_max": {
-                                            "type": ["boolean", "null"]
-                                        }
-                                    }
-                                },
-                                "last_value": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                },
-                                "sum": {
-                                    "type": ["object", "null"],
-                                    "additionalProperties": false
-                                }
-                            }
-                        },
-                        "attribute_keys": {
-                            "$ref": "common.json#/$defs/IncludeExclude"
-                        }
-                    }
+                    "$ref": "#/$defs/ViewStream"
                 }
             }
+        },
+        "ViewSelector": {
+            "title": "Selector",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "instrument_name": {
+                    "type": ["string", "null"]
+                },
+                "instrument_type": {
+                    "$ref": "#/$defs/InstrumentType"
+                },
+                "unit": {
+                    "type": ["string", "null"]
+                },
+                "meter_name": {
+                    "type": ["string", "null"]
+                },
+                "meter_version": {
+                    "type": ["string", "null"]
+                },
+                "meter_schema_url": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "InstrumentType": {
+            "type": ["string", "null"],
+            "enum": [
+                "counter",
+                "histogram",
+                "observable_counter",
+                "observable_gauge",
+                "observable_up_down_counter",
+                "up_down_counter"
+            ]
+        },
+        "ViewStream": {
+            "title": "Stream",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": ["string", "null"]
+                },
+                "description": {
+                    "type": ["string", "null"]
+                },
+                "aggregation": {
+                    "$ref": "#/$defs/Aggregation"
+                },
+                "attribute_keys": {
+                    "$ref": "common.json#/$defs/IncludeExclude"
+                }
+            }
+        },
+        "Aggregation": {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+                "default": {
+                    "$ref": "#/$defs/DefaultAggregation"
+                },
+                "drop": {
+                    "$ref": "#/$defs/DropAggregation"
+                },
+                "explicit_bucket_histogram": {
+                    "$ref": "#/$defs/ExplicitBucketHistogramAggregation"
+                },
+                "base2_exponential_bucket_histogram": {
+                    "$ref": "#/$defs/Base2ExponentialBucketHistogramAggregation"
+                },
+                "last_value": {
+                    "$ref": "#/$defs/LastValueAggregation"
+                },
+                "sum": {
+                    "$ref": "#/$defs/SumAggregation"
+                }
+            }
+        },
+        "DefaultAggregation": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "DropAggregation": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "ExplicitBucketHistogramAggregation": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "boundaries": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "record_min_max": {
+                    "type": ["boolean", "null"]
+                }
+            }
+        },
+        "Base2ExponentialBucketHistogramAggregation": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "max_scale": {
+                    "type": ["integer", "null"]
+                },
+                "max_size": {
+                    "type": ["integer", "null"]
+                },
+                "record_min_max": {
+                    "type": ["boolean", "null"]
+                }
+            }
+        },
+        "LastValueAggregation": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "SumAggregation": {
+            "type": ["object", "null"],
+            "additionalProperties": false
         }
     }
 }

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -42,22 +42,25 @@
                     ]
                 },
                 "type": {
-                    "type": ["string", "null"],
-                    "enum": [
-                        null,
-                        "string",
-                        "bool",
-                        "int",
-                        "double",
-                        "string_array",
-                        "bool_array",
-                        "int_array",
-                        "double_array"
-                    ]
+                    "$ref": "#/$defs/AttributeType"
                 }
             },
             "required": [
                 "name", "value"
+            ]
+        },
+        "AttributeType": {
+            "type": ["string", "null"],
+            "enum": [
+                null,
+                "string",
+                "bool",
+                "int",
+                "double",
+                "string_array",
+                "bool_array",
+                "int_array",
+                "double_array"
             ]
         },
         "Detectors": {

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -58,63 +58,78 @@
             "maxProperties": 1,
             "properties": {
                 "always_off": {
-                    "type": ["object", "null"],
-                    "additionalProperties": false
+                    "$ref": "#/$defs/AlwaysOffSampler"
                 },
                 "always_on": {
-                    "type": ["object", "null"],
-                    "additionalProperties": false
+                    "$ref": "#/$defs/AlwaysOnSampler"
                 },
                 "jaeger_remote": {
-                    "type": ["object", "null"],
-                    "additionalProperties": false,
-                    "properties": {
-                        "endpoint": {
-                            "type": ["string", "null"]
-                        },
-                        "interval": {
-                            "type": ["integer", "null"],
-                            "minimum": 0
-                        },
-                        "initial_sampler": {
-                            "$ref": "#/$defs/Sampler"
-                        }
-                    }
+                    "$ref": "#/$defs/JaegerRemoteSampler"
                 },
                 "parent_based": {
-                    "type": ["object", "null"],
-                    "additionalProperties": false,
-                    "properties": {
-                        "root": {
-                            "$ref": "#/$defs/Sampler"
-                        },
-                        "remote_parent_sampled": {
-                            "$ref": "#/$defs/Sampler"
-                        },
-                        "remote_parent_not_sampled": {
-                            "$ref": "#/$defs/Sampler"
-                        },
-                        "local_parent_sampled": {
-                            "$ref": "#/$defs/Sampler"
-                        },
-                        "local_parent_not_sampled": {
-                            "$ref": "#/$defs/Sampler"
-                        }
-                    }
+                    "$ref": "#/$defs/ParentBasedSampler"
                 },
                 "trace_id_ratio_based": {
-                    "type": ["object", "null"],
-                    "additionalProperties": false,
-                    "properties": {
-                        "ratio": {
-                            "type": ["number", "null"]
-                        }
-                    }
+                    "$ref": "#/$defs/TraceIdRatioBasedSampler"
                 }
             },
             "patternProperties": {
                 ".*": {
                     "type": ["object", "null"]
+                }
+            }
+        },
+        "AlwaysOffSampler": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "AlwaysOnSampler": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "JaegerRemoteSampler": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "endpoint": {
+                    "type": ["string", "null"]
+                },
+                "interval": {
+                    "type": ["integer", "null"],
+                    "minimum": 0
+                },
+                "initial_sampler": {
+                    "$ref": "#/$defs/Sampler"
+                }
+            }
+        },
+        "ParentBasedSampler": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "root": {
+                    "$ref": "#/$defs/Sampler"
+                },
+                "remote_parent_sampled": {
+                    "$ref": "#/$defs/Sampler"
+                },
+                "remote_parent_not_sampled": {
+                    "$ref": "#/$defs/Sampler"
+                },
+                "local_parent_sampled": {
+                    "$ref": "#/$defs/Sampler"
+                },
+                "local_parent_not_sampled": {
+                    "$ref": "#/$defs/Sampler"
+                }
+            }
+        },
+        "TraceIdRatioBasedSampler": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "properties": {
+                "ratio": {
+                    "type": ["number", "null"]
                 }
             }
         },


### PR DESCRIPTION
More cleanup as we approach stability.

Here I ensure the schema consistently uses JSON schema's schema / subschema options with a new schema modeling rule:

> In order to promote stylistic consistency and allow for reuse of concepts, `object` and `enum` types should be defined in either as a top level schema document or as a subschema in a schema document's `$defs`.

The stylistic consistency part is obvious.

"allow for reuse of concepts" is less obvious. When a type is defined in `$defs` we can reference as many times as needed in properties. When a type is defined directly in a property (or inline if you prefer), that type can only describe the requirements for that single property.

This guidance applies to  `object` and `enum` types. This means that excluded are all primitives and arrays.
