### PR TITLE
chore: update codeql workflow to address warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,9 @@ jobs:
           languages: go
 
       - name: Build
-        run: cd validator && go build ./...
+        run: |
+          make -C validator validator-copy-schema
+          cd validator && go build ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ~1.26.0
+          go-version: stable
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -34,8 +34,8 @@ jobs:
         with:
           languages: go
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+      - name: Build
+        run: cd validator && go build ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5


### PR DESCRIPTION
The validator code is not in the root directory, causing autobuild to fail. Update version to latest stable at the same time.