### PR TITLE
docs: document implementation matrix

### DIFF
--- a/matrix.md
+++ b/matrix.md
@@ -1,0 +1,45 @@
+# Implementation matrix
+
+The following table shows the implementation of each feature supported by the
+configuration model:
+
+
+| Top Level | C++|Java|Go|PHP |
+| --------- | -|-|-|- | 
+| `file_format` | -|-|-|- | 
+| `disabled` | -|-|-|- | 
+| `log_level` | -|-|-|- | 
+| `attribute_limits` | -|-|-|- | 
+| `attribute_limits.attribute_value_length_limit` | -|-|-|- | 
+| `attribute_limits.attribute_count_limit` | -|-|-|- | 
+| `logger_provider` | -|-|-|- | 
+| `logger_provider.processors` | -|-|-|- | 
+| `logger_provider.limits` | -|-|-|- | 
+| `meter_provider` | -|-|-|- | 
+| `meter_provider.readers` | -|-|-|- | 
+| `meter_provider.views` | -|-|-|- | 
+| `meter_provider.exemplar_filter` | -|-|-|- | 
+| `propagator` | -|-|-|- | 
+| `propagator.composite` | -|-|-|- | 
+| `tracer_provider` | -|-|-|- | 
+| `tracer_provider.processors` | -|-|-|- | 
+| `tracer_provider.limits` | -|-|-|- | 
+| `tracer_provider.sampler` | -|-|-|- | 
+| `resource` | -|-|-|- | 
+| `resource.attributes` | -|-|-|- | 
+| `resource.attributes_list` | -|-|-|- | 
+| `resource.detectors` | -|-|-|- | 
+| `resource.schema_url` | -|-|-|- | 
+| `instrumentation` | -|-|-|- | 
+| `instrumentation.general` | -|-|-|- | 
+| `instrumentation.cpp` | -|-|-|- | 
+| `instrumentation.dotnet` | -|-|-|- | 
+| `instrumentation.erlang` | -|-|-|- | 
+| `instrumentation.go` | -|-|-|- | 
+| `instrumentation.java` | -|-|-|- | 
+| `instrumentation.js` | -|-|-|- | 
+| `instrumentation.php` | -|-|-|- | 
+| `instrumentation.python` | -|-|-|- | 
+| `instrumentation.ruby` | -|-|-|- | 
+| `instrumentation.rust` | -|-|-|- | 
+| `instrumentation.swift` | -|-|-|- | 


### PR DESCRIPTION
The idea w/ this matrix is to provide end users a clear picture of what is implemented for each language implementation. Ideally, the matrix will be:

1. auto generated from the kitchen-sink
2. automatically filled in for every implementation via a test

In the short term, the automation for fill in the implementation details could be manual, but ideally that would be short-lived for the sake of users and implementors.