### PR TITLE
Move known resource detectors to properties

### DIFF
--- a/schema/resource.json
+++ b/schema/resource.json
@@ -81,7 +81,7 @@
             "additionalProperties": true,
             "minProperties": 1,
             "maxProperties": 1,
-            "patternProperties": {
+            "properties": {
                 "container": {
                     "$ref": "#/$defs/ExperimentalContainerResourceDetector"
                 },
@@ -93,7 +93,9 @@
                 },
                 "service": {
                     "$ref": "#/$defs/ExperimentalServiceResourceDetector"
-                },
+                }
+            },
+            "patternProperties": {
                 ".*": {
                     "type": ["object", "null"]
                 }


### PR DESCRIPTION
Fixing a modeling error from #199.

Shouldn't have any impact on users. 