### PR TITLE
chore: fix incorrect comment

### DIFF
--- a/.github/workflows/build-check.yaml
+++ b/.github/workflows/build-check.yaml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       # pinning this to v2.4.1 as newer versions break things
-      - uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.6.1
+      - uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
         with:
           # excluding links to pull requests and issues is done for performance
           args: >


### PR DESCRIPTION
The version of lychee-action is now pinned to v2.4.1. Updated the comment as such.