### PR TITLE
fix link checker

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
-      - uses: lycheeverse/lychee-action@5c4ee84814c983aa7164eaee476f014e53ff3963 # v2.5.0
+      - uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
         with:
           # excluding links to pull requests and issues is done for performance
           args: >


### PR DESCRIPTION
lychee update broke the checker

it seems the PR was merged despite the failing test

See https://github.com/lycheeverse/lychee/issues/1729