### PR TITLE
Add 'translation_strategy' to PrometheusMetricProducer

### DIFF
--- a/examples/kitchen-sink.yaml
+++ b/examples/kitchen-sink.yaml
@@ -202,9 +202,11 @@ meter_provider:
             port: 9464
             # Configure Prometheus Exporter to produce metrics without a unit suffix or UNIT metadata.
             # If omitted or null, false is used.
+            # Deprecated: Use .translation_strategy instead.
             without_units: false
             # Configure Prometheus Exporter to produce metrics without a type suffix.
             # If omitted or null, false is used.
+            # Deprecated: Use .translation_strategy instead.
             without_type_suffix: false
             # Configure Prometheus Exporter to produce metrics without a scope info metric.
             # If omitted or null, false is used.
@@ -225,6 +227,15 @@ meter_provider:
               # If omitted, .included resource attributes are included.
               excluded:
                 - "service.attr1"
+            # Configure how Prometheus metrics are exposed. Values include:
+            #
+            #  * UnderscoreEscapingWithSuffixes, the default. This fully escapes metric names for classic Prometheus metric name compatibility, and includes appending type and unit suffixes.
+            #  * UnderscoreEscapingWithoutSuffixes, metric names will continue to escape special characters to _, but suffixes won't be attached.
+            #  * NoUTF8EscapingWithSuffixes will disable changing special characters to _. Special suffixes like units and _total for counters will be attached.
+            #  * NoTranslation. This strategy bypasses all metric and label name translation, passing them through unaltered.
+            #
+            # If omitted or null, UnderscoreEscapingWithSuffixes is used.
+            translation_strategy: UnderscoreEscapingWithSuffixes
         # Configure metric producers.
         producers:
           - # Configure metric producer to be opencensus.

--- a/schema/meter_provider.json
+++ b/schema/meter_provider.json
@@ -206,6 +206,15 @@
                 },
                 "with_resource_constant_labels": {
                     "$ref": "common.json#/$defs/IncludeExclude"
+                },
+                "translation_strategy": {
+                    "type": ["string", "null"],
+                    "enum": [
+                        "UnderscoreEscapingWithSuffixes",
+                        "UnderscoreEscapingWithoutSuffixes",
+                        "NoUTF8EscapingWithSuffixes",
+                        "NoTranslation"
+                    ]
                 }
             }
         },

--- a/schema/type_descriptions.yaml
+++ b/schema/type_descriptions.yaml
@@ -597,15 +597,28 @@
       Configure Prometheus Exporter to produce metrics without a unit suffix or UNIT metadata.
       
       If omitted or null, false is used.
+
+      Deprecated: Use .translation_strategy instead.
     without_type_suffix: >
       Configure Prometheus Exporter to produce metrics without a type suffix.
       
       If omitted or null, false is used.
+
+      Deprecated: Use .translation_strategy instead.
     without_scope_info: >
       Configure Prometheus Exporter to produce metrics without a scope info metric.
       
       If omitted or null, false is used.
     with_resource_constant_labels: Configure Prometheus Exporter to add resource attributes as metrics attributes.
+    translation_strategy: >
+      Configure how Prometheus metrics are exposed. Values include:
+
+       * UnderscoreEscapingWithSuffixes, the default. This fully escapes metric names for classic Prometheus metric name compatibility, and includes appending type and unit suffixes.
+       * UnderscoreEscapingWithoutSuffixes, metric names will continue to escape special characters to _, but suffixes won't be attached.
+       * NoUTF8EscapingWithSuffixes will disable changing special characters to _. Special suffixes like units and _total for counters will be attached.
+       * NoTranslation. This strategy bypasses all metric and label name translation, passing them through unaltered.
+
+      If omitted or null, UnderscoreEscapingWithSuffixes is used.
   path_patterns:
     - .meter_provider.readers[].pull.exporter.prometheus/development
 - type: PrometheusIncludeExclude


### PR DESCRIPTION
Fixes #261

This PR adds a new configuration option to control how PrometheusMetricProducers expose Prometheus metrics—complying with the spec change https://github.com/open-telemetry/opentelemetry-specification/pull/4533.
