### PR TITLE
Refactor resource detection to allow config of named resource detectors

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -747,13 +747,6 @@ resource:
   # This type is in development and subject to breaking changes in minor versions.
   # If omitted or null, resource detection is disabled.
   detection/development:
-    # Configure the strategy for enabling resource detectors.
-    # Values include:
-    #  * opt_in: Resource detectors configured in .detectors are enabled and applied in the order specified. Other resource detectors are disabled. 
-    #  * enable_all: All resource detectors are enabled and applied in an unspecified order. Configuration in .detectors is passed to respective detectors.
-    #  * disable_all: All resource detectors are disabled, including any configured in .detectors.
-    # If omitted or null, opt_in is used.
-    enabled_detectors_strategy: opt_in
     # Configure attributes provided by resource detectors.
     attributes:
       # Configure list of attribute key patterns to include from resource detectors.
@@ -770,9 +763,9 @@ resource:
       # If omitted, .included attributes are included.
       excluded:
         - process.command_args
-    # Configure resource detectors. See also enabled_detectors_strategy.
+    # Configure resource detectors.
     # Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
-    # If omitted or null and enabled_detectors_strategy=opt_in, no resource detectors are enabled.
+    # If omitted or null, no resource detectors are enabled.
     detectors:
       - # Enable the container resource detector.
         # Note, the key "container" is an example and detector names may vary by SDK language ecosystem.

--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -743,9 +743,17 @@ resource:
   # The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
   # If omitted or null, no resource attributes are added.
   attributes_list: "service.namespace=my-namespace,service.version=1.0.0"
-  # Configure resource detectors.
+  # Configure resource detection.
   # This type is in development and subject to breaking changes in minor versions.
-  detectors/development:
+  # If omitted or null, resource detection is disabled.
+  detection/development:
+    # Configure the strategy for enabling resource detectors.
+    # Values include:
+    #  * opt_in: Resource detectors configured in .detectors are enabled and applied in the order specified. Other resource detectors are disabled. 
+    #  * enable_all: All resource detectors are enabled and applied in an unspecified order. Configuration in .detectors is passed to respective detectors.
+    #  * disable_all: All resource detectors are disabled, including any configured in .detectors.
+    # If omitted or null, opt_in is used.
+    enabled_detectors_strategy: opt_in
     # Configure attributes provided by resource detectors.
     attributes:
       # Configure list of attribute key patterns to include from resource detectors.
@@ -762,6 +770,22 @@ resource:
       # If omitted, .included attributes are included.
       excluded:
         - process.command_args
+    # Configure resource detectors. See also enabled_detectors_strategy.
+    # Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
+    # If omitted or null and enabled_detectors_strategy=opt_in, no resource detectors are enabled.
+    detectors:
+      - # Enable the container resource detector.
+        # Note, the key "container" is an example and detector names may vary by SDK language ecosystem.
+        container:
+      - # Enable the host resource detector.
+        # Note, the key "host" is an example and detector names may vary by SDK language ecosystem.
+        host:
+      - # Enable the os resource detector.
+        # Note, the key "os" is an example and detector names may vary by SDK language ecosystem.
+        os:
+      - # Enable the process resource detector.
+        # Note, the key "process" is an example and detector names may vary by SDK language ecosystem.
+        process:
   # Configure resource schema URL.
   # If omitted or null, no schema URL is used.
   schema_url: https://opentelemetry.io/schemas/1.16.0

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -10,8 +10,8 @@
                 "$ref": "#/$defs/AttributeNameValue"
             }
         },
-        "detectors/development": {
-            "$ref": "#/$defs/ExperimentalDetectors"
+        "detection/development": {
+            "$ref": "#/$defs/ExperimentalResourceDetection"
         },
         "schema_url": {
             "type": ["string", "null"]
@@ -61,14 +61,42 @@
                 "double_array"
             ]
         },
-        "ExperimentalDetectors": {
+        "ExperimentalResourceDetection": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "enabled_detectors_strategy": {
+                    "$ref": "#/$defs/ExperimentalEnabledResourceDetectorsStrategy"
+                },
                 "attributes": {
                     "$ref": "common.json#/$defs/IncludeExclude"
+                },
+                "detectors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ExperimentalResourceDetector"
+                    }
                 }
             }
+        },
+        "ExperimentalResourceDetector": {
+            "type": "object",
+            "additionalProperties": true,
+            "minProperties": 1,
+            "maxProperties": 1,
+            "patternProperties": {
+                ".*": {
+                    "type": ["object", "null"]
+                }
+            }
+        },
+        "ExperimentalEnabledResourceDetectorsStrategy": {
+            "type": ["string", "null"],
+            "enum": [
+                "opt_in",
+                "enable_all",
+                "disable_all"
+            ]
         }
     }
 }

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -65,9 +65,6 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "enabled_detectors_strategy": {
-                    "$ref": "#/$defs/ExperimentalEnabledResourceDetectorsStrategy"
-                },
                 "attributes": {
                     "$ref": "common.json#/$defs/IncludeExclude"
                 },
@@ -89,14 +86,6 @@
                     "type": ["object", "null"]
                 }
             }
-        },
-        "ExperimentalEnabledResourceDetectorsStrategy": {
-            "type": ["string", "null"],
-            "enum": [
-                "opt_in",
-                "enable_all",
-                "disable_all"
-            ]
         }
     }
 }

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -84,21 +84,13 @@
 
 - type: ResourceDetection
   property_descriptions:
-    enabled_detectors_strategy: >
-      Configure the strategy for enabling resource detectors.
-      
-      Values include:
-       * opt_in: Resource detectors configured in .detectors are enabled and applied in the order specified. Other resource detectors are disabled. 
-       * enable_all: All resource detectors are enabled and applied in an unspecified order. Configuration in .detectors is passed to respective detectors.
-       * disable_all: All resource detectors are disabled, including any configured in .detectors.
-      If omitted or null, opt_in is used.
     attributes: Configure attributes provided by resource detectors.
     detectors: >
-      Configure resource detectors. See also enabled_detectors_strategy.
+      Configure resource detectors.
       
       Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
       
-      If omitted or null and enabled_detectors_strategy=opt_in, no resource detectors are enabled.
+      If omitted or null, no resource detectors are enabled.
   path_patterns:
     - .resource.detection/development
 

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -69,10 +69,12 @@
       The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
       
       If omitted or null, no resource attributes are added.
-    detectors/development: >
-      Configure resource detectors.
+    detection/development: >
+      Configure resource detection.
       
       This type is in development and subject to breaking changes in minor versions.
+      
+      If omitted or null, resource detection is disabled.
     schema_url: >
       Configure resource schema URL.
       
@@ -80,11 +82,46 @@
   path_patterns:
     - .resource
 
-- type: Detectors
+- type: ResourceDetection
   property_descriptions:
+    enabled_detectors_strategy: >
+      Configure the strategy for enabling resource detectors.
+      
+      Values include:
+       * opt_in: Resource detectors configured in .detectors are enabled and applied in the order specified. Other resource detectors are disabled. 
+       * enable_all: All resource detectors are enabled and applied in an unspecified order. Configuration in .detectors is passed to respective detectors.
+       * disable_all: All resource detectors are disabled, including any configured in .detectors.
+      If omitted or null, opt_in is used.
     attributes: Configure attributes provided by resource detectors.
+    detectors: >
+      Configure resource detectors. See also enabled_detectors_strategy.
+      
+      Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
+      
+      If omitted or null and enabled_detectors_strategy=opt_in, no resource detectors are enabled.
   path_patterns:
-    - .resource.detectors/development
+    - .resource.detection/development
+
+- type: Detector
+  property_descriptions:
+    container: >
+      Enable the container resource detector.
+      
+      Note, the key "container" is an example and detector names may vary by SDK language ecosystem.
+    host: >
+      Enable the host resource detector.
+      
+      Note, the key "host" is an example and detector names may vary by SDK language ecosystem.
+    os: >
+      Enable the os resource detector.
+      
+      Note, the key "os" is an example and detector names may vary by SDK language ecosystem.
+    process: >
+      Enable the process resource detector.
+      
+      Note, the key "process" is an example and detector names may vary by SDK language ecosystem.
+  path_patterns:
+    - .resource.detection/development.detectors[]
 
 - type: DetectorAttributes
   property_descriptions:
@@ -103,7 +140,7 @@
        * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
       If omitted, .included attributes are included.
   path_patterns:
-    - .resource.detectors/development.attributes
+    - .resource.detection/development.attributes
 
 - type: AttributeLimits
   property_descriptions:


### PR DESCRIPTION
Resolves #119.

Resource detection is currently naive:

- We only have the ability to specify an allow list / disallow list of attributes that come from resource detectors.
- Its assumed / implied that all resource detectors are enabled, which conflicts with declarative config's "what you see is what you get" philosophy.
- There is no ability to pass configuration to a particular resource detector.
- There is no ability to influence the order of resource detectors, so if two provide the same attribute, you're at the mercy of whatever order they were applied in.

This PR refactors resource detection to add more expressiveness and better accommodate a wide range of use cases.

Let's take a look at an example config after this refactor:
```
resource:
  attributes:
    - name: service.name
       value: my-service
  detection/development:
    detectors:
      - container:
      - os:
      - host:
      - process:
    attributes:
      excluded:
        - process.command_line
```

Most users will want to set a static set of resource attributes, especially `service.*`, but resource detection is an important part of the otel ecosystem. You opt into resource detection by setting `resource.detection/development` and configuring to suit. 

`.detectors` is an array of objects, each with a single key referring to the name of a detector, and an object value passed to that detector to optionally configure it. This aligns resource detectors which the design of other SDK extension components.

The ability to include / exclude attributes provided by the collection of all resource detectors is still available. 