### PR TITLE
Standardize container, host, process, and service resource detectors

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -839,18 +839,14 @@ resource:
     # Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
     # If omitted or null, no resource detectors are enabled.
     detectors:
-      - # Enable the container resource detector.
-        # Note, the key "container" is an example and detector names may vary by SDK language ecosystem.
+      - # Enable the container resource detector, which populates container.* attributes.
         container:
-      - # Enable the host resource detector.
-        # Note, the key "host" is an example and detector names may vary by SDK language ecosystem.
+      - # Enable the host resource detector, which populates host.* and os.* attributes.
         host:
-      - # Enable the os resource detector.
-        # Note, the key "os" is an example and detector names may vary by SDK language ecosystem.
-        os:
-      - # Enable the process resource detector.
-        # Note, the key "process" is an example and detector names may vary by SDK language ecosystem.
+      - # Enable the process resource detector, which populates process.* attributes.
         process:
+      - # Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
+        service:
   # Configure resource schema URL.
   # If omitted or null, no schema URL is used.
   schema_url: https://opentelemetry.io/schemas/1.16.0

--- a/schema/resource.json
+++ b/schema/resource.json
@@ -82,10 +82,38 @@
             "minProperties": 1,
             "maxProperties": 1,
             "patternProperties": {
+                "container": {
+                    "$ref": "#/$defs/ExperimentalContainerResourceDetector"
+                },
+                "host": {
+                    "$ref": "#/$defs/ExperimentalHostResourceDetector"
+                },
+                "process": {
+                    "$ref": "#/$defs/ExperimentalProcessResourceDetector"
+                },
+                "service": {
+                    "$ref": "#/$defs/ExperimentalServiceResourceDetector"
+                },
                 ".*": {
                     "type": ["object", "null"]
                 }
             }
+        },
+        "ExperimentalContainerResourceDetector": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "ExperimentalHostResourceDetector": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "ExperimentalProcessResourceDetector": {
+            "type": ["object", "null"],
+            "additionalProperties": false
+        },
+        "ExperimentalServiceResourceDetector": {
+            "type": ["object", "null"],
+            "additionalProperties": false
         }
     }
 }

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -97,21 +97,13 @@
 - type: Detector
   property_descriptions:
     container: >
-      Enable the container resource detector.
-      
-      Note, the key "container" is an example and detector names may vary by SDK language ecosystem.
+      Enable the container resource detector, which populates container.* attributes.
     host: >
-      Enable the host resource detector.
-      
-      Note, the key "host" is an example and detector names may vary by SDK language ecosystem.
-    os: >
-      Enable the os resource detector.
-      
-      Note, the key "os" is an example and detector names may vary by SDK language ecosystem.
+      Enable the host resource detector, which populates host.* and os.* attributes.
     process: >
-      Enable the process resource detector.
-      
-      Note, the key "process" is an example and detector names may vary by SDK language ecosystem.
+      Enable the process resource detector, which populates process.* attributes.
+    service: >
+      Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
   path_patterns:
     - .resource.detection/development.detectors[]
 


### PR DESCRIPTION
The concept of named resource detectors with a standard set of known names has been added to the spec in https://github.com/open-telemetry/opentelemetry-specification/pull/4461