### PR TITLE
fixing broken link to env var substitution spec

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -60,7 +60,7 @@ Environment variable substitution is supported with the syntax `${VARIABLE}` or
 `${env:VARIABLE}`. Default values are supported in the form
 `${VARIABLE:-default}`. The full specification for variable substitution can be
 found in the
-[opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution).
+[opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#environment-variable-substitution).
 
 #### Using a Different Schema Version
 


### PR DESCRIPTION
fix link to the spec data model, which defines the requirements for env var substitution

Closes #163 