### PR TITLE
Remove title from logger config types

### DIFF
--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -122,7 +122,6 @@
         "ExperimentalLoggerConfigurator": {
             "type": ["object"],
             "additionalProperties": false,
-            "title": "LoggerConfigurator",
             "properties": {
                 "default_config": {
                     "$ref": "#/$defs/ExperimentalLoggerConfig"
@@ -138,7 +137,6 @@
         "ExperimentalLoggerMatcherAndConfig": {
             "type": ["object"],
             "additionalProperties": false,
-            "title": "LoggerMatcherAndConfig",
             "properties": {
                 "name": {
                     "type": ["string"]
@@ -151,7 +149,6 @@
         "ExperimentalLoggerConfig": {
             "type": ["object"],
             "additionalProperties": false,
-            "title": "LoggerConfig",
             "properties": {
                 "disabled": {
                     "type": ["boolean"]


### PR DESCRIPTION
This slipped through the cracks when I was resolving merge conflicts between #140 and #157.