### PR TITLE
chore: pin lychee-action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,10 @@
     {
       "matchUpdateTypes": ["minor", "major"],
       "schedule": ["before 8am on Monday"]
+    },
+    {
+      "matchPackageNames": ["lycheeverse/lychee-action"],
+      "enabled": false
     }
   ],
   "labels": [


### PR DESCRIPTION
This will prevent renovate from trying to update the lychee-action which is pinned to v2.4.1 as newer versions cause build failures with false positives.