### PR TITLE
docs: add python to known languages

### DIFF
--- a/language-support-status.md
+++ b/language-support-status.md
@@ -9,6 +9,7 @@ This page provides comprehensive language implementation status for each type in
 * [java](#java)
 * [js](#js)
 * [php](#php)
+* [python](#python)
 
 ## cpp <a id="cpp"></a>
 
@@ -612,6 +613,127 @@ Latest supported file format: `1.0.0-rc.2`
 | [`ExperimentalTracerConfig`](schema-docs.md#experimentaltracerconfig) | supported |  | * `enabled`: supported<br> |
 | [`ExperimentalTracerConfigurator`](schema-docs.md#experimentaltracerconfigurator) | supported |  | * `default_config`: supported<br>* `tracers`: supported<br> |
 | [`ExperimentalTracerMatcherAndConfig`](schema-docs.md#experimentaltracermatcherandconfig) | supported |  | * `config`: supported<br>* `name`: supported<br> |
+| [`ExperimentalUrlSanitization`](schema-docs.md#experimentalurlsanitization) | unknown |  | * `sensitive_query_parameters`: unknown<br> |
+
+
+## python <a id="python"></a>
+
+Latest supported file format: `1.0.0`
+
+| Type | Status | Notes | Support Status Details |
+|---|---|---|---|
+| [`Aggregation`](schema-docs.md#aggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `default`: unknown<br>* `drop`: unknown<br>* `explicit_bucket_histogram`: unknown<br>* `last_value`: unknown<br>* `sum`: unknown<br> |
+| [`AlwaysOffSampler`](schema-docs.md#alwaysoffsampler) | unknown |  |  |
+| [`AlwaysOnSampler`](schema-docs.md#alwaysonsampler) | unknown |  |  |
+| [`AttributeLimits`](schema-docs.md#attributelimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
+| [`AttributeNameValue`](schema-docs.md#attributenamevalue) | unknown |  | * `name`: unknown<br>* `type`: unknown<br>* `value`: unknown<br> |
+| [`AttributeType`](schema-docs.md#attributetype) | unknown |  | * `bool`: unknown<br>* `bool_array`: unknown<br>* `double`: unknown<br>* `double_array`: unknown<br>* `int`: unknown<br>* `int_array`: unknown<br>* `string`: unknown<br>* `string_array`: unknown<br> |
+| [`B3MultiPropagator`](schema-docs.md#b3multipropagator) | unknown |  |  |
+| [`B3Propagator`](schema-docs.md#b3propagator) | unknown |  |  |
+| [`BaggagePropagator`](schema-docs.md#baggagepropagator) | unknown |  |  |
+| [`Base2ExponentialBucketHistogramAggregation`](schema-docs.md#base2exponentialbuckethistogramaggregation) | unknown |  | * `max_scale`: unknown<br>* `max_size`: unknown<br>* `record_min_max`: unknown<br> |
+| [`BatchLogRecordProcessor`](schema-docs.md#batchlogrecordprocessor) | unknown |  | * `export_timeout`: unknown<br>* `exporter`: unknown<br>* `max_export_batch_size`: unknown<br>* `max_queue_size`: unknown<br>* `schedule_delay`: unknown<br> |
+| [`BatchSpanProcessor`](schema-docs.md#batchspanprocessor) | unknown |  | * `export_timeout`: unknown<br>* `exporter`: unknown<br>* `max_export_batch_size`: unknown<br>* `max_queue_size`: unknown<br>* `schedule_delay`: unknown<br> |
+| [`CardinalityLimits`](schema-docs.md#cardinalitylimits) | unknown |  | * `counter`: unknown<br>* `default`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
+| [`ConsoleExporter`](schema-docs.md#consoleexporter) | unknown |  |  |
+| [`ConsoleMetricExporter`](schema-docs.md#consolemetricexporter) | unknown |  | * `default_histogram_aggregation`: unknown<br>* `temporality_preference`: unknown<br> |
+| [`DefaultAggregation`](schema-docs.md#defaultaggregation) | unknown |  |  |
+| [`Distribution`](schema-docs.md#distribution) | unknown |  |  |
+| [`DropAggregation`](schema-docs.md#dropaggregation) | unknown |  |  |
+| [`ExemplarFilter`](schema-docs.md#exemplarfilter) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `trace_based`: unknown<br> |
+| [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | unknown |  | * `boundaries`: unknown<br>* `record_min_max`: unknown<br> |
+| [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `explicit_bucket_histogram`: unknown<br> |
+| [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | unknown |  | * `cumulative`: unknown<br>* `delta`: unknown<br>* `low_memory`: unknown<br> |
+| [`GrpcTls`](schema-docs.md#grpctls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `insecure`: unknown<br>* `key_file`: unknown<br> |
+| [`HttpTls`](schema-docs.md#httptls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `key_file`: unknown<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
+| [`IncludeExclude`](schema-docs.md#includeexclude) | unknown |  | * `excluded`: unknown<br>* `included`: unknown<br> |
+| [`InstrumentType`](schema-docs.md#instrumenttype) | unknown |  | * `counter`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
+| [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | unknown |  |  |
+| [`LoggerProvider`](schema-docs.md#loggerprovider) | unknown |  | * `limits`: unknown<br>* `processors`: unknown<br>* `logger_configurator/development`: unknown<br> |
+| [`LogRecordExporter`](schema-docs.md#logrecordexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`LogRecordLimits`](schema-docs.md#logrecordlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br>* `event_to_span_event_bridge/development`: unknown<br> |
+| [`MeterProvider`](schema-docs.md#meterprovider) | unknown |  | * `exemplar_filter`: unknown<br>* `readers`: unknown<br>* `views`: unknown<br>* `meter_configurator/development`: unknown<br> |
+| [`MetricProducer`](schema-docs.md#metricproducer) | unknown |  | * `opencensus`: unknown<br> |
+| [`MetricReader`](schema-docs.md#metricreader) | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
+| [`NameStringValuePair`](schema-docs.md#namestringvaluepair) | unknown |  | * `name`: unknown<br>* `value`: unknown<br> |
+| [`OpenCensusMetricProducer`](schema-docs.md#opencensusmetricproducer) | unknown |  |  |
+| [`OpenTelemetryConfiguration`](schema-docs.md#opentelemetryconfiguration) | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation/development`: unknown<br> |
+| [`OtlpGrpcExporter`](schema-docs.md#otlpgrpcexporter) | unknown |  | * `compression`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`OtlpGrpcMetricExporter`](schema-docs.md#otlpgrpcmetricexporter) | unknown |  | * `compression`: unknown<br>* `default_histogram_aggregation`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `temporality_preference`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`OtlpHttpEncoding`](schema-docs.md#otlphttpencoding) | unknown |  | * `json`: unknown<br>* `protobuf`: unknown<br> |
+| [`OtlpHttpExporter`](schema-docs.md#otlphttpexporter) | unknown |  | * `compression`: unknown<br>* `encoding`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`OtlpHttpMetricExporter`](schema-docs.md#otlphttpmetricexporter) | unknown |  | * `compression`: unknown<br>* `default_histogram_aggregation`: unknown<br>* `encoding`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `temporality_preference`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`ParentBasedSampler`](schema-docs.md#parentbasedsampler) | unknown |  | * `local_parent_not_sampled`: unknown<br>* `local_parent_sampled`: unknown<br>* `remote_parent_not_sampled`: unknown<br>* `remote_parent_sampled`: unknown<br>* `root`: unknown<br> |
+| [`PeriodicMetricReader`](schema-docs.md#periodicmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `interval`: unknown<br>* `producers`: unknown<br>* `timeout`: unknown<br>* `max_export_batch_size/development`: unknown<br> |
+| [`Propagator`](schema-docs.md#propagator) | unknown |  | * `composite`: unknown<br>* `composite_list`: unknown<br> |
+| [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | unknown |  | * `prometheus/development`: unknown<br> |
+| [`PullMetricReader`](schema-docs.md#pullmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br> |
+| [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
+| [`Resource`](schema-docs.md#resource) | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
+| [`Sampler`](schema-docs.md#sampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_based`: unknown<br>* `trace_id_ratio_based`: unknown<br>* `composite/development`: unknown<br>* `jaeger_remote/development`: unknown<br>* `probability/development`: unknown<br> |
+| [`SeverityNumber`](schema-docs.md#severitynumber) | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
+| [`SimpleLogRecordProcessor`](schema-docs.md#simplelogrecordprocessor) | unknown |  | * `exporter`: unknown<br> |
+| [`SimpleSpanProcessor`](schema-docs.md#simplespanprocessor) | unknown |  | * `exporter`: unknown<br> |
+| [`SpanExporter`](schema-docs.md#spanexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`SpanKind`](schema-docs.md#spankind) | unknown |  | * `client`: unknown<br>* `consumer`: unknown<br>* `internal`: unknown<br>* `producer`: unknown<br>* `server`: unknown<br> |
+| [`SpanLimits`](schema-docs.md#spanlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br>* `event_attribute_count_limit`: unknown<br>* `event_count_limit`: unknown<br>* `link_attribute_count_limit`: unknown<br>* `link_count_limit`: unknown<br> |
+| [`SpanProcessor`](schema-docs.md#spanprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br> |
+| [`SumAggregation`](schema-docs.md#sumaggregation) | unknown |  |  |
+| [`TextMapPropagator`](schema-docs.md#textmappropagator) | unknown |  | * `b3`: unknown<br>* `b3multi`: unknown<br>* `baggage`: unknown<br>* `tracecontext`: unknown<br> |
+| [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | unknown |  |  |
+| [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | unknown |  | * `ratio`: unknown<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | unknown |  | * `id_generator`: unknown<br>* `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
+| [`View`](schema-docs.md#view) | unknown |  | * `selector`: unknown<br>* `stream`: unknown<br> |
+| [`ViewSelector`](schema-docs.md#viewselector) | unknown |  | * `instrument_name`: unknown<br>* `instrument_type`: unknown<br>* `meter_name`: unknown<br>* `meter_schema_url`: unknown<br>* `meter_version`: unknown<br>* `unit`: unknown<br> |
+| [`ViewStream`](schema-docs.md#viewstream) | unknown |  | * `aggregation`: unknown<br>* `aggregation_cardinality_limit`: unknown<br>* `attribute_keys`: unknown<br>* `description`: unknown<br>* `name`: unknown<br> |
+| [`ExperimentalCodeInstrumentation`](schema-docs.md#experimentalcodeinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalComposableAlwaysOffSampler`](schema-docs.md#experimentalcomposablealwaysoffsampler) | unknown |  |  |
+| [`ExperimentalComposableAlwaysOnSampler`](schema-docs.md#experimentalcomposablealwaysonsampler) | unknown |  |  |
+| [`ExperimentalComposableParentThresholdSampler`](schema-docs.md#experimentalcomposableparentthresholdsampler) | unknown |  | * `root`: unknown<br> |
+| [`ExperimentalComposableProbabilitySampler`](schema-docs.md#experimentalcomposableprobabilitysampler) | unknown |  | * `ratio`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSampler`](schema-docs.md#experimentalcomposablerulebasedsampler) | unknown |  | * `rules`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRule`](schema-docs.md#experimentalcomposablerulebasedsamplerrule) | unknown |  | * `attribute_patterns`: unknown<br>* `attribute_values`: unknown<br>* `parent`: unknown<br>* `sampler`: unknown<br>* `span_kinds`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributepatterns) | unknown |  | * `excluded`: unknown<br>* `included`: unknown<br>* `key`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributevalues) | unknown |  | * `key`: unknown<br>* `values`: unknown<br> |
+| [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_threshold`: unknown<br>* `probability`: unknown<br>* `rule_based`: unknown<br> |
+| [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | unknown |  |  |
+| [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | unknown |  |  |
+| [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | unknown |  | * `code`: unknown<br>* `db`: unknown<br>* `gen_ai`: unknown<br>* `http`: unknown<br>* `messaging`: unknown<br>* `rpc`: unknown<br>* `sanitization`: unknown<br>* `stability_opt_in_list`: unknown<br> |
+| [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | unknown |  |  |
+| [`ExperimentalHttpClientInstrumentation`](schema-docs.md#experimentalhttpclientinstrumentation) | unknown |  | * `known_methods`: unknown<br>* `request_captured_headers`: unknown<br>* `response_captured_headers`: unknown<br> |
+| [`ExperimentalHttpInstrumentation`](schema-docs.md#experimentalhttpinstrumentation) | unknown |  | * `client`: unknown<br>* `semconv`: unknown<br>* `server`: unknown<br> |
+| [`ExperimentalHttpServerInstrumentation`](schema-docs.md#experimentalhttpserverinstrumentation) | unknown |  | * `known_methods`: unknown<br>* `request_captured_headers`: unknown<br>* `response_captured_headers`: unknown<br> |
+| [`ExperimentalInstrumentation`](schema-docs.md#experimentalinstrumentation) | unknown |  | * `cpp`: unknown<br>* `dotnet`: unknown<br>* `erlang`: unknown<br>* `general`: unknown<br>* `go`: unknown<br>* `java`: unknown<br>* `js`: unknown<br>* `php`: unknown<br>* `python`: unknown<br>* `ruby`: unknown<br>* `rust`: unknown<br>* `swift`: unknown<br> |
+| [`ExperimentalJaegerRemoteSampler`](schema-docs.md#experimentaljaegerremotesampler) | unknown |  | * `endpoint`: unknown<br>* `initial_sampler`: unknown<br>* `interval`: unknown<br> |
+| [`ExperimentalLanguageSpecificInstrumentation`](schema-docs.md#experimentallanguagespecificinstrumentation) | unknown |  |  |
+| [`ExperimentalLoggerConfig`](schema-docs.md#experimentalloggerconfig) | unknown |  | * `enabled`: unknown<br>* `minimum_severity`: unknown<br>* `trace_based`: unknown<br> |
+| [`ExperimentalLoggerConfigurator`](schema-docs.md#experimentalloggerconfigurator) | unknown |  | * `default_config`: unknown<br>* `loggers`: unknown<br> |
+| [`ExperimentalLoggerMatcherAndConfig`](schema-docs.md#experimentalloggermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
+| [`ExperimentalMessagingInstrumentation`](schema-docs.md#experimentalmessaginginstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalMeterConfig`](schema-docs.md#experimentalmeterconfig) | unknown |  | * `enabled`: unknown<br> |
+| [`ExperimentalMeterConfigurator`](schema-docs.md#experimentalmeterconfigurator) | unknown |  | * `default_config`: unknown<br>* `meters`: unknown<br> |
+| [`ExperimentalMeterMatcherAndConfig`](schema-docs.md#experimentalmetermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
+| [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | unknown |  | * `output_stream`: unknown<br> |
+| [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | unknown |  | * `default_histogram_aggregation`: unknown<br>* `output_stream`: unknown<br>* `temporality_preference`: unknown<br> |
+| [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | unknown |  | * `ratio`: unknown<br> |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | unknown |  |  |
+| [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | unknown |  | * `host`: unknown<br>* `port`: unknown<br>* `resource_constant_labels`: unknown<br>* `scope_info_enabled`: unknown<br>* `translation_strategy`: unknown<br>* `target_info_enabled/development`: unknown<br> |
+| [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | unknown |  | * `no_translation/development`: unknown<br>* `no_utf8_escaping_with_suffixes/development`: unknown<br>* `underscore_escaping_with_suffixes`: unknown<br>* `underscore_escaping_without_suffixes/development`: unknown<br> |
+| [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | unknown |  | * `attributes`: unknown<br>* `detectors`: unknown<br> |
+| [`ExperimentalResourceDetector`](schema-docs.md#experimentalresourcedetector) | unknown |  | * `container`: unknown<br>* `host`: unknown<br>* `process`: unknown<br>* `service`: unknown<br> |
+| [`ExperimentalRpcInstrumentation`](schema-docs.md#experimentalrpcinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalSanitization`](schema-docs.md#experimentalsanitization) | unknown |  | * `url`: unknown<br> |
+| [`ExperimentalSemconvConfig`](schema-docs.md#experimentalsemconvconfig) | unknown |  | * `dual_emit`: unknown<br>* `experimental`: unknown<br>* `version`: unknown<br> |
+| [`ExperimentalServiceResourceDetector`](schema-docs.md#experimentalserviceresourcedetector) | unknown |  |  |
+| [`ExperimentalSpanParent`](schema-docs.md#experimentalspanparent) | unknown |  | * `local`: unknown<br>* `none`: unknown<br>* `remote`: unknown<br> |
+| [`ExperimentalTracerConfig`](schema-docs.md#experimentaltracerconfig) | unknown |  | * `enabled`: unknown<br> |
+| [`ExperimentalTracerConfigurator`](schema-docs.md#experimentaltracerconfigurator) | unknown |  | * `default_config`: unknown<br>* `tracers`: unknown<br> |
+| [`ExperimentalTracerMatcherAndConfig`](schema-docs.md#experimentaltracermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
 | [`ExperimentalUrlSanitization`](schema-docs.md#experimentalurlsanitization) | unknown |  | * `sensitive_query_parameters`: unknown<br> |
 
 

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -27,14 +27,14 @@ See also [language support status](language-support-status.md) for all details a
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored |
-| `default` | supported | unknown | supported | unknown | ignored |
-| `drop` | supported | unknown | supported | unknown | ignored |
-| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored |
-| `last_value` | supported | unknown | supported | unknown | ignored |
-| `sum` | supported | unknown | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
+| `default` | supported | unknown | supported | unknown | ignored | unknown |
+| `drop` | supported | unknown | supported | unknown | ignored | unknown |
+| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
+| `last_value` | supported | unknown | supported | unknown | ignored | unknown |
+| `sum` | supported | unknown | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -151,10 +151,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | supported | supported | unknown | supported |
-| `attribute_value_length_limit` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_count_limit` | supported | supported | supported | unknown | supported | unknown |
+| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -206,11 +206,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `name` | supported | supported | supported | unknown | supported |
-| `type` | supported | supported | supported | unknown | not_implemented |
-| `value` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `name` | supported | supported | supported | unknown | supported | unknown |
+| `type` | supported | supported | supported | unknown | not_implemented | unknown |
+| `value` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -304,16 +304,16 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `bool` | supported | supported | supported | unknown | not_implemented |
-| `bool_array` | supported | supported | supported | unknown | not_implemented |
-| `double` | supported | supported | supported | unknown | not_implemented |
-| `double_array` | supported | supported | supported | unknown | not_implemented |
-| `int` | supported | supported | supported | unknown | not_implemented |
-| `int_array` | supported | supported | supported | unknown | not_implemented |
-| `string` | supported | supported | supported | unknown | not_implemented |
-| `string_array` | supported | supported | supported | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `bool` | supported | supported | supported | unknown | not_implemented | unknown |
+| `bool_array` | supported | supported | supported | unknown | not_implemented | unknown |
+| `double` | supported | supported | supported | unknown | not_implemented | unknown |
+| `double_array` | supported | supported | supported | unknown | not_implemented | unknown |
+| `int` | supported | supported | supported | unknown | not_implemented | unknown |
+| `int_array` | supported | supported | supported | unknown | not_implemented | unknown |
+| `string` | supported | supported | supported | unknown | not_implemented | unknown |
+| `string_array` | supported | supported | supported | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -438,11 +438,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `max_scale` | supported | unknown | supported | unknown | not_implemented |
-| `max_size` | supported | unknown | supported | unknown | not_implemented |
-| `record_min_max` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `max_scale` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `max_size` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `record_min_max` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -507,13 +507,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `export_timeout` | supported | supported | supported | unknown | supported |
-| `exporter` | supported | supported | supported | unknown | supported |
-| `max_export_batch_size` | supported | supported | supported | unknown | supported |
-| `max_queue_size` | supported | supported | supported | unknown | supported |
-| `schedule_delay` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `export_timeout` | supported | supported | supported | unknown | supported | unknown |
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
+| `max_export_batch_size` | supported | supported | supported | unknown | supported | unknown |
+| `max_queue_size` | supported | supported | supported | unknown | supported | unknown |
+| `schedule_delay` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -591,13 +591,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `export_timeout` | supported | supported | supported | unknown | supported |
-| `exporter` | supported | supported | supported | unknown | supported |
-| `max_export_batch_size` | supported | supported | supported | unknown | supported |
-| `max_queue_size` | supported | supported | supported | unknown | supported |
-| `schedule_delay` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `export_timeout` | supported | supported | supported | unknown | supported | unknown |
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
+| `max_export_batch_size` | supported | supported | supported | unknown | supported | unknown |
+| `max_queue_size` | supported | supported | supported | unknown | supported | unknown |
+| `schedule_delay` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -678,16 +678,16 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `counter` | ignored | unknown | supported | unknown | not_implemented |
-| `default` | ignored | unknown | supported | unknown | not_implemented |
-| `gauge` | ignored | unknown | supported | unknown | not_implemented |
-| `histogram` | ignored | unknown | supported | unknown | not_implemented |
-| `observable_counter` | ignored | unknown | supported | unknown | not_implemented |
-| `observable_gauge` | ignored | unknown | supported | unknown | not_implemented |
-| `observable_up_down_counter` | ignored | unknown | supported | unknown | not_implemented |
-| `up_down_counter` | ignored | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `default` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `gauge` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `histogram` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `observable_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `observable_gauge` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `observable_up_down_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `up_down_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -850,10 +850,10 @@ Snippets:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_histogram_aggregation` | supported | not_implemented | not_implemented | unknown | not_implemented |
-| `temporality_preference` | supported | not_implemented | ignored | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_histogram_aggregation` | supported | not_implemented | not_implemented | unknown | not_implemented | unknown |
+| `temporality_preference` | supported | not_implemented | ignored | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -994,11 +994,11 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `always_off` | supported | unknown | supported | unknown | supported |
-| `always_on` | supported | unknown | supported | unknown | supported |
-| `trace_based` | supported | unknown | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `always_off` | supported | unknown | supported | unknown | supported | unknown |
+| `always_on` | supported | unknown | supported | unknown | supported | unknown |
+| `trace_based` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -1036,10 +1036,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `boundaries` | supported | unknown | supported | unknown | ignored |
-| `record_min_max` | supported | unknown | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `boundaries` | supported | unknown | supported | unknown | ignored | unknown |
+| `record_min_max` | supported | unknown | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -1094,10 +1094,10 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored |
-| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
+| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
 </details>
 
 No constraints.
@@ -1140,11 +1140,11 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cumulative` | supported | supported | supported | unknown | supported |
-| `delta` | supported | supported | supported | unknown | supported |
-| `low_memory` | supported | supported | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cumulative` | supported | supported | supported | unknown | supported | unknown |
+| `delta` | supported | supported | supported | unknown | supported | unknown |
+| `low_memory` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -1187,12 +1187,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ca_file` | supported | supported | supported | unknown | ignored |
-| `cert_file` | supported | supported | supported | unknown | ignored |
-| `insecure` | supported | supported | not_implemented | unknown | ignored |
-| `key_file` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ca_file` | supported | supported | supported | unknown | ignored | unknown |
+| `cert_file` | supported | supported | supported | unknown | ignored | unknown |
+| `insecure` | supported | supported | not_implemented | unknown | ignored | unknown |
+| `key_file` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -1260,11 +1260,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ca_file` | supported | supported | supported | unknown | ignored |
-| `cert_file` | supported | supported | supported | unknown | ignored |
-| `key_file` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ca_file` | supported | supported | supported | unknown | ignored | unknown |
+| `cert_file` | supported | supported | supported | unknown | ignored | unknown |
+| `key_file` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -1325,9 +1325,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `random` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `random` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -1386,10 +1386,10 @@ my_custom_id_generator:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `excluded` | supported | supported | supported | unknown | supported |
-| `included` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `excluded` | supported | supported | supported | unknown | supported | unknown |
+| `included` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1449,15 +1449,15 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `counter` | supported | supported | supported | unknown | supported |
-| `gauge` | supported | supported | supported | unknown | supported |
-| `histogram` | supported | supported | supported | unknown | supported |
-| `observable_counter` | supported | supported | supported | unknown | supported |
-| `observable_gauge` | supported | supported | supported | unknown | supported |
-| `observable_up_down_counter` | supported | supported | supported | unknown | supported |
-| `up_down_counter` | supported | supported | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `counter` | supported | supported | supported | unknown | supported | unknown |
+| `gauge` | supported | supported | supported | unknown | supported | unknown |
+| `histogram` | supported | supported | supported | unknown | supported | unknown |
+| `observable_counter` | supported | supported | supported | unknown | supported | unknown |
+| `observable_gauge` | supported | supported | supported | unknown | supported | unknown |
+| `observable_up_down_counter` | supported | supported | supported | unknown | supported | unknown |
+| `up_down_counter` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -1527,11 +1527,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `limits` | supported | supported | supported | unknown | supported |
-| `processors` | supported | supported | supported | unknown | supported |
-| `logger_configurator/development` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `limits` | supported | supported | supported | unknown | supported | unknown |
+| `processors` | supported | supported | supported | unknown | supported | unknown |
+| `logger_configurator/development` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1590,12 +1590,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `console` | supported | supported | supported | unknown | supported |
-| `otlp_grpc` | supported | supported | supported | unknown | supported |
-| `otlp_http` | supported | supported | supported | unknown | supported |
-| `otlp_file/development` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `console` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_grpc` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_http` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1656,10 +1656,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | supported | supported | unknown | supported |
-| `attribute_value_length_limit` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_count_limit` | supported | supported | supported | unknown | supported | unknown |
+| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1724,11 +1724,11 @@ attribute_value_length_limit: 4096
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `batch` | supported | supported | supported | unknown | supported |
-| `simple` | supported | supported | supported | unknown | supported |
-| `event_to_span_event_bridge/development` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `batch` | supported | supported | supported | unknown | supported | unknown |
+| `simple` | supported | supported | supported | unknown | supported | unknown |
+| `event_to_span_event_bridge/development` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -1786,12 +1786,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `exemplar_filter` | supported | supported | supported | unknown | supported |
-| `readers` | supported | supported | supported | unknown | supported |
-| `views` | supported | supported | supported | unknown | supported |
-| `meter_configurator/development` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `exemplar_filter` | supported | supported | supported | unknown | supported | unknown |
+| `readers` | supported | supported | supported | unknown | supported | unknown |
+| `views` | supported | supported | supported | unknown | supported | unknown |
+| `meter_configurator/development` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1855,9 +1855,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `opencensus` | supported | unknown | ignored | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `opencensus` | supported | unknown | ignored | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -1907,10 +1907,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `periodic` | supported | unknown | supported | unknown | supported |
-| `pull` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `periodic` | supported | unknown | supported | unknown | supported | unknown |
+| `pull` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -1957,10 +1957,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `name` | supported | supported | supported | unknown | supported |
-| `value` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `name` | supported | supported | supported | unknown | supported | unknown |
+| `value` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2052,19 +2052,19 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_limits` | supported | unknown | supported | unknown | supported |
-| `disabled` | supported | unknown | supported | unknown | supported |
-| `distribution` | supported | unknown | supported | unknown | not_implemented |
-| `file_format` | supported | unknown | supported | unknown | supported |
-| `log_level` | supported | unknown | not_implemented | unknown | not_implemented |
-| `logger_provider` | supported | unknown | supported | unknown | supported |
-| `meter_provider` | supported | unknown | supported | unknown | supported |
-| `propagator` | supported | unknown | supported | unknown | supported |
-| `resource` | supported | unknown | supported | unknown | supported |
-| `tracer_provider` | supported | unknown | supported | unknown | supported |
-| `instrumentation/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_limits` | supported | unknown | supported | unknown | supported | unknown |
+| `disabled` | supported | unknown | supported | unknown | supported | unknown |
+| `distribution` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `file_format` | supported | unknown | supported | unknown | supported | unknown |
+| `log_level` | supported | unknown | not_implemented | unknown | not_implemented | unknown |
+| `logger_provider` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_provider` | supported | unknown | supported | unknown | supported | unknown |
+| `propagator` | supported | unknown | supported | unknown | supported | unknown |
+| `resource` | supported | unknown | supported | unknown | supported | unknown |
+| `tracer_provider` | supported | unknown | supported | unknown | supported | unknown |
+| `instrumentation/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2154,14 +2154,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2287,16 +2287,16 @@ timeout: 10000
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `temporality_preference` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `temporality_preference` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2405,10 +2405,10 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `json` | supported | not_implemented | not_implemented | unknown | supported |
-| `protobuf` | supported | not_implemented | not_implemented | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `json` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `protobuf` | supported | not_implemented | not_implemented | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -2451,15 +2451,15 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `encoding` | supported | not_implemented | not_implemented | unknown | supported |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `encoding` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2590,17 +2590,17 @@ encoding: protobuf
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented |
-| `encoding` | supported | not_implemented | not_implemented | unknown | supported |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `temporality_preference` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `encoding` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `temporality_preference` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2726,13 +2726,13 @@ default_histogram_aggregation: base2_exponential_bucket_histogram
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `local_parent_not_sampled` | supported | supported | supported | unknown | supported |
-| `local_parent_sampled` | supported | supported | supported | unknown | supported |
-| `remote_parent_not_sampled` | supported | supported | supported | unknown | supported |
-| `remote_parent_sampled` | supported | supported | supported | unknown | supported |
-| `root` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `local_parent_not_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `local_parent_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `remote_parent_not_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `remote_parent_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `root` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2794,14 +2794,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cardinality_limits` | supported | not_implemented | supported | unknown | supported |
-| `exporter` | supported | supported | supported | unknown | supported |
-| `interval` | supported | supported | supported | unknown | not_implemented |
-| `producers` | supported | not_implemented | not_implemented | unknown | not_implemented |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `max_export_batch_size/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cardinality_limits` | supported | not_implemented | supported | unknown | supported | unknown |
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
+| `interval` | supported | supported | supported | unknown | not_implemented | unknown |
+| `producers` | supported | not_implemented | not_implemented | unknown | not_implemented | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `max_export_batch_size/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -2880,10 +2880,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `composite` | supported | supported | supported | unknown | supported |
-| `composite_list` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `composite` | supported | supported | supported | unknown | supported | unknown |
+| `composite_list` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2949,9 +2949,9 @@ composite_list: "xray"
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `prometheus/development` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `prometheus/development` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -3000,11 +3000,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cardinality_limits` | supported | unknown | supported | unknown | not_implemented |
-| `exporter` | supported | unknown | supported | unknown | not_implemented |
-| `producers` | supported | unknown | not_implemented | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cardinality_limits` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `exporter` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `producers` | supported | unknown | not_implemented | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -3063,12 +3063,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `console` | supported | unknown | supported | unknown | supported |
-| `otlp_grpc` | supported | unknown | supported | unknown | supported |
-| `otlp_http` | supported | unknown | supported | unknown | supported |
-| `otlp_file/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `console` | supported | unknown | supported | unknown | supported | unknown |
+| `otlp_grpc` | supported | unknown | supported | unknown | supported | unknown |
+| `otlp_http` | supported | unknown | supported | unknown | supported | unknown |
+| `otlp_file/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3157,12 +3157,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attributes` | supported | unknown | supported | unknown | supported |
-| `attributes_list` | supported | unknown | supported | unknown | supported |
-| `schema_url` | supported | unknown | supported | unknown | supported |
-| `detection/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attributes` | supported | unknown | supported | unknown | supported | unknown |
+| `attributes_list` | supported | unknown | supported | unknown | supported | unknown |
+| `schema_url` | supported | unknown | supported | unknown | supported | unknown |
+| `detection/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3278,15 +3278,15 @@ schema_url: https://opentelemetry.io/schemas/1.16.0
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `always_off` | supported | supported | supported | unknown | supported |
-| `always_on` | supported | supported | supported | unknown | supported |
-| `parent_based` | supported | supported | supported | unknown | supported |
-| `trace_id_ratio_based` | supported | supported | supported | unknown | supported |
-| `composite/development` | supported | not_implemented | supported | unknown | not_implemented |
-| `jaeger_remote/development` | supported | not_implemented | supported | unknown | not_implemented |
-| `probability/development` | supported | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `always_off` | supported | supported | supported | unknown | supported | unknown |
+| `always_on` | supported | supported | supported | unknown | supported | unknown |
+| `parent_based` | supported | supported | supported | unknown | supported | unknown |
+| `trace_id_ratio_based` | supported | supported | supported | unknown | supported | unknown |
+| `composite/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `jaeger_remote/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `probability/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -3502,32 +3502,32 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `debug` | supported | unknown | supported | unknown | supported |
-| `debug2` | supported | unknown | supported | unknown | supported |
-| `debug3` | supported | unknown | supported | unknown | supported |
-| `debug4` | supported | unknown | supported | unknown | supported |
-| `error` | supported | unknown | supported | unknown | supported |
-| `error2` | supported | unknown | supported | unknown | supported |
-| `error3` | supported | unknown | supported | unknown | supported |
-| `error4` | supported | unknown | supported | unknown | supported |
-| `fatal` | supported | unknown | supported | unknown | supported |
-| `fatal2` | supported | unknown | supported | unknown | supported |
-| `fatal3` | supported | unknown | supported | unknown | supported |
-| `fatal4` | supported | unknown | supported | unknown | supported |
-| `info` | supported | unknown | supported | unknown | supported |
-| `info2` | supported | unknown | supported | unknown | supported |
-| `info3` | supported | unknown | supported | unknown | supported |
-| `info4` | supported | unknown | supported | unknown | supported |
-| `trace` | supported | unknown | supported | unknown | supported |
-| `trace2` | supported | unknown | supported | unknown | supported |
-| `trace3` | supported | unknown | supported | unknown | supported |
-| `trace4` | supported | unknown | supported | unknown | supported |
-| `warn` | supported | unknown | supported | unknown | supported |
-| `warn2` | supported | unknown | supported | unknown | supported |
-| `warn3` | supported | unknown | supported | unknown | supported |
-| `warn4` | supported | unknown | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `debug` | supported | unknown | supported | unknown | supported | unknown |
+| `debug2` | supported | unknown | supported | unknown | supported | unknown |
+| `debug3` | supported | unknown | supported | unknown | supported | unknown |
+| `debug4` | supported | unknown | supported | unknown | supported | unknown |
+| `error` | supported | unknown | supported | unknown | supported | unknown |
+| `error2` | supported | unknown | supported | unknown | supported | unknown |
+| `error3` | supported | unknown | supported | unknown | supported | unknown |
+| `error4` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal2` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal3` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal4` | supported | unknown | supported | unknown | supported | unknown |
+| `info` | supported | unknown | supported | unknown | supported | unknown |
+| `info2` | supported | unknown | supported | unknown | supported | unknown |
+| `info3` | supported | unknown | supported | unknown | supported | unknown |
+| `info4` | supported | unknown | supported | unknown | supported | unknown |
+| `trace` | supported | unknown | supported | unknown | supported | unknown |
+| `trace2` | supported | unknown | supported | unknown | supported | unknown |
+| `trace3` | supported | unknown | supported | unknown | supported | unknown |
+| `trace4` | supported | unknown | supported | unknown | supported | unknown |
+| `warn` | supported | unknown | supported | unknown | supported | unknown |
+| `warn2` | supported | unknown | supported | unknown | supported | unknown |
+| `warn3` | supported | unknown | supported | unknown | supported | unknown |
+| `warn4` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -3586,9 +3586,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `exporter` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `exporter` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3630,9 +3630,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `exporter` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3679,12 +3679,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `console` | supported | supported | supported | unknown | supported |
-| `otlp_grpc` | supported | supported | supported | unknown | supported |
-| `otlp_http` | supported | supported | supported | unknown | supported |
-| `otlp_file/development` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `console` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_grpc` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_http` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3750,13 +3750,13 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `client` | not_implemented | unknown | supported | unknown | not_implemented |
-| `consumer` | not_implemented | unknown | supported | unknown | not_implemented |
-| `internal` | not_implemented | unknown | supported | unknown | not_implemented |
-| `producer` | not_implemented | unknown | supported | unknown | not_implemented |
-| `server` | not_implemented | unknown | supported | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `client` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `consumer` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `internal` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `producer` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `server` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -3800,14 +3800,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | unknown | supported | unknown | supported |
-| `attribute_value_length_limit` | supported | unknown | supported | unknown | supported |
-| `event_attribute_count_limit` | supported | unknown | supported | unknown | supported |
-| `event_count_limit` | supported | unknown | supported | unknown | supported |
-| `link_attribute_count_limit` | supported | unknown | supported | unknown | supported |
-| `link_count_limit` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `attribute_value_length_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `event_attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `event_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `link_attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `link_count_limit` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3907,10 +3907,10 @@ link_count_limit: 128
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `batch` | supported | supported | supported | unknown | supported |
-| `simple` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `batch` | supported | supported | supported | unknown | supported | unknown |
+| `simple` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3993,12 +3993,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `b3` | supported | supported | supported | unknown | supported |
-| `b3multi` | supported | supported | supported | unknown | supported |
-| `baggage` | supported | supported | supported | unknown | supported |
-| `tracecontext` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `b3` | supported | supported | supported | unknown | supported | unknown |
+| `b3multi` | supported | supported | supported | unknown | supported | unknown |
+| `baggage` | supported | supported | supported | unknown | supported | unknown |
+| `tracecontext` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4084,9 +4084,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ratio` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ratio` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4136,13 +4136,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `id_generator` | supported | unknown | supported | unknown | supported |
-| `limits` | supported | unknown | supported | unknown | supported |
-| `processors` | supported | unknown | supported | unknown | supported |
-| `sampler` | supported | unknown | supported | unknown | supported |
-| `tracer_configurator/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `id_generator` | supported | unknown | supported | unknown | supported | unknown |
+| `limits` | supported | unknown | supported | unknown | supported | unknown |
+| `processors` | supported | unknown | supported | unknown | supported | unknown |
+| `sampler` | supported | unknown | supported | unknown | supported | unknown |
+| `tracer_configurator/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4205,10 +4205,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `selector` | supported | unknown | supported | unknown | supported |
-| `stream` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `selector` | supported | unknown | supported | unknown | supported | unknown |
+| `stream` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4322,14 +4322,14 @@ stream:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `instrument_name` | supported | unknown | supported | unknown | supported |
-| `instrument_type` | supported | unknown | supported | unknown | supported |
-| `meter_name` | supported | unknown | supported | unknown | supported |
-| `meter_schema_url` | supported | unknown | supported | unknown | supported |
-| `meter_version` | supported | unknown | supported | unknown | supported |
-| `unit` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `instrument_name` | supported | unknown | supported | unknown | supported | unknown |
+| `instrument_type` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_name` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_schema_url` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_version` | supported | unknown | supported | unknown | supported | unknown |
+| `unit` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4406,13 +4406,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `aggregation` | supported | unknown | supported | unknown | ignored |
-| `aggregation_cardinality_limit` | supported | unknown | supported | unknown | not_implemented |
-| `attribute_keys` | supported | unknown | supported | unknown | supported |
-| `description` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `aggregation` | supported | unknown | supported | unknown | ignored | unknown |
+| `aggregation_cardinality_limit` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `attribute_keys` | supported | unknown | supported | unknown | supported | unknown |
+| `description` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4481,9 +4481,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -4584,9 +4584,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `root` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `root` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4633,9 +4633,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ratio` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4684,9 +4684,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `rules` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `rules` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4738,13 +4738,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_patterns` | ignored | not_implemented | supported | unknown | not_implemented |
-| `attribute_values` | ignored | not_implemented | supported | unknown | not_implemented |
-| `parent` | ignored | not_implemented | supported | unknown | not_implemented |
-| `sampler` | ignored | not_implemented | supported | unknown | not_implemented |
-| `span_kinds` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_patterns` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `attribute_values` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `parent` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `sampler` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `span_kinds` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4816,11 +4816,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `excluded` | ignored | not_implemented | supported | unknown | not_implemented |
-| `included` | ignored | not_implemented | supported | unknown | not_implemented |
-| `key` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `excluded` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `included` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `key` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4882,10 +4882,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `key` | ignored | not_implemented | supported | unknown | not_implemented |
-| `values` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `key` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `values` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4943,13 +4943,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `always_off` | ignored | not_implemented | supported | unknown | not_implemented |
-| `always_on` | ignored | not_implemented | supported | unknown | not_implemented |
-| `parent_threshold` | ignored | not_implemented | supported | unknown | not_implemented |
-| `probability` | ignored | not_implemented | supported | unknown | not_implemented |
-| `rule_based` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `always_off` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `always_on` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `parent_threshold` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `probability` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `rule_based` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -5047,9 +5047,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -5120,9 +5120,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -5170,16 +5170,16 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `code` | not_applicable | not_implemented | supported | unknown | supported |
-| `db` | not_applicable | not_implemented | supported | unknown | supported |
-| `gen_ai` | not_applicable | not_implemented | supported | unknown | supported |
-| `http` | not_applicable | not_implemented | supported | unknown | supported |
-| `messaging` | not_applicable | not_implemented | supported | unknown | supported |
-| `rpc` | not_applicable | not_implemented | supported | unknown | supported |
-| `sanitization` | not_applicable | not_implemented | supported | unknown | supported |
-| `stability_opt_in_list` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `code` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `db` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `gen_ai` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `http` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `messaging` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `rpc` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `sanitization` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `stability_opt_in_list` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5305,11 +5305,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `known_methods` | not_applicable | not_implemented | supported | unknown | supported |
-| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
-| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5372,11 +5372,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `client` | not_applicable | not_implemented | supported | unknown | supported |
-| `semconv` | not_applicable | not_implemented | supported | unknown | supported |
-| `server` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `client` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `semconv` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `server` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5427,11 +5427,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `known_methods` | not_applicable | not_implemented | supported | unknown | supported |
-| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
-| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5503,20 +5503,20 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cpp` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `dotnet` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `erlang` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `general` | not_applicable | not_implemented | supported | unknown | supported |
-| `go` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `java` | not_applicable | not_implemented | supported | unknown | not_applicable |
-| `js` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `php` | not_applicable | not_implemented | not_applicable | unknown | supported |
-| `python` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `ruby` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `rust` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `swift` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cpp` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `dotnet` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `erlang` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `general` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `go` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `java` | not_applicable | not_implemented | supported | unknown | not_applicable | unknown |
+| `js` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `php` | not_applicable | not_implemented | not_applicable | unknown | supported | unknown |
+| `python` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `ruby` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `rust` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `swift` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
 </details>
 
 Constraints: 
@@ -5708,11 +5708,11 @@ swift:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `endpoint` | not_implemented | not_implemented | supported | unknown | not_implemented |
-| `initial_sampler` | not_implemented | not_implemented | supported | unknown | not_implemented |
-| `interval` | not_implemented | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `endpoint` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
+| `initial_sampler` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
+| `interval` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -5816,11 +5816,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `enabled` | not_implemented | unknown | supported | unknown | supported |
-| `minimum_severity` | not_implemented | unknown | supported | unknown | not_implemented |
-| `trace_based` | not_implemented | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `enabled` | not_implemented | unknown | supported | unknown | supported | unknown |
+| `minimum_severity` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `trace_based` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -5879,10 +5879,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported |
-| `loggers` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
+| `loggers` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5950,10 +5950,10 @@ loggers:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `config` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6007,9 +6007,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6050,9 +6050,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `enabled` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `enabled` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6099,10 +6099,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported |
-| `meters` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
+| `meters` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6168,10 +6168,10 @@ meters:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `config` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6225,9 +6225,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `output_stream` | supported | not_implemented | not_implemented | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6313,11 +6313,11 @@ output_stream: stdout
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented |
-| `output_stream` | supported | not_implemented | not_implemented | unknown | supported |
-| `temporality_preference` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `temporality_preference` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6394,9 +6394,9 @@ default_histogram_aggregation: explicit_bucket_histogram
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ratio` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -6480,14 +6480,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `host` | supported | supported | supported | unknown | not_implemented |
-| `port` | supported | supported | supported | unknown | not_implemented |
-| `resource_constant_labels` | supported | supported | supported | unknown | not_implemented |
-| `scope_info_enabled` | supported | supported | supported | unknown | not_implemented |
-| `translation_strategy` | supported | supported | not_implemented | unknown | not_implemented |
-| `target_info_enabled/development` | supported | supported | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `host` | supported | supported | supported | unknown | not_implemented | unknown |
+| `port` | supported | supported | supported | unknown | not_implemented | unknown |
+| `resource_constant_labels` | supported | supported | supported | unknown | not_implemented | unknown |
+| `scope_info_enabled` | supported | supported | supported | unknown | not_implemented | unknown |
+| `translation_strategy` | supported | supported | not_implemented | unknown | not_implemented | unknown |
+| `target_info_enabled/development` | supported | supported | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -6586,12 +6586,12 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `no_translation/development` | not_implemented | supported | not_implemented | unknown | not_implemented |
-| `no_utf8_escaping_with_suffixes/development` | not_implemented | supported | not_implemented | unknown | not_implemented |
-| `underscore_escaping_with_suffixes` | supported | supported | not_implemented | unknown | not_implemented |
-| `underscore_escaping_without_suffixes/development` | supported | supported | not_implemented | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `no_translation/development` | not_implemented | supported | not_implemented | unknown | not_implemented | unknown |
+| `no_utf8_escaping_with_suffixes/development` | not_implemented | supported | not_implemented | unknown | not_implemented | unknown |
+| `underscore_escaping_with_suffixes` | supported | supported | not_implemented | unknown | not_implemented | unknown |
+| `underscore_escaping_without_suffixes/development` | supported | supported | not_implemented | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -6633,10 +6633,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attributes` | not_implemented | supported | supported | unknown | supported |
-| `detectors` | not_implemented | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attributes` | not_implemented | supported | supported | unknown | supported | unknown |
+| `detectors` | not_implemented | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6690,12 +6690,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `container` | not_implemented | supported | supported | unknown | ignored |
-| `host` | not_implemented | supported | supported | unknown | supported |
-| `process` | not_implemented | supported | supported | unknown | supported |
-| `service` | not_implemented | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `container` | not_implemented | supported | supported | unknown | ignored | unknown |
+| `host` | not_implemented | supported | supported | unknown | supported | unknown |
+| `process` | not_implemented | supported | supported | unknown | supported | unknown |
+| `service` | not_implemented | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6757,9 +6757,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6800,9 +6800,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `url` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `url` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6845,11 +6845,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `dual_emit` | unknown | unknown | unknown | unknown | unknown |
-| `experimental` | unknown | unknown | unknown | unknown | unknown |
-| `version` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `dual_emit` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `experimental` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `version` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6947,11 +6947,11 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `local` | not_implemented | unknown | supported | unknown | not_implemented |
-| `none` | not_implemented | unknown | supported | unknown | not_implemented |
-| `remote` | not_implemented | unknown | supported | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `local` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `none` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `remote` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -6991,9 +6991,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `enabled` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `enabled` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -7040,10 +7040,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported |
-| `tracers` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
+| `tracers` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -7109,10 +7109,10 @@ tracers:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `config` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -7166,9 +7166,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `sensitive_query_parameters` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `sensitive_query_parameters` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 

--- a/schema/meta_schema_language_python.yaml
+++ b/schema/meta_schema_language_python.yaml
@@ -1,0 +1,341 @@
+latestSupportedFileFormat: 1.0.0
+typeSupportStatuses:
+  - type: Aggregation
+    status: unknown
+    propertyOverrides: []
+  - type: AlwaysOffSampler
+    status: unknown
+    propertyOverrides: []
+  - type: AlwaysOnSampler
+    status: unknown
+    propertyOverrides: []
+  - type: AttributeLimits
+    status: unknown
+    propertyOverrides: []
+  - type: AttributeNameValue
+    status: unknown
+    propertyOverrides: []
+  - type: AttributeType
+    status: unknown
+    enumOverrides: []
+  - type: B3MultiPropagator
+    status: unknown
+    propertyOverrides: []
+  - type: B3Propagator
+    status: unknown
+    propertyOverrides: []
+  - type: BaggagePropagator
+    status: unknown
+    propertyOverrides: []
+  - type: Base2ExponentialBucketHistogramAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: BatchLogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: BatchSpanProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: CardinalityLimits
+    status: unknown
+    propertyOverrides: []
+  - type: ConsoleExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ConsoleMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: DefaultAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: Distribution
+    status: unknown
+    propertyOverrides: []
+  - type: DropAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: ExemplarFilter
+    status: unknown
+    enumOverrides: []
+  - type: ExplicitBucketHistogramAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: ExporterDefaultHistogramAggregation
+    status: unknown
+    enumOverrides: []
+  - type: ExporterTemporalityPreference
+    status: unknown
+    enumOverrides: []
+  - type: GrpcTls
+    status: unknown
+    propertyOverrides: []
+  - type: HttpTls
+    status: unknown
+    propertyOverrides: []
+  - type: IdGenerator
+    status: unknown
+    propertyOverrides: []
+  - type: IncludeExclude
+    status: unknown
+    propertyOverrides: []
+  - type: InstrumentType
+    status: unknown
+    enumOverrides: []
+  - type: LastValueAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: LoggerProvider
+    status: unknown
+    propertyOverrides: []
+  - type: LogRecordExporter
+    status: unknown
+    propertyOverrides: []
+  - type: LogRecordLimits
+    status: unknown
+    propertyOverrides: []
+  - type: LogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: MeterProvider
+    status: unknown
+    propertyOverrides: []
+  - type: MetricProducer
+    status: unknown
+    propertyOverrides: []
+  - type: MetricReader
+    status: unknown
+    propertyOverrides: []
+  - type: NameStringValuePair
+    status: unknown
+    propertyOverrides: []
+  - type: OpenCensusMetricProducer
+    status: unknown
+    propertyOverrides: []
+  - type: OpenTelemetryConfiguration
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpGrpcExporter
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpGrpcMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpHttpEncoding
+    status: unknown
+    enumOverrides: []
+  - type: OtlpHttpExporter
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpHttpMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ParentBasedSampler
+    status: unknown
+    propertyOverrides: []
+  - type: PeriodicMetricReader
+    status: unknown
+    propertyOverrides: []
+  - type: Propagator
+    status: unknown
+    propertyOverrides: []
+  - type: PullMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: PullMetricReader
+    status: unknown
+    propertyOverrides: []
+  - type: PushMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: RandomIdGenerator
+    status: unknown
+    propertyOverrides: []
+  - type: Resource
+    status: unknown
+    propertyOverrides: []
+  - type: Sampler
+    status: unknown
+    propertyOverrides: []
+  - type: SeverityNumber
+    status: unknown
+    enumOverrides: []
+  - type: SimpleLogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: SimpleSpanProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: SpanExporter
+    status: unknown
+    propertyOverrides: []
+  - type: SpanKind
+    status: unknown
+    enumOverrides: []
+  - type: SpanLimits
+    status: unknown
+    propertyOverrides: []
+  - type: SpanProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: SumAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: TextMapPropagator
+    status: unknown
+    propertyOverrides: []
+  - type: TraceContextPropagator
+    status: unknown
+    propertyOverrides: []
+  - type: TraceIdRatioBasedSampler
+    status: unknown
+    propertyOverrides: []
+  - type: TracerProvider
+    status: unknown
+    propertyOverrides: []
+  - type: View
+    status: unknown
+    propertyOverrides: []
+  - type: ViewSelector
+    status: unknown
+    propertyOverrides: []
+  - type: ViewStream
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalCodeInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableAlwaysOffSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableAlwaysOnSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableParentThresholdSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableProbabilitySampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSamplerRule
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSamplerRuleAttributePatterns
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSamplerRuleAttributeValues
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalContainerResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalDbInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalGenAiInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalGeneralInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHostResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHttpClientInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHttpInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHttpServerInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalJaegerRemoteSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLanguageSpecificInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLoggerConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLoggerConfigurator
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLoggerMatcherAndConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMessagingInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMeterConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMeterConfigurator
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMeterMatcherAndConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalOtlpFileExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalOtlpFileMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalProbabilitySampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalProcessResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalPrometheusMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalPrometheusTranslationStrategy
+    status: unknown
+    enumOverrides: []
+  - type: ExperimentalResourceDetection
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalRpcInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalSanitization
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalSemconvConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalServiceResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalSpanParent
+    status: unknown
+    enumOverrides: []
+  - type: ExperimentalTracerConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalTracerConfigurator
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalTracerMatcherAndConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalUrlSanitization
+    status: unknown
+    propertyOverrides: []

--- a/scripts/language-implementations.js
+++ b/scripts/language-implementations.js
@@ -10,11 +10,12 @@ import {
 import {readSourceTypesByType} from "./source-schema.js";
 
 export const KNOWN_LANGUAGES = [
-    'cpp', 
-    'go', 
+    'cpp',
+    'go',
     'java',
     'js',
     'php',
+    'python',
 ];
 
 const IMPLEMENTATION_STATUS_UNKNOWN = 'unknown';


### PR DESCRIPTION
## Description

Adds `python` to the set of languages tracked in `language-support-status.md` (alongside `cpp`, `go`, `java`, `js`, `php`).

Mirrors the existing per-language workflow: `python` is added to `KNOWN_LANGUAGES` in `scripts/language-implementations.js`, a seed `schema/meta_schema_language_python.yaml` is populated by `make fix-language-implementations`, and `language-support-status.md` + `schema-docs.md` are regenerated by `make generate-markdown`. All Python rows are seeded as `unknown` so the status can be filled in by a separate follow-up PR (similar to how JS started).

This unblocks linking from the language SDK repo (open-telemetry/opentelemetry-python#5347) to the shared matrix here rather than duplicating it per language, picking up the same discussion happening on open-telemetry/opentelemetry-js#6846.

## Next step

A follow-up PR will populate the Python statuses with real values based on the conformance work already done in open-telemetry/opentelemetry-python.