### PR TITLE
Update link check

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -19,13 +19,16 @@ jobs:
 
       - uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3.5.1
 
-      - name: Link check - relative links (all files)
+      - name: Link check for pull requests
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: mise run lint:local-links
+        run: |
+          mise run lint:local-links
+          mise run lint:links-in-modified-files --base origin/${{ github.base_ref }} --head ${{ github.event.pull_request.head.sha }}
 
-      - name: Link check (modified files only)
+      - name: Link check for pushes and scheduled workflows
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: mise run lint:links-in-modified-files --base origin/${{ github.base_ref }} --head ${{ github.event.pull_request.head.sha }} --event ${{ github.event_name }}
+        run: mise run lint:links


### PR DESCRIPTION
Fixes [link check warning](https://github.com/open-telemetry/opentelemetry-configuration/actions/runs/19675157536/job/56354129973) on `main`:

```
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Also allows us to remove the now unused `--event` from the underlying `opentelemetry-java-contrib` file that this uses:

https://github.com/open-telemetry/opentelemetry-configuration/blob/e6462271fee8bb98921e019e92b39f6ae762dfdc/mise.toml#L21