### PR TITLE
Refactor propagator schema

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -497,11 +497,29 @@ meter_provider:
   # If omitted or null, trace_based is used.
   exemplar_filter: trace_based
 # Configure text map context propagators.
-# If omitted, tracecontext and baggage are used.
+# If omitted, a noop propagator is used.
 propagator:
-  # Configure the set of propagators to include in the composite text map propagator. 
-  # Built-in values include: tracecontext, baggage, b3, b3multi, jaeger, none. Known third party values include: xray, ottrace. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration.
-  composite: [ tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace ]
+  # Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
+  # Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite:
+    - # Include the w3c trace context propagator.
+      tracecontext:
+    - # Include the w3c baggage propagator.
+      baggage:
+    - # Include the zipkin b3 propagator.
+      b3:
+    - # Include the zipkin b3 multi propagator.
+      b3multi:
+    - # Include the jaeger propagator.
+      jaeger:
+    - # Include the opentracing propagator.
+      ottrace:
+  # Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out.
+  # The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
+  # Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party identifiers include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite_list: "tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray"
 # Configure tracer provider.
 # If omitted, a noop tracer provider is used.
 tracer_provider:

--- a/examples/sdk-config.yaml
+++ b/examples/sdk-config.yaml
@@ -35,11 +35,16 @@ attribute_limits:
   # If omitted or null, 128 is used.
   attribute_count_limit: 128
 # Configure text map context propagators.
-# If omitted, tracecontext and baggage are used.
+# If omitted, a noop propagator is used.
 propagator:
-  # Configure the set of propagators to include in the composite text map propagator. 
-  # Built-in values include: tracecontext, baggage, b3, b3multi, jaeger, none. Known third party values include: xray, ottrace. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration.
-  composite: [ tracecontext, baggage ]
+  # Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
+  # Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite:
+    - # Include the w3c trace context propagator.
+      tracecontext:
+    - # Include the w3c baggage propagator.
+      baggage:
 # Configure tracer provider.
 # If omitted, a noop tracer provider is used.
 tracer_provider:

--- a/examples/sdk-migration-config.yaml
+++ b/examples/sdk-migration-config.yaml
@@ -14,7 +14,6 @@
 # for more information. The following spec defined env vars are NOT referenced and are thus
 # ignored:
 #
-# - OTEL_PROPAGATORS
 # - OTEL_TRACES_SAMPLER
 # - OTEL_TRACES_SAMPLER_ARG
 # - OTEL_EXPORTER_ZIPKIN_ENDPOINT
@@ -67,11 +66,17 @@ attribute_limits:
   # If omitted or null, 128 is used.
   attribute_count_limit: ${OTEL_ATTRIBUTE_COUNT_LIMIT:-128}
 # Configure text map context propagators.
-# If omitted, tracecontext and baggage are used.
+# If omitted, a noop propagator is used.
 propagator:
-  # Configure the set of propagators to include in the composite text map propagator. 
-  # Built-in values include: tracecontext, baggage, b3, b3multi, jaeger, none. Known third party values include: xray, ottrace. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration.
-  composite: [ tracecontext, baggage ]
+  # Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
+  # Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite: []
+  # Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out.
+  # The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
+  # Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party identifiers include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite_list: ${OTEL_PROPAGATORS:-tracecontext,baggage}
 # Configure tracer provider.
 # If omitted, a noop tracer provider is used.
 tracer_provider:

--- a/schema/propagator.json
+++ b/schema/propagator.json
@@ -6,11 +6,68 @@
         "composite": {
             "type": "array",
             "items": {
-                "type": ["string"]
+                "$ref": "#/$defs/TextMapPropagator"
             }
+        },
+        "composite_list": {
+            "type": ["string", "null"]
         }
     },
-    "required": [
-        "composite"
-    ]
+    "$defs": {
+        "TextMapPropagator": {
+            "type": "object",
+            "additionalProperties": true,
+            "minProperties": 1,
+            "maxProperties": 1,
+            "properties": {
+                "tracecontext": {
+                    "$ref": "#/$defs/TraceContextPropagator"
+                },
+                "baggage": {
+                    "$ref": "#/$defs/BaggagePropagator"
+                },
+                "b3": {
+                    "$ref": "#/$defs/B3Propagator"
+                },
+                "b3multi": {
+                    "$ref": "#/$defs/B3MultiPropagator"
+                },
+                "jaeger": {
+                    "$ref": "#/$defs/JaegerPropagator"
+                },
+                "ottrace": {
+                    "$ref": "#/$defs/OpenTracingPropagator"
+                }
+            },
+            "patternProperties": {
+                ".*": {
+                    "type": ["object", "null"]
+                }
+            }
+        },
+        "TraceContextPropagator": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "BaggagePropagator": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "B3Propagator": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "B3MultiPropagator": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "JaegerPropagator": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "OpenTracingPropagator": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        }
+    }
 }

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -34,7 +34,7 @@
     propagator: >
       Configure text map context propagators.
       
-      If omitted, tracecontext and baggage are used.
+      If omitted, a noop propagator is used.
     attribute_limits: Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
     logger_provider: >
       Configure logger provider.
@@ -122,11 +122,31 @@
 - type: Propagator
   property_descriptions:
     composite: >
-      Configure the set of propagators to include in the composite text map propagator. 
+      Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
       
-      Built-in values include: tracecontext, baggage, b3, b3multi, jaeger, none. Known third party values include: xray, ottrace. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration.
+      Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray. 
+      
+      If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+    composite_list: >
+      Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out.
+      
+      The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
+      
+      Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party identifiers include: xray. 
+      
+      If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
   path_patterns:
     - .propagator
+- type: CompositePropagator
+  property_descriptions:
+    tracecontext: Include the w3c trace context propagator.
+    baggage: Include the w3c baggage propagator.
+    b3: Include the zipkin b3 propagator.
+    b3multi: Include the zipkin b3 multi propagator.
+    jaeger: Include the jaeger propagator.
+    ottrace: Include the opentracing propagator.
+  path_patterns:
+    - .propagator.composite[]
 # END OpenTelemetryConfiguration
 
 # START LoggerProvider


### PR DESCRIPTION
See [comment](https://github.com/open-telemetry/opentelemetry-configuration/pull/173#issuecomment-2694969495).

Supersedes #173.

This refactors `.propagator.composite` from being an array of string entries to an array of objects. Each object has a single key identifying the name of the propagator.

This aligns propagator with the data modeling of other SDK extension points (processors, exporters, readers, sampler) where the extension point identifier is a key, and the object's value is passed as a node to configure that extension point. In the case of propagators, none of the built-in propagators currently accept configuration, but its conceivable that they may in the future.

The propagator comments have also been changed to indicate that omitting `.propagator` or having an empty `.propagator.composite` list results in a noop propgator. This aligns propagator config with the "what you see is what you get" philosophy used elsewhere in declarative config data modeling.

Finally, a new `.propagator.composite_list` property has been added with the same semantics as `OTEL_PROPAGATORS` env var. The comments indicate a merge semantic where entries from `.propagator.composite_list` are appended to `.propagator.composite` (with duplicates removed) when both are present. The ordering here is important because order that propagators are registered is signficiant, particularly when extracting context.