### PR TITLE
Fix link exclusion

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -50,6 +50,6 @@ jobs:
           # excluding links to pull requests and issues is done for performance
           args: >
             --include-fragments
-            --exclude "^https://github.com/open-telemetry/opentelemetry-configuration/(issue|pull)/\\d+$"
+            --exclude "^https://github.com/open-telemetry/opentelemetry-configuration/(issues|pull)/\\d+$"
             --max-retries 6
             .


### PR DESCRIPTION
Oddly `issues` is plural while `pull` is singular.

(discovered in https://github.com/open-telemetry/opentelemetry-java/pull/7282#issuecomment-2810142838)