### PR TITLE
add IdGenerator definition to TracerProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Add development max_export_batch_size configuration to Periodic MetricReader
   ([#610](https://github.com/open-telemetry/opentelemetry-configuration/pull/610))
+* Add `id_generator` SDK extension plugin to `TracerProvider`, with built-in
+  `random` mapping to the spec-default random TraceId/SpanId generation
+  ([#70](https://github.com/open-telemetry/opentelemetry-configuration/issues/70))
 
 ## [v1.0.0] - 2026-02-27
 

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -40,6 +40,7 @@ Latest supported file format: `1.0.0`
 | [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | supported |  | * `cumulative`: supported<br>* `delta`: supported<br>* `low_memory`: supported<br> |
 | [`GrpcTls`](schema-docs.md#grpctls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `insecure`: supported<br>* `key_file`: supported<br> |
 | [`HttpTls`](schema-docs.md#httptls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `key_file`: supported<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
 | [`IncludeExclude`](schema-docs.md#includeexclude) | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | [`InstrumentType`](schema-docs.md#instrumenttype) | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | supported |  |  |
@@ -64,6 +65,7 @@ Latest supported file format: `1.0.0`
 | [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | supported |  | * `prometheus/development`: supported<br> |
 | [`PullMetricReader`](schema-docs.md#pullmetricreader) | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br> |
 | [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
 | [`Resource`](schema-docs.md#resource) | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | [`Sampler`](schema-docs.md#sampler) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | [`SeverityNumber`](schema-docs.md#severitynumber) | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
@@ -77,7 +79,7 @@ Latest supported file format: `1.0.0`
 | [`TextMapPropagator`](schema-docs.md#textmappropagator) | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | supported |  |  |
 | [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | supported |  | * `ratio`: supported<br> |
-| [`TracerProvider`](schema-docs.md#tracerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
 | [`View`](schema-docs.md#view) | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | [`ViewSelector`](schema-docs.md#viewselector) | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: supported<br> |
 | [`ViewStream`](schema-docs.md#viewstream) | supported |  | * `aggregation`: supported<br>* `aggregation_cardinality_limit`: supported<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
@@ -159,6 +161,7 @@ Latest supported file format: `1.0.0`
 | [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | supported |  | * `cumulative`: supported<br>* `delta`: supported<br>* `low_memory`: supported<br> |
 | [`GrpcTls`](schema-docs.md#grpctls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `insecure`: supported<br>* `key_file`: supported<br> |
 | [`HttpTls`](schema-docs.md#httptls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `key_file`: supported<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
 | [`IncludeExclude`](schema-docs.md#includeexclude) | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | [`InstrumentType`](schema-docs.md#instrumenttype) | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | supported |  |  |
@@ -183,6 +186,7 @@ Latest supported file format: `1.0.0`
 | [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | unknown |  | * `prometheus/development`: unknown<br> |
 | [`PullMetricReader`](schema-docs.md#pullmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br> |
 | [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
 | [`Resource`](schema-docs.md#resource) | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
 | [`Sampler`](schema-docs.md#sampler) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
 | [`SeverityNumber`](schema-docs.md#severitynumber) | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
@@ -196,7 +200,7 @@ Latest supported file format: `1.0.0`
 | [`TextMapPropagator`](schema-docs.md#textmappropagator) | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | supported |  |  |
 | [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | supported |  | * `ratio`: supported<br> |
-| [`TracerProvider`](schema-docs.md#tracerprovider) | unknown |  | * `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | unknown |  | * `id_generator`: unknown<br>* `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
 | [`View`](schema-docs.md#view) | unknown |  | * `selector`: unknown<br>* `stream`: unknown<br> |
 | [`ViewSelector`](schema-docs.md#viewselector) | unknown |  | * `instrument_name`: unknown<br>* `instrument_type`: unknown<br>* `meter_name`: unknown<br>* `meter_schema_url`: unknown<br>* `meter_version`: unknown<br>* `unit`: unknown<br> |
 | [`ViewStream`](schema-docs.md#viewstream) | unknown |  | * `aggregation`: unknown<br>* `aggregation_cardinality_limit`: unknown<br>* `attribute_keys`: unknown<br>* `description`: unknown<br>* `name`: unknown<br> |
@@ -278,6 +282,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | supported |  | * `cumulative`: supported<br>* `delta`: supported<br>* `low_memory`: supported<br> |
 | [`GrpcTls`](schema-docs.md#grpctls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `insecure`: not_implemented<br>* `key_file`: supported<br> |
 | [`HttpTls`](schema-docs.md#httptls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `key_file`: supported<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
 | [`IncludeExclude`](schema-docs.md#includeexclude) | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | [`InstrumentType`](schema-docs.md#instrumenttype) | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | supported |  |  |
@@ -302,6 +307,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | supported |  | * `prometheus/development`: supported<br> |
 | [`PullMetricReader`](schema-docs.md#pullmetricreader) | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: not_implemented<br> |
 | [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
 | [`Resource`](schema-docs.md#resource) | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | [`Sampler`](schema-docs.md#sampler) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | [`SeverityNumber`](schema-docs.md#severitynumber) | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
@@ -315,7 +321,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`TextMapPropagator`](schema-docs.md#textmappropagator) | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | supported |  |  |
 | [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | supported |  | * `ratio`: supported<br> |
-| [`TracerProvider`](schema-docs.md#tracerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
 | [`View`](schema-docs.md#view) | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | [`ViewSelector`](schema-docs.md#viewselector) | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: supported<br> |
 | [`ViewStream`](schema-docs.md#viewstream) | supported |  | * `aggregation`: supported<br>* `aggregation_cardinality_limit`: supported<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
@@ -397,6 +403,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | unknown |  | * `cumulative`: unknown<br>* `delta`: unknown<br>* `low_memory`: unknown<br> |
 | [`GrpcTls`](schema-docs.md#grpctls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `insecure`: unknown<br>* `key_file`: unknown<br> |
 | [`HttpTls`](schema-docs.md#httptls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `key_file`: unknown<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
 | [`IncludeExclude`](schema-docs.md#includeexclude) | unknown |  | * `excluded`: unknown<br>* `included`: unknown<br> |
 | [`InstrumentType`](schema-docs.md#instrumenttype) | unknown |  | * `counter`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
 | [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | unknown |  |  |
@@ -421,6 +428,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | unknown |  | * `prometheus/development`: unknown<br> |
 | [`PullMetricReader`](schema-docs.md#pullmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br> |
 | [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
 | [`Resource`](schema-docs.md#resource) | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
 | [`Sampler`](schema-docs.md#sampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_based`: unknown<br>* `trace_id_ratio_based`: unknown<br>* `composite/development`: unknown<br>* `jaeger_remote/development`: unknown<br>* `probability/development`: unknown<br> |
 | [`SeverityNumber`](schema-docs.md#severitynumber) | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
@@ -434,7 +442,7 @@ Latest supported file format: `1.0.0-rc.3`
 | [`TextMapPropagator`](schema-docs.md#textmappropagator) | unknown |  | * `b3`: unknown<br>* `b3multi`: unknown<br>* `baggage`: unknown<br>* `tracecontext`: unknown<br> |
 | [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | unknown |  |  |
 | [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | unknown |  | * `ratio`: unknown<br> |
-| [`TracerProvider`](schema-docs.md#tracerprovider) | unknown |  | * `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | unknown |  | * `id_generator`: unknown<br>* `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
 | [`View`](schema-docs.md#view) | unknown |  | * `selector`: unknown<br>* `stream`: unknown<br> |
 | [`ViewSelector`](schema-docs.md#viewselector) | unknown |  | * `instrument_name`: unknown<br>* `instrument_type`: unknown<br>* `meter_name`: unknown<br>* `meter_schema_url`: unknown<br>* `meter_version`: unknown<br>* `unit`: unknown<br> |
 | [`ViewStream`](schema-docs.md#viewstream) | unknown |  | * `aggregation`: unknown<br>* `aggregation_cardinality_limit`: unknown<br>* `attribute_keys`: unknown<br>* `description`: unknown<br>* `name`: unknown<br> |
@@ -516,6 +524,7 @@ Latest supported file format: `1.0.0-rc.2`
 | [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | supported |  | * `cumulative`: supported<br>* `delta`: supported<br>* `low_memory`: supported<br> |
 | [`GrpcTls`](schema-docs.md#grpctls) | ignored |  | * `ca_file`: ignored<br>* `cert_file`: ignored<br>* `insecure`: ignored<br>* `key_file`: ignored<br> |
 | [`HttpTls`](schema-docs.md#httptls) | ignored |  | * `ca_file`: ignored<br>* `cert_file`: ignored<br>* `key_file`: ignored<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
 | [`IncludeExclude`](schema-docs.md#includeexclude) | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | [`InstrumentType`](schema-docs.md#instrumenttype) | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | ignored |  |  |
@@ -540,6 +549,7 @@ Latest supported file format: `1.0.0-rc.2`
 | [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | not_implemented |  | * `prometheus/development`: not_implemented<br> |
 | [`PullMetricReader`](schema-docs.md#pullmetricreader) | not_implemented |  | * `cardinality_limits`: not_implemented<br>* `exporter`: not_implemented<br>* `producers`: not_implemented<br> |
 | [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
 | [`Resource`](schema-docs.md#resource) | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | [`Sampler`](schema-docs.md#sampler) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
 | [`SeverityNumber`](schema-docs.md#severitynumber) | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
@@ -553,7 +563,7 @@ Latest supported file format: `1.0.0-rc.2`
 | [`TextMapPropagator`](schema-docs.md#textmappropagator) | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | supported |  |  |
 | [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | supported |  | * `ratio`: supported<br> |
-| [`TracerProvider`](schema-docs.md#tracerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
 | [`View`](schema-docs.md#view) | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | [`ViewSelector`](schema-docs.md#viewselector) | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: not_implemented<br> |
 | [`ViewStream`](schema-docs.md#viewstream) | supported | `attribute_keys.excluded` is not implemented, only `attribute_keys.included` is supported. | * `aggregation`: ignored<br>* `aggregation_cardinality_limit`: not_implemented<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -2462,7 +2462,7 @@
         },
         "id_generator": {
           "$ref": "#/$defs/IdGenerator",
-          "description": "Configure the trace and span ID generator.\nIf omitted, an ID generator which randomly generates TraceIds and SpanIds is used.\n"
+          "description": "Configure the trace and span ID generator.\nIf omitted, RandomIdGenerator is used.\n"
         },
         "tracer_configurator/development": {
           "$ref": "#/$defs/ExperimentalTracerConfigurator",

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -1464,6 +1464,23 @@
         }
       }
     },
+    "IdGenerator": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "object",
+          "null"
+        ]
+      },
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "random": {
+          "$ref": "#/$defs/RandomIdGenerator",
+          "description": "Configure the ID generator to randomly generate TraceIds and SpanIds (spec default).\nIf omitted, ignore.\n"
+        }
+      }
+    },
     "IncludeExclude": {
       "type": "object",
       "additionalProperties": false,
@@ -2107,6 +2124,13 @@
         }
       }
     },
+    "RandomIdGenerator": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
     "Resource": {
       "type": "object",
       "additionalProperties": false,
@@ -2435,6 +2459,10 @@
         "sampler": {
           "$ref": "#/$defs/Sampler",
           "description": "Configure the sampler.\nIf omitted, parent based sampler with a root of always_on is used.\n"
+        },
+        "id_generator": {
+          "$ref": "#/$defs/IdGenerator",
+          "description": "Configure the trace and span ID generator.\nIf omitted, an ID generator which randomly generates TraceIds and SpanIds is used.\n"
         },
         "tracer_configurator/development": {
           "$ref": "#/$defs/ExperimentalTracerConfigurator",

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -1314,6 +1314,68 @@ No snippets.
 }</pre>
 </details>
 
+## IdGenerator <a id="idgenerator"></a>
+
+`IdGenerator` is an [SDK extension plugin](#sdk-extension-plugins).
+
+| Property | Type | Required? | Default and Null Behavior | Constraints | Description |
+|---|---|---|---|---|---|
+| `random` | [`RandomIdGenerator`](#randomidgenerator) | `false` | If omitted, ignore. | No constraints. | Configure the ID generator to randomly generate TraceIds and SpanIds (spec default). |
+
+<details>
+<summary>Language support status</summary>
+
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
+|---|---|---|---|---|---|
+| `random` | unknown | unknown | unknown | unknown | unknown |
+</details>
+
+Constraints: 
+
+* `additionalProperties`: `{"type":["object","null"]}`
+* `minProperties`: `1`
+* `maxProperties`: `1`
+
+Usages:
+
+* [`TracerProvider.id_generator`](#tracerprovider)
+
+Snippets:
+
+<details>
+<summary>Custom</summary>
+
+[Snippet Source File](./snippets/IdGenerator_custom.yaml)
+```yaml
+# configure a custom ID generator registered via PluginComponentProvider
+my_custom_id_generator:
+  property: value
+```
+</details>
+
+<details>
+<summary>JSON Schema</summary>
+
+[JSON Schema Source File](./schema/tracer_provider.yaml)
+<pre>{
+  "type": "object",
+  "additionalProperties": {
+    "type": [
+      "object",
+      "null"
+    ]
+  },
+  "minProperties": 1,
+  "maxProperties": 1,
+  "properties": {
+    "random": {
+      "$ref": "#/$defs/RandomIdGenerator",
+      "description": "Configure the ID generator to randomly generate TraceIds and SpanIds (spec default).\nIf omitted, ignore.\n"
+    }
+  }
+}</pre>
+</details>
+
 ## IncludeExclude <a id="includeexclude"></a>
 
 | Property | Type | Required? | Default and Null Behavior | Constraints | Description |
@@ -3053,6 +3115,33 @@ No snippets.
 }</pre>
 </details>
 
+## RandomIdGenerator <a id="randomidgenerator"></a>
+
+No properties.
+
+Constraints: 
+
+* `additionalProperties`: `false`
+
+Usages:
+
+* [`IdGenerator.random`](#idgenerator)
+
+No snippets.
+
+<details>
+<summary>JSON Schema</summary>
+
+[JSON Schema Source File](./schema/tracer_provider.yaml)
+<pre>{
+  "type": [
+    "object",
+    "null"
+  ],
+  "additionalProperties": false
+}</pre>
+</details>
+
 ## Resource <a id="resource"></a>
 
 | Property | Type | Required? | Default and Null Behavior | Constraints | Description |
@@ -4035,6 +4124,7 @@ No snippets.
 
 | Property | Type | Required? | Default and Null Behavior | Constraints | Description |
 |---|---|---|---|---|---|
+| `id_generator` | [`IdGenerator`](#idgenerator) | `false` | If omitted, an ID generator which randomly generates TraceIds and SpanIds is used. | No constraints. | Configure the trace and span ID generator.<br> |
 | `limits` | [`SpanLimits`](#spanlimits) | `false` | If omitted, default values as described in SpanLimits are used. | No constraints. | Configure span limits. See also attribute_limits. |
 | `processors` | `array` of [`SpanProcessor`](#spanprocessor) | `true` | Property is required and must be non-null. | * `minItems`: `1`<br> | Configure span processors. |
 | `sampler` | [`Sampler`](#sampler) | `false` | If omitted, parent based sampler with a root of always_on is used. | No constraints. | Configure the sampler.<br> |
@@ -4045,6 +4135,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
 |---|---|---|---|---|---|
+| `id_generator` | supported | unknown | supported | unknown | supported |
 | `limits` | supported | unknown | supported | unknown | supported |
 | `processors` | supported | unknown | supported | unknown | supported |
 | `sampler` | supported | unknown | supported | unknown | supported |
@@ -4085,6 +4176,10 @@ No snippets.
     "sampler": {
       "$ref": "#/$defs/Sampler",
       "description": "Configure the sampler.\nIf omitted, parent based sampler with a root of always_on is used.\n"
+    },
+    "id_generator": {
+      "$ref": "#/$defs/IdGenerator",
+      "description": "Configure the trace and span ID generator.\nIf omitted, an ID generator which randomly generates TraceIds and SpanIds is used.\n"
     },
     "tracer_configurator/development": {
       "$ref": "#/$defs/ExperimentalTracerConfigurator",
@@ -7114,6 +7209,7 @@ Each of the following types support referencing custom interface implementations
 SDK extension plugin types may have properties defined corresponding to built-in implementations of the interface. For example, the `otlp_http` property of `SpanExporter` defines the OTLP http/protobuf exporter.
 
 * [ExperimentalResourceDetector](#ExperimentalResourceDetector)
+* [IdGenerator](#IdGenerator)
 * [LogRecordExporter](#LogRecordExporter)
 * [LogRecordProcessor](#LogRecordProcessor)
 * [MetricProducer](#MetricProducer)

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -4124,7 +4124,7 @@ No snippets.
 
 | Property | Type | Required? | Default and Null Behavior | Constraints | Description |
 |---|---|---|---|---|---|
-| `id_generator` | [`IdGenerator`](#idgenerator) | `false` | If omitted, an ID generator which randomly generates TraceIds and SpanIds is used. | No constraints. | Configure the trace and span ID generator.<br> |
+| `id_generator` | [`IdGenerator`](#idgenerator) | `false` | If omitted, RandomIdGenerator is used. | No constraints. | Configure the trace and span ID generator.<br> |
 | `limits` | [`SpanLimits`](#spanlimits) | `false` | If omitted, default values as described in SpanLimits are used. | No constraints. | Configure span limits. See also attribute_limits. |
 | `processors` | `array` of [`SpanProcessor`](#spanprocessor) | `true` | Property is required and must be non-null. | * `minItems`: `1`<br> | Configure span processors. |
 | `sampler` | [`Sampler`](#sampler) | `false` | If omitted, parent based sampler with a root of always_on is used. | No constraints. | Configure the sampler.<br> |
@@ -4179,7 +4179,7 @@ No snippets.
     },
     "id_generator": {
       "$ref": "#/$defs/IdGenerator",
-      "description": "Configure the trace and span ID generator.\nIf omitted, an ID generator which randomly generates TraceIds and SpanIds is used.\n"
+      "description": "Configure the trace and span ID generator.\nIf omitted, RandomIdGenerator is used.\n"
     },
     "tracer_configurator/development": {
       "$ref": "#/$defs/ExperimentalTracerConfigurator",

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -72,6 +72,9 @@ typeSupportStatuses:
   - type: HttpTls
     status: supported
     propertyOverrides: []
+  - type: IdGenerator
+    status: unknown
+    propertyOverrides: []
   - type: IncludeExclude
     status: supported
     propertyOverrides: []
@@ -147,6 +150,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: PushMetricExporter
     status: supported
+    propertyOverrides: []
+  - type: RandomIdGenerator
+    status: unknown
     propertyOverrides: []
   - type: Resource
     status: supported

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -76,6 +76,9 @@ typeSupportStatuses:
   - type: HttpTls
     status: supported
     propertyOverrides: []
+  - type: IdGenerator
+    status: unknown
+    propertyOverrides: []
   - type: IncludeExclude
     status: supported
     propertyOverrides: []
@@ -166,6 +169,9 @@ typeSupportStatuses:
     status: unknown
     propertyOverrides: []
   - type: PushMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: RandomIdGenerator
     status: unknown
     propertyOverrides: []
   - type: Resource

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -78,6 +78,9 @@ typeSupportStatuses:
   - type: HttpTls
     status: supported
     propertyOverrides: []
+  - type: IdGenerator
+    status: unknown
+    propertyOverrides: []
   - type: IncludeExclude
     status: supported
     propertyOverrides: []
@@ -163,6 +166,9 @@ typeSupportStatuses:
         status: not_implemented
   - type: PushMetricExporter
     status: supported
+    propertyOverrides: []
+  - type: RandomIdGenerator
+    status: unknown
     propertyOverrides: []
   - type: Resource
     status: supported

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -72,6 +72,9 @@ typeSupportStatuses:
   - type: HttpTls
     status: unknown
     propertyOverrides: []
+  - type: IdGenerator
+    status: unknown
+    propertyOverrides: []
   - type: IncludeExclude
     status: unknown
     propertyOverrides: []
@@ -144,6 +147,9 @@ typeSupportStatuses:
     status: unknown
     propertyOverrides: []
   - type: PushMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: RandomIdGenerator
     status: unknown
     propertyOverrides: []
   - type: Resource

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -80,6 +80,9 @@ typeSupportStatuses:
   - type: HttpTls
     status: ignored
     propertyOverrides: []
+  - type: IdGenerator
+    status: unknown
+    propertyOverrides: []
   - type: IncludeExclude
     status: supported
     propertyOverrides: []
@@ -177,6 +180,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: PushMetricExporter
     status: supported
+    propertyOverrides: []
+  - type: RandomIdGenerator
+    status: unknown
     propertyOverrides: []
   - type: Resource
     status: supported

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -16,6 +16,11 @@ properties:
     description: |
       Configure the sampler.
     defaultBehavior: parent based sampler with a root of always_on is used
+  id_generator:
+    $ref: "#/$defs/IdGenerator"
+    description: |
+      Configure the trace and span ID generator.
+    defaultBehavior: an ID generator which randomly generates TraceIds and SpanIds is used
   tracer_configurator/development:
     $ref: "#/$defs/ExperimentalTracerConfigurator"
     description: |
@@ -396,6 +401,25 @@ $defs:
         $ref: "#/$defs/ExperimentalComposableRuleBasedSampler"
         description: Configure sampler to be rule_based.
         defaultBehavior: ignore
+  IdGenerator:
+    type: object
+    additionalProperties:
+      type:
+        - object
+        - "null"
+    minProperties: 1
+    maxProperties: 1
+    properties:
+      random:
+        $ref: "#/$defs/RandomIdGenerator"
+        description: Configure the ID generator to randomly generate TraceIds and SpanIds (spec default).
+        defaultBehavior: ignore
+    isSdkExtensionPlugin: true
+  RandomIdGenerator:
+    type:
+      - object
+      - "null"
+    additionalProperties: false
   SimpleSpanProcessor:
     type: object
     additionalProperties: false

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -20,7 +20,7 @@ properties:
     $ref: "#/$defs/IdGenerator"
     description: |
       Configure the trace and span ID generator.
-    defaultBehavior: an ID generator which randomly generates TraceIds and SpanIds is used
+    defaultBehavior: RandomIdGenerator is used
   tracer_configurator/development:
     $ref: "#/$defs/ExperimentalTracerConfigurator"
     description: |

--- a/snippets/IdGenerator_custom.yaml
+++ b/snippets/IdGenerator_custom.yaml
@@ -1,0 +1,12 @@
+file_format: "1.0"
+
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  id_generator:
+    # SNIPPET_START
+    # configure a custom ID generator registered via PluginComponentProvider
+    my_custom_id_generator:
+      property: value


### PR DESCRIPTION
## Summary

Adds `IdGenerator` to the schema as an SDK extension plugin under `TracerProvider`, with a single built-in `random` for the spec-default random TraceId/SpanId generation.

Modeled consistently with existing SDK extension plugins (`Sampler`, `SpanExporter`, `SpanProcessor`). Treated as stable (no `/development` suffix) — IdGenerator is a stable spec extension point in [trace/sdk.md](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#id-generators), and the plugin shape (name + opaque properties bag) has nothing in flux. The property is optional and falls back to the SDK's random default when omitted.

Closes #70. Unblocks opentelemetry-js#6616 and similar work in other languages (originally surfaced from opentelemetry-cpp prototyping).

## Notes

- Built-in name chosen: `random` (matches Java autoconfigure's `OTEL_TRACES_ID_GENERATOR=random` convention). The spec doesn't standardize a name.
- `RandomIdGenerator` has no configuration properties — the spec doesn't define any.
- Language status files have new types stubbed as `unknown`; the inline property-level status for `id_generator` inherits `TracerProvider`'s overall status per the existing tooling behavior. Maintainers can add `propertyOverrides` in follow-up PRs.

## Test plan

- [x] `make` passes (compile-schema, validate-examples, validate-snippets, fix-language-implementations, generate-markdown)
- [x] `opentelemetry_configuration.json` contains `IdGenerator` and `RandomIdGenerator` `$defs`
- [x] `schema-docs.md` lists `IdGenerator` under SDK Extension Plugins
- [x] `IdGenerator_custom.yaml` snippet validates against the compiled schema
- [ ] Reviewer confirms `random` is acceptable vs. `default` / `default_random`