### PR TITLE
Add minItems=1 to processors, readers

### DIFF
--- a/schema/logger_provider.json
+++ b/schema/logger_provider.json
@@ -6,6 +6,7 @@
     "properties": {
         "processors": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "$ref": "#/$defs/LogRecordProcessor"
             }

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -6,6 +6,7 @@
     "properties": {
         "readers": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "$ref": "#/$defs/MetricReader"
             }

--- a/schema/tracer_provider.json
+++ b/schema/tracer_provider.json
@@ -6,6 +6,7 @@
     "properties": {
         "processors": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "$ref": "#/$defs/SpanProcessor"
             }


### PR DESCRIPTION
Was reviewing some things and noticed that while `.tracer_provider.processors` is required, its valid for it to be an empty array. For the same reason we want `.tracer_provider.processors` to be required (i.e. a provider with no processors doesn't do anything) we should specify that processors has at least one entry.

Applied the same to `.logger_provider.processors`, `.meter_provider.readers`.