### PR TITLE
feat: add DevelopmentEventToSpanEventBridgeLogRecordProcessor

### DIFF
--- a/language-support-status.md
+++ b/language-support-status.md
@@ -34,6 +34,7 @@ Latest supported file format: `1.0.0`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | supported |  |  |
 | [`Distribution`](schema-docs.md#distribution) | supported |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | supported |  |  |
+| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `trace_based`: supported<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | supported |  | * `boundaries`: supported<br>* `record_min_max`: supported<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `explicit_bucket_histogram`: supported<br> |
@@ -46,7 +47,7 @@ Latest supported file format: `1.0.0`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | supported |  | * `opencensus`: supported<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
@@ -152,6 +153,7 @@ Latest supported file format: `1.0.0`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | unknown |  |  |
 | [`Distribution`](schema-docs.md#distribution) | unknown |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | unknown |  |  |
+| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `trace_based`: unknown<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | unknown |  | * `boundaries`: unknown<br>* `record_min_max`: unknown<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `explicit_bucket_histogram`: unknown<br> |
@@ -164,7 +166,7 @@ Latest supported file format: `1.0.0`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: not_implemented<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: not_implemented<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | unknown |  | * `opencensus`: unknown<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
@@ -270,6 +272,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | supported |  |  |
 | [`Distribution`](schema-docs.md#distribution) | supported |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | supported |  |  |
+| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | supported |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `trace_based`: supported<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | supported |  | * `boundaries`: supported<br>* `record_min_max`: supported<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `explicit_bucket_histogram`: supported<br> |
@@ -282,7 +285,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | ignored |  | * `opencensus`: ignored<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
@@ -388,6 +391,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | unknown |  |  |
 | [`Distribution`](schema-docs.md#distribution) | unknown |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | unknown |  |  |
+| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `trace_based`: unknown<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | unknown |  | * `boundaries`: unknown<br>* `record_min_max`: unknown<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `explicit_bucket_histogram`: unknown<br> |
@@ -400,7 +404,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | unknown |  | * `limits`: unknown<br>* `processors`: unknown<br>* `logger_configurator/development`: unknown<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | unknown |  | * `batch`: unknown<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: unknown<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | unknown |  | * `exemplar_filter`: unknown<br>* `readers`: unknown<br>* `views`: unknown<br>* `meter_configurator/development`: unknown<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | unknown |  | * `opencensus`: unknown<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
@@ -506,6 +510,7 @@ Latest supported file format: `1.0.0-rc.2`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | ignored |  |  |
 | [`Distribution`](schema-docs.md#distribution) | not_implemented |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | ignored |  |  |
+| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `trace_based`: supported<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | ignored |  | * `boundaries`: ignored<br>* `record_min_max`: ignored<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | ignored |  | * `base2_exponential_bucket_histogram`: ignored<br>* `explicit_bucket_histogram`: ignored<br> |
@@ -518,7 +523,7 @@ Latest supported file format: `1.0.0-rc.2`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | not_implemented |  | * `opencensus`: not_implemented<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | supported |  | * `periodic`: supported<br>* `pull`: not_implemented<br> |

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -34,7 +34,6 @@ Latest supported file format: `1.0.0`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | supported |  |  |
 | [`Distribution`](schema-docs.md#distribution) | supported |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | supported |  |  |
-| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `trace_based`: supported<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | supported |  | * `boundaries`: supported<br>* `record_min_max`: supported<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `explicit_bucket_histogram`: supported<br> |
@@ -47,7 +46,7 @@ Latest supported file format: `1.0.0`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: unknown<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | supported |  | * `opencensus`: supported<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
@@ -94,6 +93,7 @@ Latest supported file format: `1.0.0`
 | [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | not_implemented |  | * `always_off`: not_implemented<br>* `always_on`: not_implemented<br>* `parent_threshold`: not_implemented<br>* `probability`: not_implemented<br>* `rule_based`: not_implemented<br> |
 | [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | not_implemented |  |  |
 | [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | unknown |  | * `semconv`: unknown<br> |
 | [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | not_applicable |  | * `code`: not_applicable<br>* `db`: not_applicable<br>* `gen_ai`: not_applicable<br>* `http`: not_applicable<br>* `messaging`: not_applicable<br>* `rpc`: not_applicable<br>* `sanitization`: not_applicable<br>* `stability_opt_in_list`: not_applicable<br> |
 | [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | not_implemented |  |  |
@@ -153,7 +153,6 @@ Latest supported file format: `1.0.0`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | unknown |  |  |
 | [`Distribution`](schema-docs.md#distribution) | unknown |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | unknown |  |  |
-| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `trace_based`: unknown<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | unknown |  | * `boundaries`: unknown<br>* `record_min_max`: unknown<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `explicit_bucket_histogram`: unknown<br> |
@@ -166,7 +165,7 @@ Latest supported file format: `1.0.0`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: not_implemented<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: not_implemented<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: unknown<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | unknown |  | * `opencensus`: unknown<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
@@ -213,6 +212,7 @@ Latest supported file format: `1.0.0`
 | [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | not_implemented |  | * `always_off`: not_implemented<br>* `always_on`: not_implemented<br>* `parent_threshold`: not_implemented<br>* `probability`: not_implemented<br>* `rule_based`: not_implemented<br> |
 | [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | supported |  |  |
 | [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | not_implemented |  | * `semconv`: not_implemented<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | not_implemented |  | * `semconv`: not_implemented<br> |
 | [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | not_implemented |  | * `code`: not_implemented<br>* `db`: not_implemented<br>* `gen_ai`: not_implemented<br>* `http`: not_implemented<br>* `messaging`: not_implemented<br>* `rpc`: not_implemented<br>* `sanitization`: not_implemented<br>* `stability_opt_in_list`: not_implemented<br> |
 | [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | supported |  |  |
@@ -272,7 +272,6 @@ Latest supported file format: `1.0.0-rc.3`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | supported |  |  |
 | [`Distribution`](schema-docs.md#distribution) | supported |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | supported |  |  |
-| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | supported |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `trace_based`: supported<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | supported |  | * `boundaries`: supported<br>* `record_min_max`: supported<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `explicit_bucket_histogram`: supported<br> |
@@ -285,7 +284,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: unknown<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | ignored |  | * `opencensus`: ignored<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
@@ -332,6 +331,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_threshold`: supported<br>* `probability`: supported<br>* `rule_based`: supported<br> |
 | [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | supported |  |  |
 | [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | supported |  |  |
 | [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | unknown |  | * `semconv`: unknown<br> |
 | [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | supported |  | * `code`: supported<br>* `db`: supported<br>* `gen_ai`: supported<br>* `http`: supported<br>* `messaging`: supported<br>* `rpc`: supported<br>* `sanitization`: supported<br>* `stability_opt_in_list`: supported<br> |
 | [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | supported |  |  |
@@ -391,7 +391,6 @@ Latest supported file format: `1.0.0-rc.3`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | unknown |  |  |
 | [`Distribution`](schema-docs.md#distribution) | unknown |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | unknown |  |  |
-| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `trace_based`: unknown<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | unknown |  | * `boundaries`: unknown<br>* `record_min_max`: unknown<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `explicit_bucket_histogram`: unknown<br> |
@@ -404,7 +403,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | unknown |  | * `limits`: unknown<br>* `processors`: unknown<br>* `logger_configurator/development`: unknown<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | unknown |  | * `batch`: unknown<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: unknown<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br>* `event_to_span_event_bridge/development`: unknown<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | unknown |  | * `exemplar_filter`: unknown<br>* `readers`: unknown<br>* `views`: unknown<br>* `meter_configurator/development`: unknown<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | unknown |  | * `opencensus`: unknown<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
@@ -451,6 +450,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_threshold`: unknown<br>* `probability`: unknown<br>* `rule_based`: unknown<br> |
 | [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | unknown |  |  |
 | [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | unknown |  | * `semconv`: unknown<br> |
 | [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | unknown |  | * `code`: unknown<br>* `db`: unknown<br>* `gen_ai`: unknown<br>* `http`: unknown<br>* `messaging`: unknown<br>* `rpc`: unknown<br>* `sanitization`: unknown<br>* `stability_opt_in_list`: unknown<br> |
 | [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | unknown |  |  |
@@ -510,7 +510,6 @@ Latest supported file format: `1.0.0-rc.2`
 | [`DefaultAggregation`](schema-docs.md#defaultaggregation) | ignored |  |  |
 | [`Distribution`](schema-docs.md#distribution) | not_implemented |  |  |
 | [`DropAggregation`](schema-docs.md#dropaggregation) | ignored |  |  |
-| [`EventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#eventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExemplarFilter`](schema-docs.md#exemplarfilter) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `trace_based`: supported<br> |
 | [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | ignored |  | * `boundaries`: ignored<br>* `record_min_max`: ignored<br> |
 | [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | ignored |  | * `base2_exponential_bucket_histogram`: ignored<br>* `explicit_bucket_histogram`: ignored<br> |
@@ -523,7 +522,7 @@ Latest supported file format: `1.0.0-rc.2`
 | [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
 | [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | [`LogRecordLimits`](schema-docs.md#logrecordlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `event_to_span_event_bridge`: unknown<br>* `simple`: supported<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: unknown<br> |
 | [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
 | [`MetricProducer`](schema-docs.md#metricproducer) | not_implemented |  | * `opencensus`: not_implemented<br> |
 | [`MetricReader`](schema-docs.md#metricreader) | supported |  | * `periodic`: supported<br>* `pull`: not_implemented<br> |
@@ -570,6 +569,7 @@ Latest supported file format: `1.0.0-rc.2`
 | [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | not_implemented |  | * `always_off`: not_implemented<br>* `always_on`: not_implemented<br>* `parent_threshold`: not_implemented<br>* `probability`: not_implemented<br>* `rule_based`: not_implemented<br> |
 | [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | ignored |  |  |
 | [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | not_implemented |  |  |
 | [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | unknown |  | * `semconv`: unknown<br> |
 | [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | supported |  | * `code`: supported<br>* `db`: supported<br>* `gen_ai`: supported<br>* `http`: supported<br>* `messaging`: supported<br>* `rpc`: supported<br>* `sanitization`: supported<br>* `stability_opt_in_list`: supported<br> |
 | [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | supported |  |  |

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -455,13 +455,6 @@
       ],
       "additionalProperties": false
     },
-    "EventToSpanEventBridgeLogRecordProcessor": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "additionalProperties": false
-    },
     "ExemplarFilter": {
       "type": [
         "string",
@@ -685,6 +678,13 @@
           "description": "Configure database semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee database migration: https://opentelemetry.io/docs/specs/semconv/database/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
         }
       }
+    },
+    "ExperimentalEventToSpanEventBridgeLogRecordProcessor": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
     },
     "ExperimentalGenAiInstrumentation": {
       "type": "object",
@@ -1603,8 +1603,8 @@
           "$ref": "#/$defs/SimpleLogRecordProcessor",
           "description": "Configure a simple log record processor.\nIf omitted, ignore.\n"
         },
-        "event_to_span_event_bridge": {
-          "$ref": "#/$defs/EventToSpanEventBridgeLogRecordProcessor",
+        "event_to_span_event_bridge/development": {
+          "$ref": "#/$defs/ExperimentalEventToSpanEventBridgeLogRecordProcessor",
           "description": "Configure an event to span event bridge log record processor.\nIf omitted, ignore.\n"
         }
       }

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -455,6 +455,13 @@
       ],
       "additionalProperties": false
     },
+    "EventToSpanEventBridgeLogRecordProcessor": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
     "ExemplarFilter": {
       "type": [
         "string",
@@ -1595,6 +1602,10 @@
         "simple": {
           "$ref": "#/$defs/SimpleLogRecordProcessor",
           "description": "Configure a simple log record processor.\nIf omitted, ignore.\n"
+        },
+        "event_to_span_event_bridge": {
+          "$ref": "#/$defs/EventToSpanEventBridgeLogRecordProcessor",
+          "description": "Configure an event to span event bridge log record processor.\nIf omitted, ignore.\n"
         }
       }
     },

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -981,33 +981,6 @@ No snippets.
 }</pre>
 </details>
 
-## EventToSpanEventBridgeLogRecordProcessor <a id="eventtospaneventbridgelogrecordprocessor"></a>
-
-No properties.
-
-Constraints: 
-
-* `additionalProperties`: `false`
-
-Usages:
-
-* [`LogRecordProcessor.event_to_span_event_bridge`](#logrecordprocessor)
-
-No snippets.
-
-<details>
-<summary>JSON Schema</summary>
-
-[JSON Schema Source File](./schema/logger_provider.yaml)
-<pre>{
-  "type": [
-    "object",
-    "null"
-  ],
-  "additionalProperties": false
-}</pre>
-</details>
-
 ## ExemplarFilter <a id="exemplarfilter"></a>
 
 This is a enum type.
@@ -1683,8 +1656,8 @@ attribute_value_length_limit: 4096
 | Property | Type | Required? | Default and Null Behavior | Constraints | Description |
 |---|---|---|---|---|---|
 | `batch` | [`BatchLogRecordProcessor`](#batchlogrecordprocessor) | `false` | If omitted, ignore. | No constraints. | Configure a batch log record processor. |
-| `event_to_span_event_bridge` | [`EventToSpanEventBridgeLogRecordProcessor`](#eventtospaneventbridgelogrecordprocessor) | `false` | If omitted, ignore. | No constraints. | Configure an event to span event bridge log record processor. |
 | `simple` | [`SimpleLogRecordProcessor`](#simplelogrecordprocessor) | `false` | If omitted, ignore. | No constraints. | Configure a simple log record processor. |
+| `event_to_span_event_bridge/development`<br>**WARNING:** This property is [experimental](VERSIONING.md#experimental-features). | [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](#experimentaleventtospaneventbridgelogrecordprocessor) | `false` | If omitted, ignore. | No constraints. | Configure an event to span event bridge log record processor. |
 
 <details>
 <summary>Language support status</summary>
@@ -1692,8 +1665,8 @@ attribute_value_length_limit: 4096
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
 |---|---|---|---|---|---|
 | `batch` | supported | supported | supported | unknown | supported |
-| `event_to_span_event_bridge` | unknown | unknown | unknown | unknown | unknown |
 | `simple` | supported | supported | supported | unknown | supported |
+| `event_to_span_event_bridge/development` | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -1731,8 +1704,8 @@ No snippets.
       "$ref": "#/$defs/SimpleLogRecordProcessor",
       "description": "Configure a simple log record processor.\nIf omitted, ignore.\n"
     },
-    "event_to_span_event_bridge": {
-      "$ref": "#/$defs/EventToSpanEventBridgeLogRecordProcessor",
+    "event_to_span_event_bridge/development": {
+      "$ref": "#/$defs/ExperimentalEventToSpanEventBridgeLogRecordProcessor",
       "description": "Configure an event to span event bridge log record processor.\nIf omitted, ignore.\n"
     }
   }
@@ -4963,6 +4936,36 @@ No snippets.
       "description": "Configure database semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee database migration: https://opentelemetry.io/docs/specs/semconv/database/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
     }
   }
+}</pre>
+</details>
+
+## ExperimentalEventToSpanEventBridgeLogRecordProcessor <a id="experimentaleventtospaneventbridgelogrecordprocessor"></a>
+
+> [!WARNING]
+> This type is [experimental](VERSIONING.md#experimental-features).
+
+No properties.
+
+Constraints: 
+
+* `additionalProperties`: `false`
+
+Usages:
+
+* [`LogRecordProcessor.event_to_span_event_bridge/development`](#logrecordprocessor)
+
+No snippets.
+
+<details>
+<summary>JSON Schema</summary>
+
+[JSON Schema Source File](./schema/logger_provider.yaml)
+<pre>{
+  "type": [
+    "object",
+    "null"
+  ],
+  "additionalProperties": false
 }</pre>
 </details>
 

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -981,6 +981,33 @@ No snippets.
 }</pre>
 </details>
 
+## EventToSpanEventBridgeLogRecordProcessor <a id="eventtospaneventbridgelogrecordprocessor"></a>
+
+No properties.
+
+Constraints: 
+
+* `additionalProperties`: `false`
+
+Usages:
+
+* [`LogRecordProcessor.event_to_span_event_bridge`](#logrecordprocessor)
+
+No snippets.
+
+<details>
+<summary>JSON Schema</summary>
+
+[JSON Schema Source File](./schema/logger_provider.yaml)
+<pre>{
+  "type": [
+    "object",
+    "null"
+  ],
+  "additionalProperties": false
+}</pre>
+</details>
+
 ## ExemplarFilter <a id="exemplarfilter"></a>
 
 This is a enum type.
@@ -1656,6 +1683,7 @@ attribute_value_length_limit: 4096
 | Property | Type | Required? | Default and Null Behavior | Constraints | Description |
 |---|---|---|---|---|---|
 | `batch` | [`BatchLogRecordProcessor`](#batchlogrecordprocessor) | `false` | If omitted, ignore. | No constraints. | Configure a batch log record processor. |
+| `event_to_span_event_bridge` | [`EventToSpanEventBridgeLogRecordProcessor`](#eventtospaneventbridgelogrecordprocessor) | `false` | If omitted, ignore. | No constraints. | Configure an event to span event bridge log record processor. |
 | `simple` | [`SimpleLogRecordProcessor`](#simplelogrecordprocessor) | `false` | If omitted, ignore. | No constraints. | Configure a simple log record processor. |
 
 <details>
@@ -1664,6 +1692,7 @@ attribute_value_length_limit: 4096
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
 |---|---|---|---|---|---|
 | `batch` | supported | supported | supported | unknown | supported |
+| `event_to_span_event_bridge` | unknown | unknown | unknown | unknown | unknown |
 | `simple` | supported | supported | supported | unknown | supported |
 </details>
 
@@ -1701,6 +1730,10 @@ No snippets.
     "simple": {
       "$ref": "#/$defs/SimpleLogRecordProcessor",
       "description": "Configure a simple log record processor.\nIf omitted, ignore.\n"
+    },
+    "event_to_span_event_bridge": {
+      "$ref": "#/$defs/EventToSpanEventBridgeLogRecordProcessor",
+      "description": "Configure an event to span event bridge log record processor.\nIf omitted, ignore.\n"
     }
   }
 }</pre>

--- a/schema/logger_provider.yaml
+++ b/schema/logger_provider.yaml
@@ -71,7 +71,7 @@ $defs:
         description: Configure exporter.
     required:
       - exporter
-  EventToSpanEventBridgeLogRecordProcessor:
+  ExperimentalEventToSpanEventBridgeLogRecordProcessor:
     type:
       - object
       - "null"
@@ -142,8 +142,8 @@ $defs:
         $ref: "#/$defs/SimpleLogRecordProcessor"
         description: Configure a simple log record processor.
         defaultBehavior: ignore
-      event_to_span_event_bridge:
-        $ref: "#/$defs/EventToSpanEventBridgeLogRecordProcessor"
+      event_to_span_event_bridge/development:
+        $ref: "#/$defs/ExperimentalEventToSpanEventBridgeLogRecordProcessor"
         description: Configure an event to span event bridge log record processor.
         defaultBehavior: ignore
     isSdkExtensionPlugin: true

--- a/schema/logger_provider.yaml
+++ b/schema/logger_provider.yaml
@@ -71,6 +71,11 @@ $defs:
         description: Configure exporter.
     required:
       - exporter
+  EventToSpanEventBridgeLogRecordProcessor:
+    type:
+      - object
+      - "null"
+    additionalProperties: false
   LogRecordExporter:
     type: object
     additionalProperties:
@@ -136,6 +141,10 @@ $defs:
       simple:
         $ref: "#/$defs/SimpleLogRecordProcessor"
         description: Configure a simple log record processor.
+        defaultBehavior: ignore
+      event_to_span_event_bridge:
+        $ref: "#/$defs/EventToSpanEventBridgeLogRecordProcessor"
+        description: Configure an event to span event bridge log record processor.
         defaultBehavior: ignore
     isSdkExtensionPlugin: true
   ExperimentalLoggerConfigurator:

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -54,9 +54,6 @@ typeSupportStatuses:
   - type: DropAggregation
     status: supported
     propertyOverrides: []
-  - type: EventToSpanEventBridgeLogRecordProcessor
-    status: not_implemented
-    propertyOverrides: []
   - type: ExemplarFilter
     status: supported
     enumOverrides: []
@@ -96,7 +93,7 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge
+      - property: event_to_span_event_bridge/development
         status: unknown
   - type: MeterProvider
     status: supported
@@ -235,6 +232,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalDbInstrumentation
     status: unknown
+    propertyOverrides: []
+  - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
+    status: not_implemented
     propertyOverrides: []
   - type: ExperimentalGenAiInstrumentation
     status: unknown

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -54,6 +54,9 @@ typeSupportStatuses:
   - type: DropAggregation
     status: supported
     propertyOverrides: []
+  - type: EventToSpanEventBridgeLogRecordProcessor
+    status: not_implemented
+    propertyOverrides: []
   - type: ExemplarFilter
     status: supported
     enumOverrides: []
@@ -92,7 +95,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: LogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: event_to_span_event_bridge
+        status: unknown
   - type: MeterProvider
     status: supported
     propertyOverrides: []

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -58,9 +58,6 @@ typeSupportStatuses:
   - type: DropAggregation
     status: unknown
     propertyOverrides: []
-  - type: EventToSpanEventBridgeLogRecordProcessor
-    status: not_implemented
-    propertyOverrides: []
   - type: ExemplarFilter
     status: unknown
     enumOverrides: []
@@ -104,7 +101,7 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge
+      - property: event_to_span_event_bridge/development
         status: unknown
   - type: MeterProvider
     status: supported
@@ -262,6 +259,9 @@ typeSupportStatuses:
     status: supported
     propertyOverrides: []
   - type: ExperimentalDbInstrumentation
+    status: not_implemented
+    propertyOverrides: []
+  - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
     status: not_implemented
     propertyOverrides: []
   - type: ExperimentalGenAiInstrumentation

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -58,6 +58,9 @@ typeSupportStatuses:
   - type: DropAggregation
     status: unknown
     propertyOverrides: []
+  - type: EventToSpanEventBridgeLogRecordProcessor
+    status: not_implemented
+    propertyOverrides: []
   - type: ExemplarFilter
     status: unknown
     enumOverrides: []
@@ -100,7 +103,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: LogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: event_to_span_event_bridge
+        status: unknown
   - type: MeterProvider
     status: supported
     propertyOverrides: []

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -58,9 +58,6 @@ typeSupportStatuses:
   - type: DropAggregation
     status: supported
     propertyOverrides: []
-  - type: EventToSpanEventBridgeLogRecordProcessor
-    status: supported
-    propertyOverrides: []
   - type: ExemplarFilter
     status: supported
     enumOverrides: []
@@ -102,7 +99,7 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge
+      - property: event_to_span_event_bridge/development
         status: unknown
   - type: MeterProvider
     status: supported
@@ -251,6 +248,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalDbInstrumentation
     status: unknown
+    propertyOverrides: []
+  - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
+    status: supported
     propertyOverrides: []
   - type: ExperimentalGenAiInstrumentation
     status: unknown

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -58,6 +58,9 @@ typeSupportStatuses:
   - type: DropAggregation
     status: supported
     propertyOverrides: []
+  - type: EventToSpanEventBridgeLogRecordProcessor
+    status: supported
+    propertyOverrides: []
   - type: ExemplarFilter
     status: supported
     enumOverrides: []
@@ -98,7 +101,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: LogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: event_to_span_event_bridge
+        status: unknown
   - type: MeterProvider
     status: supported
     propertyOverrides: []

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -54,6 +54,9 @@ typeSupportStatuses:
   - type: DropAggregation
     status: unknown
     propertyOverrides: []
+  - type: EventToSpanEventBridgeLogRecordProcessor
+    status: not_implemented
+    propertyOverrides: []
   - type: ExemplarFilter
     status: unknown
     enumOverrides: []

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -54,9 +54,6 @@ typeSupportStatuses:
   - type: DropAggregation
     status: unknown
     propertyOverrides: []
-  - type: EventToSpanEventBridgeLogRecordProcessor
-    status: not_implemented
-    propertyOverrides: []
   - type: ExemplarFilter
     status: unknown
     enumOverrides: []
@@ -233,6 +230,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalDbInstrumentation
     status: unknown
+    propertyOverrides: []
+  - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
+    status: not_implemented
     propertyOverrides: []
   - type: ExperimentalGenAiInstrumentation
     status: unknown

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -62,6 +62,9 @@ typeSupportStatuses:
   - type: DropAggregation
     status: ignored
     propertyOverrides: []
+  - type: EventToSpanEventBridgeLogRecordProcessor
+    status: not_implemented
+    propertyOverrides: []
   - type: ExemplarFilter
     status: supported
     enumOverrides: []
@@ -100,7 +103,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: LogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: event_to_span_event_bridge
+        status: unknown
   - type: MeterProvider
     status: supported
     propertyOverrides: []

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -62,9 +62,6 @@ typeSupportStatuses:
   - type: DropAggregation
     status: ignored
     propertyOverrides: []
-  - type: EventToSpanEventBridgeLogRecordProcessor
-    status: not_implemented
-    propertyOverrides: []
   - type: ExemplarFilter
     status: supported
     enumOverrides: []
@@ -104,7 +101,7 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge
+      - property: event_to_span_event_bridge/development
         status: unknown
   - type: MeterProvider
     status: supported
@@ -278,6 +275,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalDbInstrumentation
     status: unknown
+    propertyOverrides: []
+  - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
+    status: not_implemented
     propertyOverrides: []
   - type: ExperimentalGenAiInstrumentation
     status: unknown


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry-specification/pull/5006

Example usages below.


Emit events only via in OTLP traces:

```yaml
file_format: "1.0"
logger_provider:
  processors:
    - event_to_span_event_bridge/development:

tracer_provider:
  processors:
    - batch:
         exporter:
           otlp_http:
```

Emit events via OTLP both trace and logs signals:

```yaml
file_format: "1.0"
logger_provider:
  processors:
    - event_to_span_event_bridge/development:
    - batch:
         exporter:
           otlp_http:

tracer_provider:
  processors:
    - batch:
         exporter:
           otlp_http:
```

If we would need a DEMUX for log and (log-based) event processing then it is tracked via https://github.com/open-telemetry/opentelemetry-specification/issues/5009