### PR TITLE
Add mark down link checking build step

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -39,3 +39,16 @@ jobs:
           echo $(git diff --cached)
           exit 1
         fi
+
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: lycheeverse/lychee-action@f613c4a64e50d792e0b31ec34bbcbba12263c6a6 # v2.3.0
+        with:
+          # excluding links to pull requests and issues is done for performance
+          args: >
+            --include-fragments
+            --exclude "^https://github.com/open-telemetry/opentelemetry-java/(issue|pull)/\\d+$"
+            --max-retries 6

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -50,6 +50,6 @@ jobs:
           # excluding links to pull requests and issues is done for performance
           args: >
             --include-fragments
-            --exclude "^https://github.com/open-telemetry/opentelemetry-java/(issue|pull)/\\d+$"
+            --exclude "^https://github.com/open-telemetry/opentelemetry-configuration/(issue|pull)/\\d+$"
             --max-retries 6
             .

--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -52,3 +52,4 @@ jobs:
             --include-fragments
             --exclude "^https://github.com/open-telemetry/opentelemetry-java/(issue|pull)/\\d+$"
             --max-retries 6
+            .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,5 +325,5 @@ A PR is ready to merge when:
 
 ```
 
-[env var substitution]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution
+[env var substitution]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#environment-variable-substitution
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,7 @@ How it works:
 * The [./schema/type_descriptions.yaml](./schema/type_descriptions.yaml) file
   defines descriptions for each of the properties of each type defines in
   the [JSON schema](./schema) data model.
-* The [./scripts/generate-descriptions.js](./scripts/generate-comments.js) is a
+* The [./scripts/generate-descriptions.js](./scripts/generate-descriptions.js) is a
   script which for a given input configuration file will:
   * Parse the YAML.
   * Walk through each key / value pair, and for each:
@@ -305,7 +305,7 @@ each key value pair, including the computed dot notation location, the matched
 rule, the previous description, the new description, etc.
 
 ```shell
-npm run-script generate-comments -- /absolute/path/to/input/file.yaml /absolute/path/to/output/file.yaml --debug
+npm run-script generate-descriptions -- /absolute/path/to/input/file.yaml /absolute/path/to/output/file.yaml --debug
 ```
 
 ## Pull requests

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository strictly follows [Semantic Versioning 2.0.0](https://semver.org/
 
 Stability definition consists of the following sections:
 
-* [Objectives](#objectives): Overview of the motivation behind stability.
+* [Objectives](#objective): Overview of the motivation behind stability.
 * [Guarantees and allowed changes](#guarantees-and-allowed-changes): Specific details on allowed and disallowed changes within stability guarantees.
 * [Applicability](#applicability): Limits of stability definitions, including experimental features and extension points.
 * [File format](#file-format): The `file_format` property and implementation behavior when schema versions are not aligned.
@@ -136,5 +136,5 @@ Maintainers ([@open-telemetry/configuration-maintainers](https://github.com/orgs
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).*
 
 [annotation]: https://json-schema.org/understanding-json-schema/reference/annotations
-[env var substitution]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution
+[env var substitution]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#environment-variable-substitution
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The [examples](./examples) directory contains a variety of sample configuration 
 
 ## Code generation
 
-There are [several tools](https://json-schema.org/implementations.html) available to generate code from a JSON schema. The following shows an example for generating code from the JSON schema in Go:
+There are [several tools](https://json-schema.org/tools) available to generate code from a JSON schema. The following shows an example for generating code from the JSON schema in Go:
 
 ```bash
 go-jsonschema \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 * Prepare the release by:
   * If preparing a minor or major release, merge a PR to `main`
-    to [update `file_format`](#update-fileformat).
+    to [update `file_format`](#update-file-format).
   * Merge a PR to `main` to update the [CHANGELOG.md](CHANGELOG.md). Changes
     should be listed under a heading of the
     form `## v{Major}.{Minor}.{Patch} - YYYY-MM-DD` under `## Unreleased`.
@@ -25,7 +25,7 @@ Our tags follow the naming convention of `v<major>.<minor>.<patch>`. Increment `
 and use `patch` value of 0 for new minor version releases. For patch releases keep `minor`
 unchanged and increment the `patch`.
 
-## Update file_format
+## Update `file_format` {#update-file-format}
 
 Update the `file_format: "<major>.<minor>` of [./examples](./examples) as follows:
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,7 +25,7 @@ Our tags follow the naming convention of `v<major>.<minor>.<patch>`. Increment `
 and use `patch` value of 0 for new minor version releases. For patch releases keep `minor`
 unchanged and increment the `patch`.
 
-## Update `file_format`
+## Update file_format
 
 Update the `file_format: "<major>.<minor>` of [./examples](./examples) as follows:
 

--- a/validator/README.md
+++ b/validator/README.md
@@ -2,7 +2,7 @@
 
 This application will replace environment variables in values of valid yaml
 files, following the rules of [file configuration environment variable
-substitution](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#environment-variable-substitution),
+substitution](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#environment-variable-substitution),
 before validating that result against a version of the [OpenTelemetry SDK
 Configuration
 schema](https://github.com/open-telemetry/opentelemetry-configuration/) and


### PR DESCRIPTION
Noticed a broken link and figured we're overdue for adding built automation for link checking. This is the same link checking tool we use in `opentelemetry-java-*`, e.g.: https://github.com/open-telemetry/opentelemetry-java/blob/main/.github/workflows/reusable-markdown-link-check.yml