### PR TITLE
docs: populate python support

### DIFF
--- a/language-support-status.md
+++ b/language-support-status.md
@@ -622,118 +622,118 @@ Latest supported file format: `1.0.0`
 
 | Type | Status | Notes | Support Status Details |
 |---|---|---|---|
-| [`Aggregation`](schema-docs.md#aggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `default`: unknown<br>* `drop`: unknown<br>* `explicit_bucket_histogram`: unknown<br>* `last_value`: unknown<br>* `sum`: unknown<br> |
-| [`AlwaysOffSampler`](schema-docs.md#alwaysoffsampler) | unknown |  |  |
-| [`AlwaysOnSampler`](schema-docs.md#alwaysonsampler) | unknown |  |  |
-| [`AttributeLimits`](schema-docs.md#attributelimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
-| [`AttributeNameValue`](schema-docs.md#attributenamevalue) | unknown |  | * `name`: unknown<br>* `type`: unknown<br>* `value`: unknown<br> |
-| [`AttributeType`](schema-docs.md#attributetype) | unknown |  | * `bool`: unknown<br>* `bool_array`: unknown<br>* `double`: unknown<br>* `double_array`: unknown<br>* `int`: unknown<br>* `int_array`: unknown<br>* `string`: unknown<br>* `string_array`: unknown<br> |
-| [`B3MultiPropagator`](schema-docs.md#b3multipropagator) | unknown |  |  |
-| [`B3Propagator`](schema-docs.md#b3propagator) | unknown |  |  |
-| [`BaggagePropagator`](schema-docs.md#baggagepropagator) | unknown |  |  |
-| [`Base2ExponentialBucketHistogramAggregation`](schema-docs.md#base2exponentialbuckethistogramaggregation) | unknown |  | * `max_scale`: unknown<br>* `max_size`: unknown<br>* `record_min_max`: unknown<br> |
-| [`BatchLogRecordProcessor`](schema-docs.md#batchlogrecordprocessor) | unknown |  | * `export_timeout`: unknown<br>* `exporter`: unknown<br>* `max_export_batch_size`: unknown<br>* `max_queue_size`: unknown<br>* `schedule_delay`: unknown<br> |
-| [`BatchSpanProcessor`](schema-docs.md#batchspanprocessor) | unknown |  | * `export_timeout`: unknown<br>* `exporter`: unknown<br>* `max_export_batch_size`: unknown<br>* `max_queue_size`: unknown<br>* `schedule_delay`: unknown<br> |
-| [`CardinalityLimits`](schema-docs.md#cardinalitylimits) | unknown |  | * `counter`: unknown<br>* `default`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
-| [`ConsoleExporter`](schema-docs.md#consoleexporter) | unknown |  |  |
-| [`ConsoleMetricExporter`](schema-docs.md#consolemetricexporter) | unknown |  | * `default_histogram_aggregation`: unknown<br>* `temporality_preference`: unknown<br> |
-| [`DefaultAggregation`](schema-docs.md#defaultaggregation) | unknown |  |  |
-| [`Distribution`](schema-docs.md#distribution) | unknown |  |  |
-| [`DropAggregation`](schema-docs.md#dropaggregation) | unknown |  |  |
-| [`ExemplarFilter`](schema-docs.md#exemplarfilter) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `trace_based`: unknown<br> |
-| [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | unknown |  | * `boundaries`: unknown<br>* `record_min_max`: unknown<br> |
-| [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `explicit_bucket_histogram`: unknown<br> |
-| [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | unknown |  | * `cumulative`: unknown<br>* `delta`: unknown<br>* `low_memory`: unknown<br> |
-| [`GrpcTls`](schema-docs.md#grpctls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `insecure`: unknown<br>* `key_file`: unknown<br> |
-| [`HttpTls`](schema-docs.md#httptls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `key_file`: unknown<br> |
-| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
-| [`IncludeExclude`](schema-docs.md#includeexclude) | unknown |  | * `excluded`: unknown<br>* `included`: unknown<br> |
-| [`InstrumentType`](schema-docs.md#instrumenttype) | unknown |  | * `counter`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
-| [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | unknown |  |  |
-| [`LoggerProvider`](schema-docs.md#loggerprovider) | unknown |  | * `limits`: unknown<br>* `processors`: unknown<br>* `logger_configurator/development`: unknown<br> |
-| [`LogRecordExporter`](schema-docs.md#logrecordexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
-| [`LogRecordLimits`](schema-docs.md#logrecordlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
-| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br>* `event_to_span_event_bridge/development`: unknown<br> |
-| [`MeterProvider`](schema-docs.md#meterprovider) | unknown |  | * `exemplar_filter`: unknown<br>* `readers`: unknown<br>* `views`: unknown<br>* `meter_configurator/development`: unknown<br> |
-| [`MetricProducer`](schema-docs.md#metricproducer) | unknown |  | * `opencensus`: unknown<br> |
-| [`MetricReader`](schema-docs.md#metricreader) | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
-| [`NameStringValuePair`](schema-docs.md#namestringvaluepair) | unknown |  | * `name`: unknown<br>* `value`: unknown<br> |
-| [`OpenCensusMetricProducer`](schema-docs.md#opencensusmetricproducer) | unknown |  |  |
-| [`OpenTelemetryConfiguration`](schema-docs.md#opentelemetryconfiguration) | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation/development`: unknown<br> |
-| [`OtlpGrpcExporter`](schema-docs.md#otlpgrpcexporter) | unknown |  | * `compression`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
-| [`OtlpGrpcMetricExporter`](schema-docs.md#otlpgrpcmetricexporter) | unknown |  | * `compression`: unknown<br>* `default_histogram_aggregation`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `temporality_preference`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
-| [`OtlpHttpEncoding`](schema-docs.md#otlphttpencoding) | unknown |  | * `json`: unknown<br>* `protobuf`: unknown<br> |
-| [`OtlpHttpExporter`](schema-docs.md#otlphttpexporter) | unknown |  | * `compression`: unknown<br>* `encoding`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
-| [`OtlpHttpMetricExporter`](schema-docs.md#otlphttpmetricexporter) | unknown |  | * `compression`: unknown<br>* `default_histogram_aggregation`: unknown<br>* `encoding`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `temporality_preference`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
-| [`ParentBasedSampler`](schema-docs.md#parentbasedsampler) | unknown |  | * `local_parent_not_sampled`: unknown<br>* `local_parent_sampled`: unknown<br>* `remote_parent_not_sampled`: unknown<br>* `remote_parent_sampled`: unknown<br>* `root`: unknown<br> |
-| [`PeriodicMetricReader`](schema-docs.md#periodicmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `interval`: unknown<br>* `producers`: unknown<br>* `timeout`: unknown<br>* `max_export_batch_size/development`: unknown<br> |
-| [`Propagator`](schema-docs.md#propagator) | unknown |  | * `composite`: unknown<br>* `composite_list`: unknown<br> |
-| [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | unknown |  | * `prometheus/development`: unknown<br> |
-| [`PullMetricReader`](schema-docs.md#pullmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br> |
-| [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
-| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
-| [`Resource`](schema-docs.md#resource) | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
-| [`Sampler`](schema-docs.md#sampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_based`: unknown<br>* `trace_id_ratio_based`: unknown<br>* `composite/development`: unknown<br>* `jaeger_remote/development`: unknown<br>* `probability/development`: unknown<br> |
-| [`SeverityNumber`](schema-docs.md#severitynumber) | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
-| [`SimpleLogRecordProcessor`](schema-docs.md#simplelogrecordprocessor) | unknown |  | * `exporter`: unknown<br> |
-| [`SimpleSpanProcessor`](schema-docs.md#simplespanprocessor) | unknown |  | * `exporter`: unknown<br> |
-| [`SpanExporter`](schema-docs.md#spanexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
-| [`SpanKind`](schema-docs.md#spankind) | unknown |  | * `client`: unknown<br>* `consumer`: unknown<br>* `internal`: unknown<br>* `producer`: unknown<br>* `server`: unknown<br> |
-| [`SpanLimits`](schema-docs.md#spanlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br>* `event_attribute_count_limit`: unknown<br>* `event_count_limit`: unknown<br>* `link_attribute_count_limit`: unknown<br>* `link_count_limit`: unknown<br> |
-| [`SpanProcessor`](schema-docs.md#spanprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br> |
-| [`SumAggregation`](schema-docs.md#sumaggregation) | unknown |  |  |
-| [`TextMapPropagator`](schema-docs.md#textmappropagator) | unknown |  | * `b3`: unknown<br>* `b3multi`: unknown<br>* `baggage`: unknown<br>* `tracecontext`: unknown<br> |
-| [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | unknown |  |  |
-| [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | unknown |  | * `ratio`: unknown<br> |
-| [`TracerProvider`](schema-docs.md#tracerprovider) | unknown |  | * `id_generator`: unknown<br>* `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
-| [`View`](schema-docs.md#view) | unknown |  | * `selector`: unknown<br>* `stream`: unknown<br> |
-| [`ViewSelector`](schema-docs.md#viewselector) | unknown |  | * `instrument_name`: unknown<br>* `instrument_type`: unknown<br>* `meter_name`: unknown<br>* `meter_schema_url`: unknown<br>* `meter_version`: unknown<br>* `unit`: unknown<br> |
-| [`ViewStream`](schema-docs.md#viewstream) | unknown |  | * `aggregation`: unknown<br>* `aggregation_cardinality_limit`: unknown<br>* `attribute_keys`: unknown<br>* `description`: unknown<br>* `name`: unknown<br> |
-| [`ExperimentalCodeInstrumentation`](schema-docs.md#experimentalcodeinstrumentation) | unknown |  | * `semconv`: unknown<br> |
-| [`ExperimentalComposableAlwaysOffSampler`](schema-docs.md#experimentalcomposablealwaysoffsampler) | unknown |  |  |
-| [`ExperimentalComposableAlwaysOnSampler`](schema-docs.md#experimentalcomposablealwaysonsampler) | unknown |  |  |
-| [`ExperimentalComposableParentThresholdSampler`](schema-docs.md#experimentalcomposableparentthresholdsampler) | unknown |  | * `root`: unknown<br> |
-| [`ExperimentalComposableProbabilitySampler`](schema-docs.md#experimentalcomposableprobabilitysampler) | unknown |  | * `ratio`: unknown<br> |
-| [`ExperimentalComposableRuleBasedSampler`](schema-docs.md#experimentalcomposablerulebasedsampler) | unknown |  | * `rules`: unknown<br> |
-| [`ExperimentalComposableRuleBasedSamplerRule`](schema-docs.md#experimentalcomposablerulebasedsamplerrule) | unknown |  | * `attribute_patterns`: unknown<br>* `attribute_values`: unknown<br>* `parent`: unknown<br>* `sampler`: unknown<br>* `span_kinds`: unknown<br> |
-| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributepatterns) | unknown |  | * `excluded`: unknown<br>* `included`: unknown<br>* `key`: unknown<br> |
-| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributevalues) | unknown |  | * `key`: unknown<br>* `values`: unknown<br> |
-| [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_threshold`: unknown<br>* `probability`: unknown<br>* `rule_based`: unknown<br> |
-| [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | unknown |  |  |
-| [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | unknown |  | * `semconv`: unknown<br> |
-| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | unknown |  |  |
-| [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | unknown |  | * `semconv`: unknown<br> |
-| [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | unknown |  | * `code`: unknown<br>* `db`: unknown<br>* `gen_ai`: unknown<br>* `http`: unknown<br>* `messaging`: unknown<br>* `rpc`: unknown<br>* `sanitization`: unknown<br>* `stability_opt_in_list`: unknown<br> |
-| [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | unknown |  |  |
-| [`ExperimentalHttpClientInstrumentation`](schema-docs.md#experimentalhttpclientinstrumentation) | unknown |  | * `known_methods`: unknown<br>* `request_captured_headers`: unknown<br>* `response_captured_headers`: unknown<br> |
-| [`ExperimentalHttpInstrumentation`](schema-docs.md#experimentalhttpinstrumentation) | unknown |  | * `client`: unknown<br>* `semconv`: unknown<br>* `server`: unknown<br> |
-| [`ExperimentalHttpServerInstrumentation`](schema-docs.md#experimentalhttpserverinstrumentation) | unknown |  | * `known_methods`: unknown<br>* `request_captured_headers`: unknown<br>* `response_captured_headers`: unknown<br> |
-| [`ExperimentalInstrumentation`](schema-docs.md#experimentalinstrumentation) | unknown |  | * `cpp`: unknown<br>* `dotnet`: unknown<br>* `erlang`: unknown<br>* `general`: unknown<br>* `go`: unknown<br>* `java`: unknown<br>* `js`: unknown<br>* `php`: unknown<br>* `python`: unknown<br>* `ruby`: unknown<br>* `rust`: unknown<br>* `swift`: unknown<br> |
-| [`ExperimentalJaegerRemoteSampler`](schema-docs.md#experimentaljaegerremotesampler) | unknown |  | * `endpoint`: unknown<br>* `initial_sampler`: unknown<br>* `interval`: unknown<br> |
-| [`ExperimentalLanguageSpecificInstrumentation`](schema-docs.md#experimentallanguagespecificinstrumentation) | unknown |  |  |
-| [`ExperimentalLoggerConfig`](schema-docs.md#experimentalloggerconfig) | unknown |  | * `enabled`: unknown<br>* `minimum_severity`: unknown<br>* `trace_based`: unknown<br> |
-| [`ExperimentalLoggerConfigurator`](schema-docs.md#experimentalloggerconfigurator) | unknown |  | * `default_config`: unknown<br>* `loggers`: unknown<br> |
-| [`ExperimentalLoggerMatcherAndConfig`](schema-docs.md#experimentalloggermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
-| [`ExperimentalMessagingInstrumentation`](schema-docs.md#experimentalmessaginginstrumentation) | unknown |  | * `semconv`: unknown<br> |
-| [`ExperimentalMeterConfig`](schema-docs.md#experimentalmeterconfig) | unknown |  | * `enabled`: unknown<br> |
-| [`ExperimentalMeterConfigurator`](schema-docs.md#experimentalmeterconfigurator) | unknown |  | * `default_config`: unknown<br>* `meters`: unknown<br> |
-| [`ExperimentalMeterMatcherAndConfig`](schema-docs.md#experimentalmetermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
-| [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | unknown |  | * `output_stream`: unknown<br> |
-| [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | unknown |  | * `default_histogram_aggregation`: unknown<br>* `output_stream`: unknown<br>* `temporality_preference`: unknown<br> |
-| [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | unknown |  | * `ratio`: unknown<br> |
-| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | unknown |  |  |
-| [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | unknown |  | * `host`: unknown<br>* `port`: unknown<br>* `resource_constant_labels`: unknown<br>* `scope_info_enabled`: unknown<br>* `translation_strategy`: unknown<br>* `target_info_enabled/development`: unknown<br> |
-| [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | unknown |  | * `no_translation/development`: unknown<br>* `no_utf8_escaping_with_suffixes/development`: unknown<br>* `underscore_escaping_with_suffixes`: unknown<br>* `underscore_escaping_without_suffixes/development`: unknown<br> |
-| [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | unknown |  | * `attributes`: unknown<br>* `detectors`: unknown<br> |
-| [`ExperimentalResourceDetector`](schema-docs.md#experimentalresourcedetector) | unknown |  | * `container`: unknown<br>* `host`: unknown<br>* `process`: unknown<br>* `service`: unknown<br> |
-| [`ExperimentalRpcInstrumentation`](schema-docs.md#experimentalrpcinstrumentation) | unknown |  | * `semconv`: unknown<br> |
-| [`ExperimentalSanitization`](schema-docs.md#experimentalsanitization) | unknown |  | * `url`: unknown<br> |
-| [`ExperimentalSemconvConfig`](schema-docs.md#experimentalsemconvconfig) | unknown |  | * `dual_emit`: unknown<br>* `experimental`: unknown<br>* `version`: unknown<br> |
-| [`ExperimentalServiceResourceDetector`](schema-docs.md#experimentalserviceresourcedetector) | unknown |  |  |
-| [`ExperimentalSpanParent`](schema-docs.md#experimentalspanparent) | unknown |  | * `local`: unknown<br>* `none`: unknown<br>* `remote`: unknown<br> |
-| [`ExperimentalTracerConfig`](schema-docs.md#experimentaltracerconfig) | unknown |  | * `enabled`: unknown<br> |
-| [`ExperimentalTracerConfigurator`](schema-docs.md#experimentaltracerconfigurator) | unknown |  | * `default_config`: unknown<br>* `tracers`: unknown<br> |
-| [`ExperimentalTracerMatcherAndConfig`](schema-docs.md#experimentaltracermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
-| [`ExperimentalUrlSanitization`](schema-docs.md#experimentalurlsanitization) | unknown |  | * `sensitive_query_parameters`: unknown<br> |
+| [`Aggregation`](schema-docs.md#aggregation) | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `default`: supported<br>* `drop`: supported<br>* `explicit_bucket_histogram`: supported<br>* `last_value`: supported<br>* `sum`: supported<br> |
+| [`AlwaysOffSampler`](schema-docs.md#alwaysoffsampler) | supported |  |  |
+| [`AlwaysOnSampler`](schema-docs.md#alwaysonsampler) | supported |  |  |
+| [`AttributeLimits`](schema-docs.md#attributelimits) | ignored |  | * `attribute_count_limit`: ignored<br>* `attribute_value_length_limit`: ignored<br> |
+| [`AttributeNameValue`](schema-docs.md#attributenamevalue) | supported |  | * `name`: supported<br>* `type`: supported<br>* `value`: supported<br> |
+| [`AttributeType`](schema-docs.md#attributetype) | supported |  | * `bool`: supported<br>* `bool_array`: supported<br>* `double`: supported<br>* `double_array`: supported<br>* `int`: supported<br>* `int_array`: supported<br>* `string`: supported<br>* `string_array`: supported<br> |
+| [`B3MultiPropagator`](schema-docs.md#b3multipropagator) | supported |  |  |
+| [`B3Propagator`](schema-docs.md#b3propagator) | supported |  |  |
+| [`BaggagePropagator`](schema-docs.md#baggagepropagator) | supported |  |  |
+| [`Base2ExponentialBucketHistogramAggregation`](schema-docs.md#base2exponentialbuckethistogramaggregation) | supported |  | * `max_scale`: supported<br>* `max_size`: supported<br>* `record_min_max`: supported<br> |
+| [`BatchLogRecordProcessor`](schema-docs.md#batchlogrecordprocessor) | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| [`BatchSpanProcessor`](schema-docs.md#batchspanprocessor) | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| [`CardinalityLimits`](schema-docs.md#cardinalitylimits) | supported |  | * `counter`: supported<br>* `default`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
+| [`ConsoleExporter`](schema-docs.md#consoleexporter) | supported |  |  |
+| [`ConsoleMetricExporter`](schema-docs.md#consolemetricexporter) | supported |  | * `default_histogram_aggregation`: supported<br>* `temporality_preference`: supported<br> |
+| [`DefaultAggregation`](schema-docs.md#defaultaggregation) | supported |  |  |
+| [`Distribution`](schema-docs.md#distribution) | ignored |  |  |
+| [`DropAggregation`](schema-docs.md#dropaggregation) | supported |  |  |
+| [`ExemplarFilter`](schema-docs.md#exemplarfilter) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `trace_based`: supported<br> |
+| [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | supported |  | * `boundaries`: supported<br>* `record_min_max`: supported<br> |
+| [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `explicit_bucket_histogram`: supported<br> |
+| [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | supported |  | * `cumulative`: supported<br>* `delta`: supported<br>* `low_memory`: supported<br> |
+| [`GrpcTls`](schema-docs.md#grpctls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `insecure`: supported<br>* `key_file`: supported<br> |
+| [`HttpTls`](schema-docs.md#httptls) | supported |  | * `ca_file`: supported<br>* `cert_file`: supported<br>* `key_file`: supported<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | ignored |  | * `random`: ignored<br> |
+| [`IncludeExclude`](schema-docs.md#includeexclude) | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
+| [`InstrumentType`](schema-docs.md#instrumenttype) | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
+| [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | supported |  |  |
+| [`LoggerProvider`](schema-docs.md#loggerprovider) | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
+| [`LogRecordExporter`](schema-docs.md#logrecordexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| [`LogRecordLimits`](schema-docs.md#logrecordlimits) | ignored |  | * `attribute_count_limit`: ignored<br>* `attribute_value_length_limit`: ignored<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: supported<br> |
+| [`MeterProvider`](schema-docs.md#meterprovider) | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br> |
+| [`MetricProducer`](schema-docs.md#metricproducer) | ignored |  | * `opencensus`: ignored<br> |
+| [`MetricReader`](schema-docs.md#metricreader) | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
+| [`NameStringValuePair`](schema-docs.md#namestringvaluepair) | supported |  | * `name`: supported<br>* `value`: supported<br> |
+| [`OpenCensusMetricProducer`](schema-docs.md#opencensusmetricproducer) | ignored |  |  |
+| [`OpenTelemetryConfiguration`](schema-docs.md#opentelemetryconfiguration) | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
+| [`OtlpGrpcExporter`](schema-docs.md#otlpgrpcexporter) | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| [`OtlpGrpcMetricExporter`](schema-docs.md#otlpgrpcmetricexporter) | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| [`OtlpHttpEncoding`](schema-docs.md#otlphttpencoding) | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
+| [`OtlpHttpExporter`](schema-docs.md#otlphttpexporter) | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| [`OtlpHttpMetricExporter`](schema-docs.md#otlphttpmetricexporter) | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| [`ParentBasedSampler`](schema-docs.md#parentbasedsampler) | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
+| [`PeriodicMetricReader`](schema-docs.md#periodicmetricreader) | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: supported<br> |
+| [`Propagator`](schema-docs.md#propagator) | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
+| [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | supported |  | * `prometheus/development`: supported<br> |
+| [`PullMetricReader`](schema-docs.md#pullmetricreader) | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br> |
+| [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | ignored |  |  |
+| [`Resource`](schema-docs.md#resource) | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
+| [`Sampler`](schema-docs.md#sampler) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| [`SeverityNumber`](schema-docs.md#severitynumber) | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
+| [`SimpleLogRecordProcessor`](schema-docs.md#simplelogrecordprocessor) | supported |  | * `exporter`: supported<br> |
+| [`SimpleSpanProcessor`](schema-docs.md#simplespanprocessor) | supported |  | * `exporter`: supported<br> |
+| [`SpanExporter`](schema-docs.md#spanexporter) | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| [`SpanKind`](schema-docs.md#spankind) | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
+| [`SpanLimits`](schema-docs.md#spanlimits) | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
+| [`SpanProcessor`](schema-docs.md#spanprocessor) | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
+| [`SumAggregation`](schema-docs.md#sumaggregation) | supported |  |  |
+| [`TextMapPropagator`](schema-docs.md#textmappropagator) | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
+| [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | supported |  |  |
+| [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | supported |  | * `ratio`: supported<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| [`View`](schema-docs.md#view) | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
+| [`ViewSelector`](schema-docs.md#viewselector) | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: supported<br> |
+| [`ViewStream`](schema-docs.md#viewstream) | supported |  | * `aggregation`: supported<br>* `aggregation_cardinality_limit`: supported<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
+| [`ExperimentalCodeInstrumentation`](schema-docs.md#experimentalcodeinstrumentation) | ignored |  | * `semconv`: ignored<br> |
+| [`ExperimentalComposableAlwaysOffSampler`](schema-docs.md#experimentalcomposablealwaysoffsampler) | supported |  |  |
+| [`ExperimentalComposableAlwaysOnSampler`](schema-docs.md#experimentalcomposablealwaysonsampler) | supported |  |  |
+| [`ExperimentalComposableParentThresholdSampler`](schema-docs.md#experimentalcomposableparentthresholdsampler) | supported |  | * `root`: supported<br> |
+| [`ExperimentalComposableProbabilitySampler`](schema-docs.md#experimentalcomposableprobabilitysampler) | supported |  | * `ratio`: supported<br> |
+| [`ExperimentalComposableRuleBasedSampler`](schema-docs.md#experimentalcomposablerulebasedsampler) | supported |  | * `rules`: supported<br> |
+| [`ExperimentalComposableRuleBasedSamplerRule`](schema-docs.md#experimentalcomposablerulebasedsamplerrule) | supported |  | * `attribute_patterns`: supported<br>* `attribute_values`: supported<br>* `parent`: supported<br>* `sampler`: supported<br>* `span_kinds`: supported<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributepatterns) | supported |  | * `excluded`: supported<br>* `included`: supported<br>* `key`: supported<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributevalues) | supported |  | * `key`: supported<br>* `values`: supported<br> |
+| [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_threshold`: supported<br>* `probability`: supported<br>* `rule_based`: supported<br> |
+| [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | ignored |  |  |
+| [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | ignored |  | * `semconv`: ignored<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | ignored |  |  |
+| [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | ignored |  | * `semconv`: ignored<br> |
+| [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | ignored |  | * `code`: ignored<br>* `db`: ignored<br>* `gen_ai`: ignored<br>* `http`: ignored<br>* `messaging`: ignored<br>* `rpc`: ignored<br>* `sanitization`: ignored<br>* `stability_opt_in_list`: ignored<br> |
+| [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | supported |  |  |
+| [`ExperimentalHttpClientInstrumentation`](schema-docs.md#experimentalhttpclientinstrumentation) | ignored |  | * `known_methods`: ignored<br>* `request_captured_headers`: ignored<br>* `response_captured_headers`: ignored<br> |
+| [`ExperimentalHttpInstrumentation`](schema-docs.md#experimentalhttpinstrumentation) | ignored |  | * `client`: ignored<br>* `semconv`: ignored<br>* `server`: ignored<br> |
+| [`ExperimentalHttpServerInstrumentation`](schema-docs.md#experimentalhttpserverinstrumentation) | ignored |  | * `known_methods`: ignored<br>* `request_captured_headers`: ignored<br>* `response_captured_headers`: ignored<br> |
+| [`ExperimentalInstrumentation`](schema-docs.md#experimentalinstrumentation) | ignored |  | * `cpp`: ignored<br>* `dotnet`: ignored<br>* `erlang`: ignored<br>* `general`: ignored<br>* `go`: ignored<br>* `java`: ignored<br>* `js`: ignored<br>* `php`: ignored<br>* `python`: ignored<br>* `ruby`: ignored<br>* `rust`: ignored<br>* `swift`: ignored<br> |
+| [`ExperimentalJaegerRemoteSampler`](schema-docs.md#experimentaljaegerremotesampler) | ignored |  | * `endpoint`: ignored<br>* `initial_sampler`: ignored<br>* `interval`: ignored<br> |
+| [`ExperimentalLanguageSpecificInstrumentation`](schema-docs.md#experimentallanguagespecificinstrumentation) | ignored |  |  |
+| [`ExperimentalLoggerConfig`](schema-docs.md#experimentalloggerconfig) | ignored |  | * `enabled`: ignored<br>* `minimum_severity`: ignored<br>* `trace_based`: ignored<br> |
+| [`ExperimentalLoggerConfigurator`](schema-docs.md#experimentalloggerconfigurator) | ignored |  | * `default_config`: ignored<br>* `loggers`: ignored<br> |
+| [`ExperimentalLoggerMatcherAndConfig`](schema-docs.md#experimentalloggermatcherandconfig) | ignored |  | * `config`: ignored<br>* `name`: ignored<br> |
+| [`ExperimentalMessagingInstrumentation`](schema-docs.md#experimentalmessaginginstrumentation) | ignored |  | * `semconv`: ignored<br> |
+| [`ExperimentalMeterConfig`](schema-docs.md#experimentalmeterconfig) | ignored |  | * `enabled`: ignored<br> |
+| [`ExperimentalMeterConfigurator`](schema-docs.md#experimentalmeterconfigurator) | ignored |  | * `default_config`: ignored<br>* `meters`: ignored<br> |
+| [`ExperimentalMeterMatcherAndConfig`](schema-docs.md#experimentalmetermatcherandconfig) | ignored |  | * `config`: ignored<br>* `name`: ignored<br> |
+| [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | ignored |  | * `output_stream`: ignored<br> |
+| [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | ignored |  | * `default_histogram_aggregation`: ignored<br>* `output_stream`: ignored<br>* `temporality_preference`: ignored<br> |
+| [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | ignored |  | * `ratio`: ignored<br> |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  |  |
+| [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | ignored |  | * `host`: ignored<br>* `port`: ignored<br>* `resource_constant_labels`: ignored<br>* `scope_info_enabled`: ignored<br>* `translation_strategy`: ignored<br>* `target_info_enabled/development`: ignored<br> |
+| [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | ignored |  | * `no_translation/development`: ignored<br>* `no_utf8_escaping_with_suffixes/development`: ignored<br>* `underscore_escaping_with_suffixes`: ignored<br>* `underscore_escaping_without_suffixes/development`: ignored<br> |
+| [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
+| [`ExperimentalResourceDetector`](schema-docs.md#experimentalresourcedetector) | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
+| [`ExperimentalRpcInstrumentation`](schema-docs.md#experimentalrpcinstrumentation) | ignored |  | * `semconv`: ignored<br> |
+| [`ExperimentalSanitization`](schema-docs.md#experimentalsanitization) | ignored |  | * `url`: ignored<br> |
+| [`ExperimentalSemconvConfig`](schema-docs.md#experimentalsemconvconfig) | ignored |  | * `dual_emit`: ignored<br>* `experimental`: ignored<br>* `version`: ignored<br> |
+| [`ExperimentalServiceResourceDetector`](schema-docs.md#experimentalserviceresourcedetector) | supported |  |  |
+| [`ExperimentalSpanParent`](schema-docs.md#experimentalspanparent) | supported |  | * `local`: supported<br>* `none`: supported<br>* `remote`: supported<br> |
+| [`ExperimentalTracerConfig`](schema-docs.md#experimentaltracerconfig) | ignored |  | * `enabled`: ignored<br> |
+| [`ExperimentalTracerConfigurator`](schema-docs.md#experimentaltracerconfigurator) | ignored |  | * `default_config`: ignored<br>* `tracers`: ignored<br> |
+| [`ExperimentalTracerMatcherAndConfig`](schema-docs.md#experimentaltracermatcherandconfig) | ignored |  | * `config`: ignored<br>* `name`: ignored<br> |
+| [`ExperimentalUrlSanitization`](schema-docs.md#experimentalurlsanitization) | ignored |  | * `sensitive_query_parameters`: ignored<br> |
 
 

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -9,6 +9,7 @@ This page provides comprehensive language implementation status for each type in
 * [java](#java)
 * [js](#js)
 * [php](#php)
+* [python](#python)
 
 ## cpp <a id="cpp"></a>
 
@@ -612,6 +613,127 @@ Latest supported file format: `1.0.0-rc.2`
 | [`ExperimentalTracerConfig`](schema-docs.md#experimentaltracerconfig) | supported |  | * `enabled`: supported<br> |
 | [`ExperimentalTracerConfigurator`](schema-docs.md#experimentaltracerconfigurator) | supported |  | * `default_config`: supported<br>* `tracers`: supported<br> |
 | [`ExperimentalTracerMatcherAndConfig`](schema-docs.md#experimentaltracermatcherandconfig) | supported |  | * `config`: supported<br>* `name`: supported<br> |
+| [`ExperimentalUrlSanitization`](schema-docs.md#experimentalurlsanitization) | unknown |  | * `sensitive_query_parameters`: unknown<br> |
+
+
+## python <a id="python"></a>
+
+Latest supported file format: `1.0.0`
+
+| Type | Status | Notes | Support Status Details |
+|---|---|---|---|
+| [`Aggregation`](schema-docs.md#aggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `default`: unknown<br>* `drop`: unknown<br>* `explicit_bucket_histogram`: unknown<br>* `last_value`: unknown<br>* `sum`: unknown<br> |
+| [`AlwaysOffSampler`](schema-docs.md#alwaysoffsampler) | unknown |  |  |
+| [`AlwaysOnSampler`](schema-docs.md#alwaysonsampler) | unknown |  |  |
+| [`AttributeLimits`](schema-docs.md#attributelimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
+| [`AttributeNameValue`](schema-docs.md#attributenamevalue) | unknown |  | * `name`: unknown<br>* `type`: unknown<br>* `value`: unknown<br> |
+| [`AttributeType`](schema-docs.md#attributetype) | unknown |  | * `bool`: unknown<br>* `bool_array`: unknown<br>* `double`: unknown<br>* `double_array`: unknown<br>* `int`: unknown<br>* `int_array`: unknown<br>* `string`: unknown<br>* `string_array`: unknown<br> |
+| [`B3MultiPropagator`](schema-docs.md#b3multipropagator) | unknown |  |  |
+| [`B3Propagator`](schema-docs.md#b3propagator) | unknown |  |  |
+| [`BaggagePropagator`](schema-docs.md#baggagepropagator) | unknown |  |  |
+| [`Base2ExponentialBucketHistogramAggregation`](schema-docs.md#base2exponentialbuckethistogramaggregation) | unknown |  | * `max_scale`: unknown<br>* `max_size`: unknown<br>* `record_min_max`: unknown<br> |
+| [`BatchLogRecordProcessor`](schema-docs.md#batchlogrecordprocessor) | unknown |  | * `export_timeout`: unknown<br>* `exporter`: unknown<br>* `max_export_batch_size`: unknown<br>* `max_queue_size`: unknown<br>* `schedule_delay`: unknown<br> |
+| [`BatchSpanProcessor`](schema-docs.md#batchspanprocessor) | unknown |  | * `export_timeout`: unknown<br>* `exporter`: unknown<br>* `max_export_batch_size`: unknown<br>* `max_queue_size`: unknown<br>* `schedule_delay`: unknown<br> |
+| [`CardinalityLimits`](schema-docs.md#cardinalitylimits) | unknown |  | * `counter`: unknown<br>* `default`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
+| [`ConsoleExporter`](schema-docs.md#consoleexporter) | unknown |  |  |
+| [`ConsoleMetricExporter`](schema-docs.md#consolemetricexporter) | unknown |  | * `default_histogram_aggregation`: unknown<br>* `temporality_preference`: unknown<br> |
+| [`DefaultAggregation`](schema-docs.md#defaultaggregation) | unknown |  |  |
+| [`Distribution`](schema-docs.md#distribution) | unknown |  |  |
+| [`DropAggregation`](schema-docs.md#dropaggregation) | unknown |  |  |
+| [`ExemplarFilter`](schema-docs.md#exemplarfilter) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `trace_based`: unknown<br> |
+| [`ExplicitBucketHistogramAggregation`](schema-docs.md#explicitbuckethistogramaggregation) | unknown |  | * `boundaries`: unknown<br>* `record_min_max`: unknown<br> |
+| [`ExporterDefaultHistogramAggregation`](schema-docs.md#exporterdefaulthistogramaggregation) | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `explicit_bucket_histogram`: unknown<br> |
+| [`ExporterTemporalityPreference`](schema-docs.md#exportertemporalitypreference) | unknown |  | * `cumulative`: unknown<br>* `delta`: unknown<br>* `low_memory`: unknown<br> |
+| [`GrpcTls`](schema-docs.md#grpctls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `insecure`: unknown<br>* `key_file`: unknown<br> |
+| [`HttpTls`](schema-docs.md#httptls) | unknown |  | * `ca_file`: unknown<br>* `cert_file`: unknown<br>* `key_file`: unknown<br> |
+| [`IdGenerator`](schema-docs.md#idgenerator) | unknown |  | * `random`: unknown<br> |
+| [`IncludeExclude`](schema-docs.md#includeexclude) | unknown |  | * `excluded`: unknown<br>* `included`: unknown<br> |
+| [`InstrumentType`](schema-docs.md#instrumenttype) | unknown |  | * `counter`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
+| [`LastValueAggregation`](schema-docs.md#lastvalueaggregation) | unknown |  |  |
+| [`LoggerProvider`](schema-docs.md#loggerprovider) | unknown |  | * `limits`: unknown<br>* `processors`: unknown<br>* `logger_configurator/development`: unknown<br> |
+| [`LogRecordExporter`](schema-docs.md#logrecordexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`LogRecordLimits`](schema-docs.md#logrecordlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br> |
+| [`LogRecordProcessor`](schema-docs.md#logrecordprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br>* `event_to_span_event_bridge/development`: unknown<br> |
+| [`MeterProvider`](schema-docs.md#meterprovider) | unknown |  | * `exemplar_filter`: unknown<br>* `readers`: unknown<br>* `views`: unknown<br>* `meter_configurator/development`: unknown<br> |
+| [`MetricProducer`](schema-docs.md#metricproducer) | unknown |  | * `opencensus`: unknown<br> |
+| [`MetricReader`](schema-docs.md#metricreader) | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
+| [`NameStringValuePair`](schema-docs.md#namestringvaluepair) | unknown |  | * `name`: unknown<br>* `value`: unknown<br> |
+| [`OpenCensusMetricProducer`](schema-docs.md#opencensusmetricproducer) | unknown |  |  |
+| [`OpenTelemetryConfiguration`](schema-docs.md#opentelemetryconfiguration) | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation/development`: unknown<br> |
+| [`OtlpGrpcExporter`](schema-docs.md#otlpgrpcexporter) | unknown |  | * `compression`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`OtlpGrpcMetricExporter`](schema-docs.md#otlpgrpcmetricexporter) | unknown |  | * `compression`: unknown<br>* `default_histogram_aggregation`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `temporality_preference`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`OtlpHttpEncoding`](schema-docs.md#otlphttpencoding) | unknown |  | * `json`: unknown<br>* `protobuf`: unknown<br> |
+| [`OtlpHttpExporter`](schema-docs.md#otlphttpexporter) | unknown |  | * `compression`: unknown<br>* `encoding`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`OtlpHttpMetricExporter`](schema-docs.md#otlphttpmetricexporter) | unknown |  | * `compression`: unknown<br>* `default_histogram_aggregation`: unknown<br>* `encoding`: unknown<br>* `endpoint`: unknown<br>* `headers`: unknown<br>* `headers_list`: unknown<br>* `temporality_preference`: unknown<br>* `timeout`: unknown<br>* `tls`: unknown<br> |
+| [`ParentBasedSampler`](schema-docs.md#parentbasedsampler) | unknown |  | * `local_parent_not_sampled`: unknown<br>* `local_parent_sampled`: unknown<br>* `remote_parent_not_sampled`: unknown<br>* `remote_parent_sampled`: unknown<br>* `root`: unknown<br> |
+| [`PeriodicMetricReader`](schema-docs.md#periodicmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `interval`: unknown<br>* `producers`: unknown<br>* `timeout`: unknown<br>* `max_export_batch_size/development`: unknown<br> |
+| [`Propagator`](schema-docs.md#propagator) | unknown |  | * `composite`: unknown<br>* `composite_list`: unknown<br> |
+| [`PullMetricExporter`](schema-docs.md#pullmetricexporter) | unknown |  | * `prometheus/development`: unknown<br> |
+| [`PullMetricReader`](schema-docs.md#pullmetricreader) | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br> |
+| [`PushMetricExporter`](schema-docs.md#pushmetricexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`RandomIdGenerator`](schema-docs.md#randomidgenerator) | unknown |  |  |
+| [`Resource`](schema-docs.md#resource) | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
+| [`Sampler`](schema-docs.md#sampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_based`: unknown<br>* `trace_id_ratio_based`: unknown<br>* `composite/development`: unknown<br>* `jaeger_remote/development`: unknown<br>* `probability/development`: unknown<br> |
+| [`SeverityNumber`](schema-docs.md#severitynumber) | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
+| [`SimpleLogRecordProcessor`](schema-docs.md#simplelogrecordprocessor) | unknown |  | * `exporter`: unknown<br> |
+| [`SimpleSpanProcessor`](schema-docs.md#simplespanprocessor) | unknown |  | * `exporter`: unknown<br> |
+| [`SpanExporter`](schema-docs.md#spanexporter) | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| [`SpanKind`](schema-docs.md#spankind) | unknown |  | * `client`: unknown<br>* `consumer`: unknown<br>* `internal`: unknown<br>* `producer`: unknown<br>* `server`: unknown<br> |
+| [`SpanLimits`](schema-docs.md#spanlimits) | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br>* `event_attribute_count_limit`: unknown<br>* `event_count_limit`: unknown<br>* `link_attribute_count_limit`: unknown<br>* `link_count_limit`: unknown<br> |
+| [`SpanProcessor`](schema-docs.md#spanprocessor) | unknown |  | * `batch`: unknown<br>* `simple`: unknown<br> |
+| [`SumAggregation`](schema-docs.md#sumaggregation) | unknown |  |  |
+| [`TextMapPropagator`](schema-docs.md#textmappropagator) | unknown |  | * `b3`: unknown<br>* `b3multi`: unknown<br>* `baggage`: unknown<br>* `tracecontext`: unknown<br> |
+| [`TraceContextPropagator`](schema-docs.md#tracecontextpropagator) | unknown |  |  |
+| [`TraceIdRatioBasedSampler`](schema-docs.md#traceidratiobasedsampler) | unknown |  | * `ratio`: unknown<br> |
+| [`TracerProvider`](schema-docs.md#tracerprovider) | unknown |  | * `id_generator`: unknown<br>* `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
+| [`View`](schema-docs.md#view) | unknown |  | * `selector`: unknown<br>* `stream`: unknown<br> |
+| [`ViewSelector`](schema-docs.md#viewselector) | unknown |  | * `instrument_name`: unknown<br>* `instrument_type`: unknown<br>* `meter_name`: unknown<br>* `meter_schema_url`: unknown<br>* `meter_version`: unknown<br>* `unit`: unknown<br> |
+| [`ViewStream`](schema-docs.md#viewstream) | unknown |  | * `aggregation`: unknown<br>* `aggregation_cardinality_limit`: unknown<br>* `attribute_keys`: unknown<br>* `description`: unknown<br>* `name`: unknown<br> |
+| [`ExperimentalCodeInstrumentation`](schema-docs.md#experimentalcodeinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalComposableAlwaysOffSampler`](schema-docs.md#experimentalcomposablealwaysoffsampler) | unknown |  |  |
+| [`ExperimentalComposableAlwaysOnSampler`](schema-docs.md#experimentalcomposablealwaysonsampler) | unknown |  |  |
+| [`ExperimentalComposableParentThresholdSampler`](schema-docs.md#experimentalcomposableparentthresholdsampler) | unknown |  | * `root`: unknown<br> |
+| [`ExperimentalComposableProbabilitySampler`](schema-docs.md#experimentalcomposableprobabilitysampler) | unknown |  | * `ratio`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSampler`](schema-docs.md#experimentalcomposablerulebasedsampler) | unknown |  | * `rules`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRule`](schema-docs.md#experimentalcomposablerulebasedsamplerrule) | unknown |  | * `attribute_patterns`: unknown<br>* `attribute_values`: unknown<br>* `parent`: unknown<br>* `sampler`: unknown<br>* `span_kinds`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributePatterns`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributepatterns) | unknown |  | * `excluded`: unknown<br>* `included`: unknown<br>* `key`: unknown<br> |
+| [`ExperimentalComposableRuleBasedSamplerRuleAttributeValues`](schema-docs.md#experimentalcomposablerulebasedsamplerruleattributevalues) | unknown |  | * `key`: unknown<br>* `values`: unknown<br> |
+| [`ExperimentalComposableSampler`](schema-docs.md#experimentalcomposablesampler) | unknown |  | * `always_off`: unknown<br>* `always_on`: unknown<br>* `parent_threshold`: unknown<br>* `probability`: unknown<br>* `rule_based`: unknown<br> |
+| [`ExperimentalContainerResourceDetector`](schema-docs.md#experimentalcontainerresourcedetector) | unknown |  |  |
+| [`ExperimentalDbInstrumentation`](schema-docs.md#experimentaldbinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalEventToSpanEventBridgeLogRecordProcessor`](schema-docs.md#experimentaleventtospaneventbridgelogrecordprocessor) | unknown |  |  |
+| [`ExperimentalGenAiInstrumentation`](schema-docs.md#experimentalgenaiinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalGeneralInstrumentation`](schema-docs.md#experimentalgeneralinstrumentation) | unknown |  | * `code`: unknown<br>* `db`: unknown<br>* `gen_ai`: unknown<br>* `http`: unknown<br>* `messaging`: unknown<br>* `rpc`: unknown<br>* `sanitization`: unknown<br>* `stability_opt_in_list`: unknown<br> |
+| [`ExperimentalHostResourceDetector`](schema-docs.md#experimentalhostresourcedetector) | unknown |  |  |
+| [`ExperimentalHttpClientInstrumentation`](schema-docs.md#experimentalhttpclientinstrumentation) | unknown |  | * `known_methods`: unknown<br>* `request_captured_headers`: unknown<br>* `response_captured_headers`: unknown<br> |
+| [`ExperimentalHttpInstrumentation`](schema-docs.md#experimentalhttpinstrumentation) | unknown |  | * `client`: unknown<br>* `semconv`: unknown<br>* `server`: unknown<br> |
+| [`ExperimentalHttpServerInstrumentation`](schema-docs.md#experimentalhttpserverinstrumentation) | unknown |  | * `known_methods`: unknown<br>* `request_captured_headers`: unknown<br>* `response_captured_headers`: unknown<br> |
+| [`ExperimentalInstrumentation`](schema-docs.md#experimentalinstrumentation) | unknown |  | * `cpp`: unknown<br>* `dotnet`: unknown<br>* `erlang`: unknown<br>* `general`: unknown<br>* `go`: unknown<br>* `java`: unknown<br>* `js`: unknown<br>* `php`: unknown<br>* `python`: unknown<br>* `ruby`: unknown<br>* `rust`: unknown<br>* `swift`: unknown<br> |
+| [`ExperimentalJaegerRemoteSampler`](schema-docs.md#experimentaljaegerremotesampler) | unknown |  | * `endpoint`: unknown<br>* `initial_sampler`: unknown<br>* `interval`: unknown<br> |
+| [`ExperimentalLanguageSpecificInstrumentation`](schema-docs.md#experimentallanguagespecificinstrumentation) | unknown |  |  |
+| [`ExperimentalLoggerConfig`](schema-docs.md#experimentalloggerconfig) | unknown |  | * `enabled`: unknown<br>* `minimum_severity`: unknown<br>* `trace_based`: unknown<br> |
+| [`ExperimentalLoggerConfigurator`](schema-docs.md#experimentalloggerconfigurator) | unknown |  | * `default_config`: unknown<br>* `loggers`: unknown<br> |
+| [`ExperimentalLoggerMatcherAndConfig`](schema-docs.md#experimentalloggermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
+| [`ExperimentalMessagingInstrumentation`](schema-docs.md#experimentalmessaginginstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalMeterConfig`](schema-docs.md#experimentalmeterconfig) | unknown |  | * `enabled`: unknown<br> |
+| [`ExperimentalMeterConfigurator`](schema-docs.md#experimentalmeterconfigurator) | unknown |  | * `default_config`: unknown<br>* `meters`: unknown<br> |
+| [`ExperimentalMeterMatcherAndConfig`](schema-docs.md#experimentalmetermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
+| [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | unknown |  | * `output_stream`: unknown<br> |
+| [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | unknown |  | * `default_histogram_aggregation`: unknown<br>* `output_stream`: unknown<br>* `temporality_preference`: unknown<br> |
+| [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | unknown |  | * `ratio`: unknown<br> |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | unknown |  |  |
+| [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | unknown |  | * `host`: unknown<br>* `port`: unknown<br>* `resource_constant_labels`: unknown<br>* `scope_info_enabled`: unknown<br>* `translation_strategy`: unknown<br>* `target_info_enabled/development`: unknown<br> |
+| [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | unknown |  | * `no_translation/development`: unknown<br>* `no_utf8_escaping_with_suffixes/development`: unknown<br>* `underscore_escaping_with_suffixes`: unknown<br>* `underscore_escaping_without_suffixes/development`: unknown<br> |
+| [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | unknown |  | * `attributes`: unknown<br>* `detectors`: unknown<br> |
+| [`ExperimentalResourceDetector`](schema-docs.md#experimentalresourcedetector) | unknown |  | * `container`: unknown<br>* `host`: unknown<br>* `process`: unknown<br>* `service`: unknown<br> |
+| [`ExperimentalRpcInstrumentation`](schema-docs.md#experimentalrpcinstrumentation) | unknown |  | * `semconv`: unknown<br> |
+| [`ExperimentalSanitization`](schema-docs.md#experimentalsanitization) | unknown |  | * `url`: unknown<br> |
+| [`ExperimentalSemconvConfig`](schema-docs.md#experimentalsemconvconfig) | unknown |  | * `dual_emit`: unknown<br>* `experimental`: unknown<br>* `version`: unknown<br> |
+| [`ExperimentalServiceResourceDetector`](schema-docs.md#experimentalserviceresourcedetector) | unknown |  |  |
+| [`ExperimentalSpanParent`](schema-docs.md#experimentalspanparent) | unknown |  | * `local`: unknown<br>* `none`: unknown<br>* `remote`: unknown<br> |
+| [`ExperimentalTracerConfig`](schema-docs.md#experimentaltracerconfig) | unknown |  | * `enabled`: unknown<br> |
+| [`ExperimentalTracerConfigurator`](schema-docs.md#experimentaltracerconfigurator) | unknown |  | * `default_config`: unknown<br>* `tracers`: unknown<br> |
+| [`ExperimentalTracerMatcherAndConfig`](schema-docs.md#experimentaltracermatcherandconfig) | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
 | [`ExperimentalUrlSanitization`](schema-docs.md#experimentalurlsanitization) | unknown |  | * `sensitive_query_parameters`: unknown<br> |
 
 

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -27,14 +27,14 @@ See also [language support status](language-support-status.md) for all details a
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored |
-| `default` | supported | unknown | supported | unknown | ignored |
-| `drop` | supported | unknown | supported | unknown | ignored |
-| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored |
-| `last_value` | supported | unknown | supported | unknown | ignored |
-| `sum` | supported | unknown | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
+| `default` | supported | unknown | supported | unknown | ignored | unknown |
+| `drop` | supported | unknown | supported | unknown | ignored | unknown |
+| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
+| `last_value` | supported | unknown | supported | unknown | ignored | unknown |
+| `sum` | supported | unknown | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -151,10 +151,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | supported | supported | unknown | supported |
-| `attribute_value_length_limit` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_count_limit` | supported | supported | supported | unknown | supported | unknown |
+| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -206,11 +206,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `name` | supported | supported | supported | unknown | supported |
-| `type` | supported | supported | supported | unknown | not_implemented |
-| `value` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `name` | supported | supported | supported | unknown | supported | unknown |
+| `type` | supported | supported | supported | unknown | not_implemented | unknown |
+| `value` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -304,16 +304,16 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `bool` | supported | supported | supported | unknown | not_implemented |
-| `bool_array` | supported | supported | supported | unknown | not_implemented |
-| `double` | supported | supported | supported | unknown | not_implemented |
-| `double_array` | supported | supported | supported | unknown | not_implemented |
-| `int` | supported | supported | supported | unknown | not_implemented |
-| `int_array` | supported | supported | supported | unknown | not_implemented |
-| `string` | supported | supported | supported | unknown | not_implemented |
-| `string_array` | supported | supported | supported | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `bool` | supported | supported | supported | unknown | not_implemented | unknown |
+| `bool_array` | supported | supported | supported | unknown | not_implemented | unknown |
+| `double` | supported | supported | supported | unknown | not_implemented | unknown |
+| `double_array` | supported | supported | supported | unknown | not_implemented | unknown |
+| `int` | supported | supported | supported | unknown | not_implemented | unknown |
+| `int_array` | supported | supported | supported | unknown | not_implemented | unknown |
+| `string` | supported | supported | supported | unknown | not_implemented | unknown |
+| `string_array` | supported | supported | supported | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -438,11 +438,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `max_scale` | supported | unknown | supported | unknown | not_implemented |
-| `max_size` | supported | unknown | supported | unknown | not_implemented |
-| `record_min_max` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `max_scale` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `max_size` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `record_min_max` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -507,13 +507,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `export_timeout` | supported | supported | supported | unknown | supported |
-| `exporter` | supported | supported | supported | unknown | supported |
-| `max_export_batch_size` | supported | supported | supported | unknown | supported |
-| `max_queue_size` | supported | supported | supported | unknown | supported |
-| `schedule_delay` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `export_timeout` | supported | supported | supported | unknown | supported | unknown |
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
+| `max_export_batch_size` | supported | supported | supported | unknown | supported | unknown |
+| `max_queue_size` | supported | supported | supported | unknown | supported | unknown |
+| `schedule_delay` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -591,13 +591,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `export_timeout` | supported | supported | supported | unknown | supported |
-| `exporter` | supported | supported | supported | unknown | supported |
-| `max_export_batch_size` | supported | supported | supported | unknown | supported |
-| `max_queue_size` | supported | supported | supported | unknown | supported |
-| `schedule_delay` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `export_timeout` | supported | supported | supported | unknown | supported | unknown |
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
+| `max_export_batch_size` | supported | supported | supported | unknown | supported | unknown |
+| `max_queue_size` | supported | supported | supported | unknown | supported | unknown |
+| `schedule_delay` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -678,16 +678,16 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `counter` | ignored | unknown | supported | unknown | not_implemented |
-| `default` | ignored | unknown | supported | unknown | not_implemented |
-| `gauge` | ignored | unknown | supported | unknown | not_implemented |
-| `histogram` | ignored | unknown | supported | unknown | not_implemented |
-| `observable_counter` | ignored | unknown | supported | unknown | not_implemented |
-| `observable_gauge` | ignored | unknown | supported | unknown | not_implemented |
-| `observable_up_down_counter` | ignored | unknown | supported | unknown | not_implemented |
-| `up_down_counter` | ignored | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `default` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `gauge` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `histogram` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `observable_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `observable_gauge` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `observable_up_down_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `up_down_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -850,10 +850,10 @@ Snippets:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_histogram_aggregation` | supported | not_implemented | not_implemented | unknown | not_implemented |
-| `temporality_preference` | supported | not_implemented | ignored | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_histogram_aggregation` | supported | not_implemented | not_implemented | unknown | not_implemented | unknown |
+| `temporality_preference` | supported | not_implemented | ignored | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -994,11 +994,11 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `always_off` | supported | unknown | supported | unknown | supported |
-| `always_on` | supported | unknown | supported | unknown | supported |
-| `trace_based` | supported | unknown | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `always_off` | supported | unknown | supported | unknown | supported | unknown |
+| `always_on` | supported | unknown | supported | unknown | supported | unknown |
+| `trace_based` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -1036,10 +1036,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `boundaries` | supported | unknown | supported | unknown | ignored |
-| `record_min_max` | supported | unknown | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `boundaries` | supported | unknown | supported | unknown | ignored | unknown |
+| `record_min_max` | supported | unknown | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -1094,10 +1094,10 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored |
-| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
+| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
 </details>
 
 No constraints.
@@ -1140,11 +1140,11 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cumulative` | supported | supported | supported | unknown | supported |
-| `delta` | supported | supported | supported | unknown | supported |
-| `low_memory` | supported | supported | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cumulative` | supported | supported | supported | unknown | supported | unknown |
+| `delta` | supported | supported | supported | unknown | supported | unknown |
+| `low_memory` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -1187,12 +1187,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ca_file` | supported | supported | supported | unknown | ignored |
-| `cert_file` | supported | supported | supported | unknown | ignored |
-| `insecure` | supported | supported | not_implemented | unknown | ignored |
-| `key_file` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ca_file` | supported | supported | supported | unknown | ignored | unknown |
+| `cert_file` | supported | supported | supported | unknown | ignored | unknown |
+| `insecure` | supported | supported | not_implemented | unknown | ignored | unknown |
+| `key_file` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -1260,11 +1260,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ca_file` | supported | supported | supported | unknown | ignored |
-| `cert_file` | supported | supported | supported | unknown | ignored |
-| `key_file` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ca_file` | supported | supported | supported | unknown | ignored | unknown |
+| `cert_file` | supported | supported | supported | unknown | ignored | unknown |
+| `key_file` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -1325,9 +1325,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `random` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `random` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -1386,10 +1386,10 @@ my_custom_id_generator:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `excluded` | supported | supported | supported | unknown | supported |
-| `included` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `excluded` | supported | supported | supported | unknown | supported | unknown |
+| `included` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1449,15 +1449,15 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `counter` | supported | supported | supported | unknown | supported |
-| `gauge` | supported | supported | supported | unknown | supported |
-| `histogram` | supported | supported | supported | unknown | supported |
-| `observable_counter` | supported | supported | supported | unknown | supported |
-| `observable_gauge` | supported | supported | supported | unknown | supported |
-| `observable_up_down_counter` | supported | supported | supported | unknown | supported |
-| `up_down_counter` | supported | supported | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `counter` | supported | supported | supported | unknown | supported | unknown |
+| `gauge` | supported | supported | supported | unknown | supported | unknown |
+| `histogram` | supported | supported | supported | unknown | supported | unknown |
+| `observable_counter` | supported | supported | supported | unknown | supported | unknown |
+| `observable_gauge` | supported | supported | supported | unknown | supported | unknown |
+| `observable_up_down_counter` | supported | supported | supported | unknown | supported | unknown |
+| `up_down_counter` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -1527,11 +1527,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `limits` | supported | supported | supported | unknown | supported |
-| `processors` | supported | supported | supported | unknown | supported |
-| `logger_configurator/development` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `limits` | supported | supported | supported | unknown | supported | unknown |
+| `processors` | supported | supported | supported | unknown | supported | unknown |
+| `logger_configurator/development` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1590,12 +1590,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `console` | supported | supported | supported | unknown | supported |
-| `otlp_grpc` | supported | supported | supported | unknown | supported |
-| `otlp_http` | supported | supported | supported | unknown | supported |
-| `otlp_file/development` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `console` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_grpc` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_http` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1656,10 +1656,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | supported | supported | unknown | supported |
-| `attribute_value_length_limit` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_count_limit` | supported | supported | supported | unknown | supported | unknown |
+| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1724,11 +1724,11 @@ attribute_value_length_limit: 4096
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `batch` | supported | supported | supported | unknown | supported |
-| `simple` | supported | supported | supported | unknown | supported |
-| `event_to_span_event_bridge/development` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `batch` | supported | supported | supported | unknown | supported | unknown |
+| `simple` | supported | supported | supported | unknown | supported | unknown |
+| `event_to_span_event_bridge/development` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -1786,12 +1786,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `exemplar_filter` | supported | supported | supported | unknown | supported |
-| `readers` | supported | supported | supported | unknown | supported |
-| `views` | supported | supported | supported | unknown | supported |
-| `meter_configurator/development` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `exemplar_filter` | supported | supported | supported | unknown | supported | unknown |
+| `readers` | supported | supported | supported | unknown | supported | unknown |
+| `views` | supported | supported | supported | unknown | supported | unknown |
+| `meter_configurator/development` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -1855,9 +1855,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `opencensus` | supported | unknown | ignored | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `opencensus` | supported | unknown | ignored | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -1907,10 +1907,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `periodic` | supported | unknown | supported | unknown | supported |
-| `pull` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `periodic` | supported | unknown | supported | unknown | supported | unknown |
+| `pull` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -1957,10 +1957,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `name` | supported | supported | supported | unknown | supported |
-| `value` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `name` | supported | supported | supported | unknown | supported | unknown |
+| `value` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2052,19 +2052,19 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_limits` | supported | unknown | supported | unknown | supported |
-| `disabled` | supported | unknown | supported | unknown | supported |
-| `distribution` | supported | unknown | supported | unknown | not_implemented |
-| `file_format` | supported | unknown | supported | unknown | supported |
-| `log_level` | supported | unknown | not_implemented | unknown | not_implemented |
-| `logger_provider` | supported | unknown | supported | unknown | supported |
-| `meter_provider` | supported | unknown | supported | unknown | supported |
-| `propagator` | supported | unknown | supported | unknown | supported |
-| `resource` | supported | unknown | supported | unknown | supported |
-| `tracer_provider` | supported | unknown | supported | unknown | supported |
-| `instrumentation/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_limits` | supported | unknown | supported | unknown | supported | unknown |
+| `disabled` | supported | unknown | supported | unknown | supported | unknown |
+| `distribution` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `file_format` | supported | unknown | supported | unknown | supported | unknown |
+| `log_level` | supported | unknown | not_implemented | unknown | not_implemented | unknown |
+| `logger_provider` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_provider` | supported | unknown | supported | unknown | supported | unknown |
+| `propagator` | supported | unknown | supported | unknown | supported | unknown |
+| `resource` | supported | unknown | supported | unknown | supported | unknown |
+| `tracer_provider` | supported | unknown | supported | unknown | supported | unknown |
+| `instrumentation/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2154,14 +2154,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2287,16 +2287,16 @@ timeout: 10000
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `temporality_preference` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `temporality_preference` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2405,10 +2405,10 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `json` | supported | not_implemented | not_implemented | unknown | supported |
-| `protobuf` | supported | not_implemented | not_implemented | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `json` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `protobuf` | supported | not_implemented | not_implemented | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -2451,15 +2451,15 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `encoding` | supported | not_implemented | not_implemented | unknown | supported |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `encoding` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2590,17 +2590,17 @@ encoding: protobuf
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported |
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented |
-| `encoding` | supported | not_implemented | not_implemented | unknown | supported |
-| `endpoint` | supported | supported | supported | unknown | supported |
-| `headers` | supported | supported | supported | unknown | supported |
-| `headers_list` | supported | supported | supported | unknown | supported |
-| `temporality_preference` | supported | supported | supported | unknown | supported |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `tls` | supported | supported | supported | unknown | ignored |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `compression` | supported | supported | supported | unknown | supported | unknown |
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `encoding` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `endpoint` | supported | supported | supported | unknown | supported | unknown |
+| `headers` | supported | supported | supported | unknown | supported | unknown |
+| `headers_list` | supported | supported | supported | unknown | supported | unknown |
+| `temporality_preference` | supported | supported | supported | unknown | supported | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `tls` | supported | supported | supported | unknown | ignored | unknown |
 </details>
 
 Constraints: 
@@ -2726,13 +2726,13 @@ default_histogram_aggregation: base2_exponential_bucket_histogram
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `local_parent_not_sampled` | supported | supported | supported | unknown | supported |
-| `local_parent_sampled` | supported | supported | supported | unknown | supported |
-| `remote_parent_not_sampled` | supported | supported | supported | unknown | supported |
-| `remote_parent_sampled` | supported | supported | supported | unknown | supported |
-| `root` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `local_parent_not_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `local_parent_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `remote_parent_not_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `remote_parent_sampled` | supported | supported | supported | unknown | supported | unknown |
+| `root` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2794,14 +2794,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cardinality_limits` | supported | not_implemented | supported | unknown | supported |
-| `exporter` | supported | supported | supported | unknown | supported |
-| `interval` | supported | supported | supported | unknown | not_implemented |
-| `producers` | supported | not_implemented | not_implemented | unknown | not_implemented |
-| `timeout` | supported | supported | supported | unknown | supported |
-| `max_export_batch_size/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cardinality_limits` | supported | not_implemented | supported | unknown | supported | unknown |
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
+| `interval` | supported | supported | supported | unknown | not_implemented | unknown |
+| `producers` | supported | not_implemented | not_implemented | unknown | not_implemented | unknown |
+| `timeout` | supported | supported | supported | unknown | supported | unknown |
+| `max_export_batch_size/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -2880,10 +2880,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `composite` | supported | supported | supported | unknown | supported |
-| `composite_list` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `composite` | supported | supported | supported | unknown | supported | unknown |
+| `composite_list` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -2949,9 +2949,9 @@ composite_list: "xray"
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `prometheus/development` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `prometheus/development` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -3000,11 +3000,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cardinality_limits` | supported | unknown | supported | unknown | not_implemented |
-| `exporter` | supported | unknown | supported | unknown | not_implemented |
-| `producers` | supported | unknown | not_implemented | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cardinality_limits` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `exporter` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `producers` | supported | unknown | not_implemented | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -3063,12 +3063,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `console` | supported | unknown | supported | unknown | supported |
-| `otlp_grpc` | supported | unknown | supported | unknown | supported |
-| `otlp_http` | supported | unknown | supported | unknown | supported |
-| `otlp_file/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `console` | supported | unknown | supported | unknown | supported | unknown |
+| `otlp_grpc` | supported | unknown | supported | unknown | supported | unknown |
+| `otlp_http` | supported | unknown | supported | unknown | supported | unknown |
+| `otlp_file/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3157,12 +3157,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attributes` | supported | unknown | supported | unknown | supported |
-| `attributes_list` | supported | unknown | supported | unknown | supported |
-| `schema_url` | supported | unknown | supported | unknown | supported |
-| `detection/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attributes` | supported | unknown | supported | unknown | supported | unknown |
+| `attributes_list` | supported | unknown | supported | unknown | supported | unknown |
+| `schema_url` | supported | unknown | supported | unknown | supported | unknown |
+| `detection/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3278,15 +3278,15 @@ schema_url: https://opentelemetry.io/schemas/1.16.0
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `always_off` | supported | supported | supported | unknown | supported |
-| `always_on` | supported | supported | supported | unknown | supported |
-| `parent_based` | supported | supported | supported | unknown | supported |
-| `trace_id_ratio_based` | supported | supported | supported | unknown | supported |
-| `composite/development` | supported | not_implemented | supported | unknown | not_implemented |
-| `jaeger_remote/development` | supported | not_implemented | supported | unknown | not_implemented |
-| `probability/development` | supported | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `always_off` | supported | supported | supported | unknown | supported | unknown |
+| `always_on` | supported | supported | supported | unknown | supported | unknown |
+| `parent_based` | supported | supported | supported | unknown | supported | unknown |
+| `trace_id_ratio_based` | supported | supported | supported | unknown | supported | unknown |
+| `composite/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `jaeger_remote/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `probability/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -3502,32 +3502,32 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `debug` | supported | unknown | supported | unknown | supported |
-| `debug2` | supported | unknown | supported | unknown | supported |
-| `debug3` | supported | unknown | supported | unknown | supported |
-| `debug4` | supported | unknown | supported | unknown | supported |
-| `error` | supported | unknown | supported | unknown | supported |
-| `error2` | supported | unknown | supported | unknown | supported |
-| `error3` | supported | unknown | supported | unknown | supported |
-| `error4` | supported | unknown | supported | unknown | supported |
-| `fatal` | supported | unknown | supported | unknown | supported |
-| `fatal2` | supported | unknown | supported | unknown | supported |
-| `fatal3` | supported | unknown | supported | unknown | supported |
-| `fatal4` | supported | unknown | supported | unknown | supported |
-| `info` | supported | unknown | supported | unknown | supported |
-| `info2` | supported | unknown | supported | unknown | supported |
-| `info3` | supported | unknown | supported | unknown | supported |
-| `info4` | supported | unknown | supported | unknown | supported |
-| `trace` | supported | unknown | supported | unknown | supported |
-| `trace2` | supported | unknown | supported | unknown | supported |
-| `trace3` | supported | unknown | supported | unknown | supported |
-| `trace4` | supported | unknown | supported | unknown | supported |
-| `warn` | supported | unknown | supported | unknown | supported |
-| `warn2` | supported | unknown | supported | unknown | supported |
-| `warn3` | supported | unknown | supported | unknown | supported |
-| `warn4` | supported | unknown | supported | unknown | supported |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `debug` | supported | unknown | supported | unknown | supported | unknown |
+| `debug2` | supported | unknown | supported | unknown | supported | unknown |
+| `debug3` | supported | unknown | supported | unknown | supported | unknown |
+| `debug4` | supported | unknown | supported | unknown | supported | unknown |
+| `error` | supported | unknown | supported | unknown | supported | unknown |
+| `error2` | supported | unknown | supported | unknown | supported | unknown |
+| `error3` | supported | unknown | supported | unknown | supported | unknown |
+| `error4` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal2` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal3` | supported | unknown | supported | unknown | supported | unknown |
+| `fatal4` | supported | unknown | supported | unknown | supported | unknown |
+| `info` | supported | unknown | supported | unknown | supported | unknown |
+| `info2` | supported | unknown | supported | unknown | supported | unknown |
+| `info3` | supported | unknown | supported | unknown | supported | unknown |
+| `info4` | supported | unknown | supported | unknown | supported | unknown |
+| `trace` | supported | unknown | supported | unknown | supported | unknown |
+| `trace2` | supported | unknown | supported | unknown | supported | unknown |
+| `trace3` | supported | unknown | supported | unknown | supported | unknown |
+| `trace4` | supported | unknown | supported | unknown | supported | unknown |
+| `warn` | supported | unknown | supported | unknown | supported | unknown |
+| `warn2` | supported | unknown | supported | unknown | supported | unknown |
+| `warn3` | supported | unknown | supported | unknown | supported | unknown |
+| `warn4` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 No constraints.
@@ -3586,9 +3586,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `exporter` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `exporter` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3630,9 +3630,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `exporter` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `exporter` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3679,12 +3679,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `console` | supported | supported | supported | unknown | supported |
-| `otlp_grpc` | supported | supported | supported | unknown | supported |
-| `otlp_http` | supported | supported | supported | unknown | supported |
-| `otlp_file/development` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `console` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_grpc` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_http` | supported | supported | supported | unknown | supported | unknown |
+| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3750,13 +3750,13 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `client` | not_implemented | unknown | supported | unknown | not_implemented |
-| `consumer` | not_implemented | unknown | supported | unknown | not_implemented |
-| `internal` | not_implemented | unknown | supported | unknown | not_implemented |
-| `producer` | not_implemented | unknown | supported | unknown | not_implemented |
-| `server` | not_implemented | unknown | supported | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `client` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `consumer` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `internal` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `producer` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `server` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -3800,14 +3800,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | unknown | supported | unknown | supported |
-| `attribute_value_length_limit` | supported | unknown | supported | unknown | supported |
-| `event_attribute_count_limit` | supported | unknown | supported | unknown | supported |
-| `event_count_limit` | supported | unknown | supported | unknown | supported |
-| `link_attribute_count_limit` | supported | unknown | supported | unknown | supported |
-| `link_count_limit` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `attribute_value_length_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `event_attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `event_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `link_attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `link_count_limit` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3907,10 +3907,10 @@ link_count_limit: 128
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `batch` | supported | supported | supported | unknown | supported |
-| `simple` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `batch` | supported | supported | supported | unknown | supported | unknown |
+| `simple` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -3993,12 +3993,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `b3` | supported | supported | supported | unknown | supported |
-| `b3multi` | supported | supported | supported | unknown | supported |
-| `baggage` | supported | supported | supported | unknown | supported |
-| `tracecontext` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `b3` | supported | supported | supported | unknown | supported | unknown |
+| `b3multi` | supported | supported | supported | unknown | supported | unknown |
+| `baggage` | supported | supported | supported | unknown | supported | unknown |
+| `tracecontext` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4084,9 +4084,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ratio` | supported | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ratio` | supported | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4136,13 +4136,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `id_generator` | supported | unknown | supported | unknown | supported |
-| `limits` | supported | unknown | supported | unknown | supported |
-| `processors` | supported | unknown | supported | unknown | supported |
-| `sampler` | supported | unknown | supported | unknown | supported |
-| `tracer_configurator/development` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `id_generator` | supported | unknown | supported | unknown | supported | unknown |
+| `limits` | supported | unknown | supported | unknown | supported | unknown |
+| `processors` | supported | unknown | supported | unknown | supported | unknown |
+| `sampler` | supported | unknown | supported | unknown | supported | unknown |
+| `tracer_configurator/development` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4205,10 +4205,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `selector` | supported | unknown | supported | unknown | supported |
-| `stream` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `selector` | supported | unknown | supported | unknown | supported | unknown |
+| `stream` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4322,14 +4322,14 @@ stream:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `instrument_name` | supported | unknown | supported | unknown | supported |
-| `instrument_type` | supported | unknown | supported | unknown | supported |
-| `meter_name` | supported | unknown | supported | unknown | supported |
-| `meter_schema_url` | supported | unknown | supported | unknown | supported |
-| `meter_version` | supported | unknown | supported | unknown | supported |
-| `unit` | supported | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `instrument_name` | supported | unknown | supported | unknown | supported | unknown |
+| `instrument_type` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_name` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_schema_url` | supported | unknown | supported | unknown | supported | unknown |
+| `meter_version` | supported | unknown | supported | unknown | supported | unknown |
+| `unit` | supported | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4406,13 +4406,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `aggregation` | supported | unknown | supported | unknown | ignored |
-| `aggregation_cardinality_limit` | supported | unknown | supported | unknown | not_implemented |
-| `attribute_keys` | supported | unknown | supported | unknown | supported |
-| `description` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `aggregation` | supported | unknown | supported | unknown | ignored | unknown |
+| `aggregation_cardinality_limit` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `attribute_keys` | supported | unknown | supported | unknown | supported | unknown |
+| `description` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -4481,9 +4481,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -4584,9 +4584,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `root` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `root` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4633,9 +4633,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ratio` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4684,9 +4684,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `rules` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `rules` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4738,13 +4738,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attribute_patterns` | ignored | not_implemented | supported | unknown | not_implemented |
-| `attribute_values` | ignored | not_implemented | supported | unknown | not_implemented |
-| `parent` | ignored | not_implemented | supported | unknown | not_implemented |
-| `sampler` | ignored | not_implemented | supported | unknown | not_implemented |
-| `span_kinds` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attribute_patterns` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `attribute_values` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `parent` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `sampler` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `span_kinds` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4816,11 +4816,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `excluded` | ignored | not_implemented | supported | unknown | not_implemented |
-| `included` | ignored | not_implemented | supported | unknown | not_implemented |
-| `key` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `excluded` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `included` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `key` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4882,10 +4882,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `key` | ignored | not_implemented | supported | unknown | not_implemented |
-| `values` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `key` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `values` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -4943,13 +4943,13 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `always_off` | ignored | not_implemented | supported | unknown | not_implemented |
-| `always_on` | ignored | not_implemented | supported | unknown | not_implemented |
-| `parent_threshold` | ignored | not_implemented | supported | unknown | not_implemented |
-| `probability` | ignored | not_implemented | supported | unknown | not_implemented |
-| `rule_based` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `always_off` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `always_on` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `parent_threshold` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `probability` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `rule_based` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -5047,9 +5047,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -5120,9 +5120,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -5170,16 +5170,16 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `code` | not_applicable | not_implemented | supported | unknown | supported |
-| `db` | not_applicable | not_implemented | supported | unknown | supported |
-| `gen_ai` | not_applicable | not_implemented | supported | unknown | supported |
-| `http` | not_applicable | not_implemented | supported | unknown | supported |
-| `messaging` | not_applicable | not_implemented | supported | unknown | supported |
-| `rpc` | not_applicable | not_implemented | supported | unknown | supported |
-| `sanitization` | not_applicable | not_implemented | supported | unknown | supported |
-| `stability_opt_in_list` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `code` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `db` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `gen_ai` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `http` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `messaging` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `rpc` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `sanitization` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `stability_opt_in_list` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5305,11 +5305,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `known_methods` | not_applicable | not_implemented | supported | unknown | supported |
-| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
-| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5372,11 +5372,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `client` | not_applicable | not_implemented | supported | unknown | supported |
-| `semconv` | not_applicable | not_implemented | supported | unknown | supported |
-| `server` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `client` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `semconv` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `server` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5427,11 +5427,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `known_methods` | not_applicable | not_implemented | supported | unknown | supported |
-| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
-| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5503,20 +5503,20 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `cpp` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `dotnet` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `erlang` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `general` | not_applicable | not_implemented | supported | unknown | supported |
-| `go` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `java` | not_applicable | not_implemented | supported | unknown | not_applicable |
-| `js` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `php` | not_applicable | not_implemented | not_applicable | unknown | supported |
-| `python` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `ruby` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `rust` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
-| `swift` | not_applicable | not_implemented | not_applicable | unknown | not_applicable |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `cpp` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `dotnet` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `erlang` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `general` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `go` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `java` | not_applicable | not_implemented | supported | unknown | not_applicable | unknown |
+| `js` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `php` | not_applicable | not_implemented | not_applicable | unknown | supported | unknown |
+| `python` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `ruby` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `rust` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `swift` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
 </details>
 
 Constraints: 
@@ -5708,11 +5708,11 @@ swift:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `endpoint` | not_implemented | not_implemented | supported | unknown | not_implemented |
-| `initial_sampler` | not_implemented | not_implemented | supported | unknown | not_implemented |
-| `interval` | not_implemented | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `endpoint` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
+| `initial_sampler` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
+| `interval` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -5816,11 +5816,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `enabled` | not_implemented | unknown | supported | unknown | supported |
-| `minimum_severity` | not_implemented | unknown | supported | unknown | not_implemented |
-| `trace_based` | not_implemented | unknown | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `enabled` | not_implemented | unknown | supported | unknown | supported | unknown |
+| `minimum_severity` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `trace_based` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -5879,10 +5879,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported |
-| `loggers` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
+| `loggers` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -5950,10 +5950,10 @@ loggers:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `config` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6007,9 +6007,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6050,9 +6050,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `enabled` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `enabled` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6099,10 +6099,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported |
-| `meters` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
+| `meters` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6168,10 +6168,10 @@ meters:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `config` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6225,9 +6225,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `output_stream` | supported | not_implemented | not_implemented | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6313,11 +6313,11 @@ output_stream: stdout
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented |
-| `output_stream` | supported | not_implemented | not_implemented | unknown | supported |
-| `temporality_preference` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `temporality_preference` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6394,9 +6394,9 @@ default_histogram_aggregation: explicit_bucket_histogram
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `ratio` | ignored | not_implemented | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -6480,14 +6480,14 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `host` | supported | supported | supported | unknown | not_implemented |
-| `port` | supported | supported | supported | unknown | not_implemented |
-| `resource_constant_labels` | supported | supported | supported | unknown | not_implemented |
-| `scope_info_enabled` | supported | supported | supported | unknown | not_implemented |
-| `translation_strategy` | supported | supported | not_implemented | unknown | not_implemented |
-| `target_info_enabled/development` | supported | supported | supported | unknown | not_implemented |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `host` | supported | supported | supported | unknown | not_implemented | unknown |
+| `port` | supported | supported | supported | unknown | not_implemented | unknown |
+| `resource_constant_labels` | supported | supported | supported | unknown | not_implemented | unknown |
+| `scope_info_enabled` | supported | supported | supported | unknown | not_implemented | unknown |
+| `translation_strategy` | supported | supported | not_implemented | unknown | not_implemented | unknown |
+| `target_info_enabled/development` | supported | supported | supported | unknown | not_implemented | unknown |
 </details>
 
 Constraints: 
@@ -6586,12 +6586,12 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `no_translation/development` | not_implemented | supported | not_implemented | unknown | not_implemented |
-| `no_utf8_escaping_with_suffixes/development` | not_implemented | supported | not_implemented | unknown | not_implemented |
-| `underscore_escaping_with_suffixes` | supported | supported | not_implemented | unknown | not_implemented |
-| `underscore_escaping_without_suffixes/development` | supported | supported | not_implemented | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `no_translation/development` | not_implemented | supported | not_implemented | unknown | not_implemented | unknown |
+| `no_utf8_escaping_with_suffixes/development` | not_implemented | supported | not_implemented | unknown | not_implemented | unknown |
+| `underscore_escaping_with_suffixes` | supported | supported | not_implemented | unknown | not_implemented | unknown |
+| `underscore_escaping_without_suffixes/development` | supported | supported | not_implemented | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -6633,10 +6633,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `attributes` | not_implemented | supported | supported | unknown | supported |
-| `detectors` | not_implemented | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `attributes` | not_implemented | supported | supported | unknown | supported | unknown |
+| `detectors` | not_implemented | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6690,12 +6690,12 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `container` | not_implemented | supported | supported | unknown | ignored |
-| `host` | not_implemented | supported | supported | unknown | supported |
-| `process` | not_implemented | supported | supported | unknown | supported |
-| `service` | not_implemented | supported | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `container` | not_implemented | supported | supported | unknown | ignored | unknown |
+| `host` | not_implemented | supported | supported | unknown | supported | unknown |
+| `process` | not_implemented | supported | supported | unknown | supported | unknown |
+| `service` | not_implemented | supported | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -6757,9 +6757,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6800,9 +6800,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `url` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `url` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6845,11 +6845,11 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `dual_emit` | unknown | unknown | unknown | unknown | unknown |
-| `experimental` | unknown | unknown | unknown | unknown | unknown |
-| `version` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `dual_emit` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `experimental` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `version` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 
@@ -6947,11 +6947,11 @@ This is a enum type.
 <details>
 <summary>Language support status</summary>
 
-| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `local` | not_implemented | unknown | supported | unknown | not_implemented |
-| `none` | not_implemented | unknown | supported | unknown | not_implemented |
-| `remote` | not_implemented | unknown | supported | unknown | not_implemented |
+| Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `local` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `none` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `remote` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
 </details>
 
 No constraints.
@@ -6991,9 +6991,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `enabled` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `enabled` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -7040,10 +7040,10 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported |
-| `tracers` | supported | not_implemented | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
+| `tracers` | supported | not_implemented | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -7109,10 +7109,10 @@ tracers:
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported |
-| `name` | supported | unknown | supported | unknown | supported |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `config` | supported | unknown | supported | unknown | supported | unknown |
+| `name` | supported | unknown | supported | unknown | supported | unknown |
 </details>
 
 Constraints: 
@@ -7166,9 +7166,9 @@ No snippets.
 <details>
 <summary>Language support status</summary>
 
-| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
-|---|---|---|---|---|---|
-| `sensitive_query_parameters` | unknown | unknown | unknown | unknown | unknown |
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
+|---|---|---|---|---|---|---|
+| `sensitive_query_parameters` | unknown | unknown | unknown | unknown | unknown | unknown |
 </details>
 
 Constraints: 

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -29,12 +29,12 @@ See also [language support status](language-support-status.md) for all details a
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
-| `default` | supported | unknown | supported | unknown | ignored | unknown |
-| `drop` | supported | unknown | supported | unknown | ignored | unknown |
-| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
-| `last_value` | supported | unknown | supported | unknown | ignored | unknown |
-| `sum` | supported | unknown | supported | unknown | ignored | unknown |
+| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | supported |
+| `default` | supported | unknown | supported | unknown | ignored | supported |
+| `drop` | supported | unknown | supported | unknown | ignored | supported |
+| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | supported |
+| `last_value` | supported | unknown | supported | unknown | ignored | supported |
+| `sum` | supported | unknown | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -153,8 +153,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | supported | supported | unknown | supported | unknown |
-| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | unknown |
+| `attribute_count_limit` | supported | supported | supported | unknown | supported | ignored |
+| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -208,9 +208,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `name` | supported | supported | supported | unknown | supported | unknown |
-| `type` | supported | supported | supported | unknown | not_implemented | unknown |
-| `value` | supported | supported | supported | unknown | supported | unknown |
+| `name` | supported | supported | supported | unknown | supported | supported |
+| `type` | supported | supported | supported | unknown | not_implemented | supported |
+| `value` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -306,14 +306,14 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `bool` | supported | supported | supported | unknown | not_implemented | unknown |
-| `bool_array` | supported | supported | supported | unknown | not_implemented | unknown |
-| `double` | supported | supported | supported | unknown | not_implemented | unknown |
-| `double_array` | supported | supported | supported | unknown | not_implemented | unknown |
-| `int` | supported | supported | supported | unknown | not_implemented | unknown |
-| `int_array` | supported | supported | supported | unknown | not_implemented | unknown |
-| `string` | supported | supported | supported | unknown | not_implemented | unknown |
-| `string_array` | supported | supported | supported | unknown | not_implemented | unknown |
+| `bool` | supported | supported | supported | unknown | not_implemented | supported |
+| `bool_array` | supported | supported | supported | unknown | not_implemented | supported |
+| `double` | supported | supported | supported | unknown | not_implemented | supported |
+| `double_array` | supported | supported | supported | unknown | not_implemented | supported |
+| `int` | supported | supported | supported | unknown | not_implemented | supported |
+| `int_array` | supported | supported | supported | unknown | not_implemented | supported |
+| `string` | supported | supported | supported | unknown | not_implemented | supported |
+| `string_array` | supported | supported | supported | unknown | not_implemented | supported |
 </details>
 
 No constraints.
@@ -440,9 +440,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `max_scale` | supported | unknown | supported | unknown | not_implemented | unknown |
-| `max_size` | supported | unknown | supported | unknown | not_implemented | unknown |
-| `record_min_max` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `max_scale` | supported | unknown | supported | unknown | not_implemented | supported |
+| `max_size` | supported | unknown | supported | unknown | not_implemented | supported |
+| `record_min_max` | supported | unknown | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -509,11 +509,11 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `export_timeout` | supported | supported | supported | unknown | supported | unknown |
-| `exporter` | supported | supported | supported | unknown | supported | unknown |
-| `max_export_batch_size` | supported | supported | supported | unknown | supported | unknown |
-| `max_queue_size` | supported | supported | supported | unknown | supported | unknown |
-| `schedule_delay` | supported | supported | supported | unknown | supported | unknown |
+| `export_timeout` | supported | supported | supported | unknown | supported | supported |
+| `exporter` | supported | supported | supported | unknown | supported | supported |
+| `max_export_batch_size` | supported | supported | supported | unknown | supported | supported |
+| `max_queue_size` | supported | supported | supported | unknown | supported | supported |
+| `schedule_delay` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -593,11 +593,11 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `export_timeout` | supported | supported | supported | unknown | supported | unknown |
-| `exporter` | supported | supported | supported | unknown | supported | unknown |
-| `max_export_batch_size` | supported | supported | supported | unknown | supported | unknown |
-| `max_queue_size` | supported | supported | supported | unknown | supported | unknown |
-| `schedule_delay` | supported | supported | supported | unknown | supported | unknown |
+| `export_timeout` | supported | supported | supported | unknown | supported | supported |
+| `exporter` | supported | supported | supported | unknown | supported | supported |
+| `max_export_batch_size` | supported | supported | supported | unknown | supported | supported |
+| `max_queue_size` | supported | supported | supported | unknown | supported | supported |
+| `schedule_delay` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -680,14 +680,14 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
-| `default` | ignored | unknown | supported | unknown | not_implemented | unknown |
-| `gauge` | ignored | unknown | supported | unknown | not_implemented | unknown |
-| `histogram` | ignored | unknown | supported | unknown | not_implemented | unknown |
-| `observable_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
-| `observable_gauge` | ignored | unknown | supported | unknown | not_implemented | unknown |
-| `observable_up_down_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
-| `up_down_counter` | ignored | unknown | supported | unknown | not_implemented | unknown |
+| `counter` | ignored | unknown | supported | unknown | not_implemented | supported |
+| `default` | ignored | unknown | supported | unknown | not_implemented | supported |
+| `gauge` | ignored | unknown | supported | unknown | not_implemented | supported |
+| `histogram` | ignored | unknown | supported | unknown | not_implemented | supported |
+| `observable_counter` | ignored | unknown | supported | unknown | not_implemented | supported |
+| `observable_gauge` | ignored | unknown | supported | unknown | not_implemented | supported |
+| `observable_up_down_counter` | ignored | unknown | supported | unknown | not_implemented | supported |
+| `up_down_counter` | ignored | unknown | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -852,8 +852,8 @@ Snippets:
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `default_histogram_aggregation` | supported | not_implemented | not_implemented | unknown | not_implemented | unknown |
-| `temporality_preference` | supported | not_implemented | ignored | unknown | ignored | unknown |
+| `default_histogram_aggregation` | supported | not_implemented | not_implemented | unknown | not_implemented | supported |
+| `temporality_preference` | supported | not_implemented | ignored | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -996,9 +996,9 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `always_off` | supported | unknown | supported | unknown | supported | unknown |
-| `always_on` | supported | unknown | supported | unknown | supported | unknown |
-| `trace_based` | supported | unknown | supported | unknown | supported | unknown |
+| `always_off` | supported | unknown | supported | unknown | supported | supported |
+| `always_on` | supported | unknown | supported | unknown | supported | supported |
+| `trace_based` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 No constraints.
@@ -1038,8 +1038,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `boundaries` | supported | unknown | supported | unknown | ignored | unknown |
-| `record_min_max` | supported | unknown | supported | unknown | ignored | unknown |
+| `boundaries` | supported | unknown | supported | unknown | ignored | supported |
+| `record_min_max` | supported | unknown | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -1096,8 +1096,8 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
-| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | unknown |
+| `base2_exponential_bucket_histogram` | supported | unknown | supported | unknown | ignored | supported |
+| `explicit_bucket_histogram` | supported | unknown | supported | unknown | ignored | supported |
 </details>
 
 No constraints.
@@ -1142,9 +1142,9 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `cumulative` | supported | supported | supported | unknown | supported | unknown |
-| `delta` | supported | supported | supported | unknown | supported | unknown |
-| `low_memory` | supported | supported | supported | unknown | supported | unknown |
+| `cumulative` | supported | supported | supported | unknown | supported | supported |
+| `delta` | supported | supported | supported | unknown | supported | supported |
+| `low_memory` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 No constraints.
@@ -1189,10 +1189,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `ca_file` | supported | supported | supported | unknown | ignored | unknown |
-| `cert_file` | supported | supported | supported | unknown | ignored | unknown |
-| `insecure` | supported | supported | not_implemented | unknown | ignored | unknown |
-| `key_file` | supported | supported | supported | unknown | ignored | unknown |
+| `ca_file` | supported | supported | supported | unknown | ignored | supported |
+| `cert_file` | supported | supported | supported | unknown | ignored | supported |
+| `insecure` | supported | supported | not_implemented | unknown | ignored | supported |
+| `key_file` | supported | supported | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -1262,9 +1262,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `ca_file` | supported | supported | supported | unknown | ignored | unknown |
-| `cert_file` | supported | supported | supported | unknown | ignored | unknown |
-| `key_file` | supported | supported | supported | unknown | ignored | unknown |
+| `ca_file` | supported | supported | supported | unknown | ignored | supported |
+| `cert_file` | supported | supported | supported | unknown | ignored | supported |
+| `key_file` | supported | supported | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -1327,7 +1327,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `random` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `random` | unknown | unknown | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -1388,8 +1388,8 @@ my_custom_id_generator:
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `excluded` | supported | supported | supported | unknown | supported | unknown |
-| `included` | supported | supported | supported | unknown | supported | unknown |
+| `excluded` | supported | supported | supported | unknown | supported | supported |
+| `included` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -1451,13 +1451,13 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `counter` | supported | supported | supported | unknown | supported | unknown |
-| `gauge` | supported | supported | supported | unknown | supported | unknown |
-| `histogram` | supported | supported | supported | unknown | supported | unknown |
-| `observable_counter` | supported | supported | supported | unknown | supported | unknown |
-| `observable_gauge` | supported | supported | supported | unknown | supported | unknown |
-| `observable_up_down_counter` | supported | supported | supported | unknown | supported | unknown |
-| `up_down_counter` | supported | supported | supported | unknown | supported | unknown |
+| `counter` | supported | supported | supported | unknown | supported | supported |
+| `gauge` | supported | supported | supported | unknown | supported | supported |
+| `histogram` | supported | supported | supported | unknown | supported | supported |
+| `observable_counter` | supported | supported | supported | unknown | supported | supported |
+| `observable_gauge` | supported | supported | supported | unknown | supported | supported |
+| `observable_up_down_counter` | supported | supported | supported | unknown | supported | supported |
+| `up_down_counter` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 No constraints.
@@ -1529,9 +1529,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `limits` | supported | supported | supported | unknown | supported | unknown |
-| `processors` | supported | supported | supported | unknown | supported | unknown |
-| `logger_configurator/development` | supported | not_implemented | supported | unknown | supported | unknown |
+| `limits` | supported | supported | supported | unknown | supported | supported |
+| `processors` | supported | supported | supported | unknown | supported | supported |
+| `logger_configurator/development` | supported | not_implemented | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -1592,10 +1592,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `console` | supported | supported | supported | unknown | supported | unknown |
-| `otlp_grpc` | supported | supported | supported | unknown | supported | unknown |
-| `otlp_http` | supported | supported | supported | unknown | supported | unknown |
-| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | unknown |
+| `console` | supported | supported | supported | unknown | supported | supported |
+| `otlp_grpc` | supported | supported | supported | unknown | supported | supported |
+| `otlp_http` | supported | supported | supported | unknown | supported | supported |
+| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -1658,8 +1658,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | supported | supported | unknown | supported | unknown |
-| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | unknown |
+| `attribute_count_limit` | supported | supported | supported | unknown | supported | ignored |
+| `attribute_value_length_limit` | supported | supported | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -1726,9 +1726,9 @@ attribute_value_length_limit: 4096
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `batch` | supported | supported | supported | unknown | supported | unknown |
-| `simple` | supported | supported | supported | unknown | supported | unknown |
-| `event_to_span_event_bridge/development` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `batch` | supported | supported | supported | unknown | supported | supported |
+| `simple` | supported | supported | supported | unknown | supported | supported |
+| `event_to_span_event_bridge/development` | unknown | unknown | unknown | unknown | unknown | supported |
 </details>
 
 Constraints: 
@@ -1788,10 +1788,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `exemplar_filter` | supported | supported | supported | unknown | supported | unknown |
-| `readers` | supported | supported | supported | unknown | supported | unknown |
-| `views` | supported | supported | supported | unknown | supported | unknown |
-| `meter_configurator/development` | supported | supported | supported | unknown | supported | unknown |
+| `exemplar_filter` | supported | supported | supported | unknown | supported | supported |
+| `readers` | supported | supported | supported | unknown | supported | supported |
+| `views` | supported | supported | supported | unknown | supported | supported |
+| `meter_configurator/development` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -1857,7 +1857,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `opencensus` | supported | unknown | ignored | unknown | not_implemented | unknown |
+| `opencensus` | supported | unknown | ignored | unknown | not_implemented | ignored |
 </details>
 
 Constraints: 
@@ -1909,8 +1909,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `periodic` | supported | unknown | supported | unknown | supported | unknown |
-| `pull` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `periodic` | supported | unknown | supported | unknown | supported | supported |
+| `pull` | supported | unknown | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -1959,8 +1959,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `name` | supported | supported | supported | unknown | supported | unknown |
-| `value` | supported | supported | supported | unknown | supported | unknown |
+| `name` | supported | supported | supported | unknown | supported | supported |
+| `value` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -2054,17 +2054,17 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `attribute_limits` | supported | unknown | supported | unknown | supported | unknown |
-| `disabled` | supported | unknown | supported | unknown | supported | unknown |
-| `distribution` | supported | unknown | supported | unknown | not_implemented | unknown |
-| `file_format` | supported | unknown | supported | unknown | supported | unknown |
-| `log_level` | supported | unknown | not_implemented | unknown | not_implemented | unknown |
-| `logger_provider` | supported | unknown | supported | unknown | supported | unknown |
-| `meter_provider` | supported | unknown | supported | unknown | supported | unknown |
-| `propagator` | supported | unknown | supported | unknown | supported | unknown |
-| `resource` | supported | unknown | supported | unknown | supported | unknown |
-| `tracer_provider` | supported | unknown | supported | unknown | supported | unknown |
-| `instrumentation/development` | supported | unknown | supported | unknown | supported | unknown |
+| `attribute_limits` | supported | unknown | supported | unknown | supported | supported |
+| `disabled` | supported | unknown | supported | unknown | supported | supported |
+| `distribution` | supported | unknown | supported | unknown | not_implemented | supported |
+| `file_format` | supported | unknown | supported | unknown | supported | supported |
+| `log_level` | supported | unknown | not_implemented | unknown | not_implemented | supported |
+| `logger_provider` | supported | unknown | supported | unknown | supported | supported |
+| `meter_provider` | supported | unknown | supported | unknown | supported | supported |
+| `propagator` | supported | unknown | supported | unknown | supported | supported |
+| `resource` | supported | unknown | supported | unknown | supported | supported |
+| `tracer_provider` | supported | unknown | supported | unknown | supported | supported |
+| `instrumentation/development` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -2156,12 +2156,12 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported | unknown |
-| `endpoint` | supported | supported | supported | unknown | supported | unknown |
-| `headers` | supported | supported | supported | unknown | supported | unknown |
-| `headers_list` | supported | supported | supported | unknown | supported | unknown |
-| `timeout` | supported | supported | supported | unknown | supported | unknown |
-| `tls` | supported | supported | supported | unknown | ignored | unknown |
+| `compression` | supported | supported | supported | unknown | supported | supported |
+| `endpoint` | supported | supported | supported | unknown | supported | supported |
+| `headers` | supported | supported | supported | unknown | supported | supported |
+| `headers_list` | supported | supported | supported | unknown | supported | supported |
+| `timeout` | supported | supported | supported | unknown | supported | supported |
+| `tls` | supported | supported | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -2289,14 +2289,14 @@ timeout: 10000
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported | unknown |
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
-| `endpoint` | supported | supported | supported | unknown | supported | unknown |
-| `headers` | supported | supported | supported | unknown | supported | unknown |
-| `headers_list` | supported | supported | supported | unknown | supported | unknown |
-| `temporality_preference` | supported | supported | supported | unknown | supported | unknown |
-| `timeout` | supported | supported | supported | unknown | supported | unknown |
-| `tls` | supported | supported | supported | unknown | ignored | unknown |
+| `compression` | supported | supported | supported | unknown | supported | supported |
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | supported |
+| `endpoint` | supported | supported | supported | unknown | supported | supported |
+| `headers` | supported | supported | supported | unknown | supported | supported |
+| `headers_list` | supported | supported | supported | unknown | supported | supported |
+| `temporality_preference` | supported | supported | supported | unknown | supported | supported |
+| `timeout` | supported | supported | supported | unknown | supported | supported |
+| `tls` | supported | supported | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -2407,8 +2407,8 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `json` | supported | not_implemented | not_implemented | unknown | supported | unknown |
-| `protobuf` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `json` | supported | not_implemented | not_implemented | unknown | supported | supported |
+| `protobuf` | supported | not_implemented | not_implemented | unknown | supported | supported |
 </details>
 
 No constraints.
@@ -2453,13 +2453,13 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported | unknown |
-| `encoding` | supported | not_implemented | not_implemented | unknown | supported | unknown |
-| `endpoint` | supported | supported | supported | unknown | supported | unknown |
-| `headers` | supported | supported | supported | unknown | supported | unknown |
-| `headers_list` | supported | supported | supported | unknown | supported | unknown |
-| `timeout` | supported | supported | supported | unknown | supported | unknown |
-| `tls` | supported | supported | supported | unknown | ignored | unknown |
+| `compression` | supported | supported | supported | unknown | supported | supported |
+| `encoding` | supported | not_implemented | not_implemented | unknown | supported | supported |
+| `endpoint` | supported | supported | supported | unknown | supported | supported |
+| `headers` | supported | supported | supported | unknown | supported | supported |
+| `headers_list` | supported | supported | supported | unknown | supported | supported |
+| `timeout` | supported | supported | supported | unknown | supported | supported |
+| `tls` | supported | supported | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -2592,15 +2592,15 @@ encoding: protobuf
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `compression` | supported | supported | supported | unknown | supported | unknown |
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
-| `encoding` | supported | not_implemented | not_implemented | unknown | supported | unknown |
-| `endpoint` | supported | supported | supported | unknown | supported | unknown |
-| `headers` | supported | supported | supported | unknown | supported | unknown |
-| `headers_list` | supported | supported | supported | unknown | supported | unknown |
-| `temporality_preference` | supported | supported | supported | unknown | supported | unknown |
-| `timeout` | supported | supported | supported | unknown | supported | unknown |
-| `tls` | supported | supported | supported | unknown | ignored | unknown |
+| `compression` | supported | supported | supported | unknown | supported | supported |
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | supported |
+| `encoding` | supported | not_implemented | not_implemented | unknown | supported | supported |
+| `endpoint` | supported | supported | supported | unknown | supported | supported |
+| `headers` | supported | supported | supported | unknown | supported | supported |
+| `headers_list` | supported | supported | supported | unknown | supported | supported |
+| `temporality_preference` | supported | supported | supported | unknown | supported | supported |
+| `timeout` | supported | supported | supported | unknown | supported | supported |
+| `tls` | supported | supported | supported | unknown | ignored | supported |
 </details>
 
 Constraints: 
@@ -2728,11 +2728,11 @@ default_histogram_aggregation: base2_exponential_bucket_histogram
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `local_parent_not_sampled` | supported | supported | supported | unknown | supported | unknown |
-| `local_parent_sampled` | supported | supported | supported | unknown | supported | unknown |
-| `remote_parent_not_sampled` | supported | supported | supported | unknown | supported | unknown |
-| `remote_parent_sampled` | supported | supported | supported | unknown | supported | unknown |
-| `root` | supported | supported | supported | unknown | supported | unknown |
+| `local_parent_not_sampled` | supported | supported | supported | unknown | supported | supported |
+| `local_parent_sampled` | supported | supported | supported | unknown | supported | supported |
+| `remote_parent_not_sampled` | supported | supported | supported | unknown | supported | supported |
+| `remote_parent_sampled` | supported | supported | supported | unknown | supported | supported |
+| `root` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -2796,12 +2796,12 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `cardinality_limits` | supported | not_implemented | supported | unknown | supported | unknown |
-| `exporter` | supported | supported | supported | unknown | supported | unknown |
-| `interval` | supported | supported | supported | unknown | not_implemented | unknown |
-| `producers` | supported | not_implemented | not_implemented | unknown | not_implemented | unknown |
-| `timeout` | supported | supported | supported | unknown | supported | unknown |
-| `max_export_batch_size/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented | unknown |
+| `cardinality_limits` | supported | not_implemented | supported | unknown | supported | supported |
+| `exporter` | supported | supported | supported | unknown | supported | supported |
+| `interval` | supported | supported | supported | unknown | not_implemented | supported |
+| `producers` | supported | not_implemented | not_implemented | unknown | not_implemented | supported |
+| `timeout` | supported | supported | supported | unknown | supported | supported |
+| `max_export_batch_size/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -2882,8 +2882,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `composite` | supported | supported | supported | unknown | supported | unknown |
-| `composite_list` | supported | supported | supported | unknown | supported | unknown |
+| `composite` | supported | supported | supported | unknown | supported | supported |
+| `composite_list` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -2951,7 +2951,7 @@ composite_list: "xray"
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `prometheus/development` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `prometheus/development` | supported | unknown | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -3002,9 +3002,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `cardinality_limits` | supported | unknown | supported | unknown | not_implemented | unknown |
-| `exporter` | supported | unknown | supported | unknown | not_implemented | unknown |
-| `producers` | supported | unknown | not_implemented | unknown | not_implemented | unknown |
+| `cardinality_limits` | supported | unknown | supported | unknown | not_implemented | supported |
+| `exporter` | supported | unknown | supported | unknown | not_implemented | supported |
+| `producers` | supported | unknown | not_implemented | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -3065,10 +3065,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `console` | supported | unknown | supported | unknown | supported | unknown |
-| `otlp_grpc` | supported | unknown | supported | unknown | supported | unknown |
-| `otlp_http` | supported | unknown | supported | unknown | supported | unknown |
-| `otlp_file/development` | supported | unknown | supported | unknown | supported | unknown |
+| `console` | supported | unknown | supported | unknown | supported | supported |
+| `otlp_grpc` | supported | unknown | supported | unknown | supported | supported |
+| `otlp_http` | supported | unknown | supported | unknown | supported | supported |
+| `otlp_file/development` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -3159,10 +3159,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `attributes` | supported | unknown | supported | unknown | supported | unknown |
-| `attributes_list` | supported | unknown | supported | unknown | supported | unknown |
-| `schema_url` | supported | unknown | supported | unknown | supported | unknown |
-| `detection/development` | supported | unknown | supported | unknown | supported | unknown |
+| `attributes` | supported | unknown | supported | unknown | supported | supported |
+| `attributes_list` | supported | unknown | supported | unknown | supported | supported |
+| `schema_url` | supported | unknown | supported | unknown | supported | supported |
+| `detection/development` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -3280,13 +3280,13 @@ schema_url: https://opentelemetry.io/schemas/1.16.0
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `always_off` | supported | supported | supported | unknown | supported | unknown |
-| `always_on` | supported | supported | supported | unknown | supported | unknown |
-| `parent_based` | supported | supported | supported | unknown | supported | unknown |
-| `trace_id_ratio_based` | supported | supported | supported | unknown | supported | unknown |
-| `composite/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
-| `jaeger_remote/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
-| `probability/development` | supported | not_implemented | supported | unknown | not_implemented | unknown |
+| `always_off` | supported | supported | supported | unknown | supported | supported |
+| `always_on` | supported | supported | supported | unknown | supported | supported |
+| `parent_based` | supported | supported | supported | unknown | supported | supported |
+| `trace_id_ratio_based` | supported | supported | supported | unknown | supported | supported |
+| `composite/development` | supported | not_implemented | supported | unknown | not_implemented | supported |
+| `jaeger_remote/development` | supported | not_implemented | supported | unknown | not_implemented | supported |
+| `probability/development` | supported | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -3504,30 +3504,30 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `debug` | supported | unknown | supported | unknown | supported | unknown |
-| `debug2` | supported | unknown | supported | unknown | supported | unknown |
-| `debug3` | supported | unknown | supported | unknown | supported | unknown |
-| `debug4` | supported | unknown | supported | unknown | supported | unknown |
-| `error` | supported | unknown | supported | unknown | supported | unknown |
-| `error2` | supported | unknown | supported | unknown | supported | unknown |
-| `error3` | supported | unknown | supported | unknown | supported | unknown |
-| `error4` | supported | unknown | supported | unknown | supported | unknown |
-| `fatal` | supported | unknown | supported | unknown | supported | unknown |
-| `fatal2` | supported | unknown | supported | unknown | supported | unknown |
-| `fatal3` | supported | unknown | supported | unknown | supported | unknown |
-| `fatal4` | supported | unknown | supported | unknown | supported | unknown |
-| `info` | supported | unknown | supported | unknown | supported | unknown |
-| `info2` | supported | unknown | supported | unknown | supported | unknown |
-| `info3` | supported | unknown | supported | unknown | supported | unknown |
-| `info4` | supported | unknown | supported | unknown | supported | unknown |
-| `trace` | supported | unknown | supported | unknown | supported | unknown |
-| `trace2` | supported | unknown | supported | unknown | supported | unknown |
-| `trace3` | supported | unknown | supported | unknown | supported | unknown |
-| `trace4` | supported | unknown | supported | unknown | supported | unknown |
-| `warn` | supported | unknown | supported | unknown | supported | unknown |
-| `warn2` | supported | unknown | supported | unknown | supported | unknown |
-| `warn3` | supported | unknown | supported | unknown | supported | unknown |
-| `warn4` | supported | unknown | supported | unknown | supported | unknown |
+| `debug` | supported | unknown | supported | unknown | supported | supported |
+| `debug2` | supported | unknown | supported | unknown | supported | supported |
+| `debug3` | supported | unknown | supported | unknown | supported | supported |
+| `debug4` | supported | unknown | supported | unknown | supported | supported |
+| `error` | supported | unknown | supported | unknown | supported | supported |
+| `error2` | supported | unknown | supported | unknown | supported | supported |
+| `error3` | supported | unknown | supported | unknown | supported | supported |
+| `error4` | supported | unknown | supported | unknown | supported | supported |
+| `fatal` | supported | unknown | supported | unknown | supported | supported |
+| `fatal2` | supported | unknown | supported | unknown | supported | supported |
+| `fatal3` | supported | unknown | supported | unknown | supported | supported |
+| `fatal4` | supported | unknown | supported | unknown | supported | supported |
+| `info` | supported | unknown | supported | unknown | supported | supported |
+| `info2` | supported | unknown | supported | unknown | supported | supported |
+| `info3` | supported | unknown | supported | unknown | supported | supported |
+| `info4` | supported | unknown | supported | unknown | supported | supported |
+| `trace` | supported | unknown | supported | unknown | supported | supported |
+| `trace2` | supported | unknown | supported | unknown | supported | supported |
+| `trace3` | supported | unknown | supported | unknown | supported | supported |
+| `trace4` | supported | unknown | supported | unknown | supported | supported |
+| `warn` | supported | unknown | supported | unknown | supported | supported |
+| `warn2` | supported | unknown | supported | unknown | supported | supported |
+| `warn3` | supported | unknown | supported | unknown | supported | supported |
+| `warn4` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 No constraints.
@@ -3588,7 +3588,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `exporter` | supported | unknown | supported | unknown | supported | unknown |
+| `exporter` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -3632,7 +3632,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `exporter` | supported | supported | supported | unknown | supported | unknown |
+| `exporter` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -3681,10 +3681,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `console` | supported | supported | supported | unknown | supported | unknown |
-| `otlp_grpc` | supported | supported | supported | unknown | supported | unknown |
-| `otlp_http` | supported | supported | supported | unknown | supported | unknown |
-| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | unknown |
+| `console` | supported | supported | supported | unknown | supported | supported |
+| `otlp_grpc` | supported | supported | supported | unknown | supported | supported |
+| `otlp_http` | supported | supported | supported | unknown | supported | supported |
+| `otlp_file/development` | supported | not_implemented | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -3752,11 +3752,11 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `client` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
-| `consumer` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
-| `internal` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
-| `producer` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
-| `server` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `client` | not_implemented | unknown | supported | unknown | not_implemented | supported |
+| `consumer` | not_implemented | unknown | supported | unknown | not_implemented | supported |
+| `internal` | not_implemented | unknown | supported | unknown | not_implemented | supported |
+| `producer` | not_implemented | unknown | supported | unknown | not_implemented | supported |
+| `server` | not_implemented | unknown | supported | unknown | not_implemented | supported |
 </details>
 
 No constraints.
@@ -3802,12 +3802,12 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
-| `attribute_value_length_limit` | supported | unknown | supported | unknown | supported | unknown |
-| `event_attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
-| `event_count_limit` | supported | unknown | supported | unknown | supported | unknown |
-| `link_attribute_count_limit` | supported | unknown | supported | unknown | supported | unknown |
-| `link_count_limit` | supported | unknown | supported | unknown | supported | unknown |
+| `attribute_count_limit` | supported | unknown | supported | unknown | supported | supported |
+| `attribute_value_length_limit` | supported | unknown | supported | unknown | supported | supported |
+| `event_attribute_count_limit` | supported | unknown | supported | unknown | supported | supported |
+| `event_count_limit` | supported | unknown | supported | unknown | supported | supported |
+| `link_attribute_count_limit` | supported | unknown | supported | unknown | supported | supported |
+| `link_count_limit` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -3909,8 +3909,8 @@ link_count_limit: 128
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `batch` | supported | supported | supported | unknown | supported | unknown |
-| `simple` | supported | supported | supported | unknown | supported | unknown |
+| `batch` | supported | supported | supported | unknown | supported | supported |
+| `simple` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -3995,10 +3995,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `b3` | supported | supported | supported | unknown | supported | unknown |
-| `b3multi` | supported | supported | supported | unknown | supported | unknown |
-| `baggage` | supported | supported | supported | unknown | supported | unknown |
-| `tracecontext` | supported | supported | supported | unknown | supported | unknown |
+| `b3` | supported | supported | supported | unknown | supported | supported |
+| `b3multi` | supported | supported | supported | unknown | supported | supported |
+| `baggage` | supported | supported | supported | unknown | supported | supported |
+| `tracecontext` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -4086,7 +4086,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `ratio` | supported | supported | supported | unknown | supported | unknown |
+| `ratio` | supported | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -4138,11 +4138,11 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `id_generator` | supported | unknown | supported | unknown | supported | unknown |
-| `limits` | supported | unknown | supported | unknown | supported | unknown |
-| `processors` | supported | unknown | supported | unknown | supported | unknown |
-| `sampler` | supported | unknown | supported | unknown | supported | unknown |
-| `tracer_configurator/development` | supported | unknown | supported | unknown | supported | unknown |
+| `id_generator` | supported | unknown | supported | unknown | supported | supported |
+| `limits` | supported | unknown | supported | unknown | supported | supported |
+| `processors` | supported | unknown | supported | unknown | supported | supported |
+| `sampler` | supported | unknown | supported | unknown | supported | supported |
+| `tracer_configurator/development` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -4207,8 +4207,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `selector` | supported | unknown | supported | unknown | supported | unknown |
-| `stream` | supported | unknown | supported | unknown | supported | unknown |
+| `selector` | supported | unknown | supported | unknown | supported | supported |
+| `stream` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -4324,12 +4324,12 @@ stream:
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `instrument_name` | supported | unknown | supported | unknown | supported | unknown |
-| `instrument_type` | supported | unknown | supported | unknown | supported | unknown |
-| `meter_name` | supported | unknown | supported | unknown | supported | unknown |
-| `meter_schema_url` | supported | unknown | supported | unknown | supported | unknown |
-| `meter_version` | supported | unknown | supported | unknown | supported | unknown |
-| `unit` | supported | unknown | supported | unknown | not_implemented | unknown |
+| `instrument_name` | supported | unknown | supported | unknown | supported | supported |
+| `instrument_type` | supported | unknown | supported | unknown | supported | supported |
+| `meter_name` | supported | unknown | supported | unknown | supported | supported |
+| `meter_schema_url` | supported | unknown | supported | unknown | supported | supported |
+| `meter_version` | supported | unknown | supported | unknown | supported | supported |
+| `unit` | supported | unknown | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -4408,11 +4408,11 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `aggregation` | supported | unknown | supported | unknown | ignored | unknown |
-| `aggregation_cardinality_limit` | supported | unknown | supported | unknown | not_implemented | unknown |
-| `attribute_keys` | supported | unknown | supported | unknown | supported | unknown |
-| `description` | supported | unknown | supported | unknown | supported | unknown |
-| `name` | supported | unknown | supported | unknown | supported | unknown |
+| `aggregation` | supported | unknown | supported | unknown | ignored | supported |
+| `aggregation_cardinality_limit` | supported | unknown | supported | unknown | not_implemented | supported |
+| `attribute_keys` | supported | unknown | supported | unknown | supported | supported |
+| `description` | supported | unknown | supported | unknown | supported | supported |
+| `name` | supported | unknown | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -4483,7 +4483,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -4586,7 +4586,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `root` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `root` | ignored | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -4635,7 +4635,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -4686,7 +4686,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `rules` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `rules` | ignored | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -4740,11 +4740,11 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `attribute_patterns` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `attribute_values` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `parent` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `sampler` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `span_kinds` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `attribute_patterns` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `attribute_values` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `parent` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `sampler` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `span_kinds` | ignored | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -4818,9 +4818,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `excluded` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `included` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `key` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `excluded` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `included` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `key` | ignored | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -4884,8 +4884,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `key` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `values` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `key` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `values` | ignored | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -4945,11 +4945,11 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `always_off` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `always_on` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `parent_threshold` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `probability` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
-| `rule_based` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `always_off` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `always_on` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `parent_threshold` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `probability` | ignored | not_implemented | supported | unknown | not_implemented | supported |
+| `rule_based` | ignored | not_implemented | supported | unknown | not_implemented | supported |
 </details>
 
 Constraints: 
@@ -5049,7 +5049,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -5122,7 +5122,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -5172,14 +5172,14 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `code` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `db` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `gen_ai` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `http` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `messaging` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `rpc` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `sanitization` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `stability_opt_in_list` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `code` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `db` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `gen_ai` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `http` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `messaging` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `rpc` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `sanitization` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `stability_opt_in_list` | not_applicable | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -5307,9 +5307,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -5374,9 +5374,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `client` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `semconv` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `server` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `client` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `semconv` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `server` | not_applicable | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -5429,9 +5429,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | unknown |
+| `known_methods` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `request_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `response_captured_headers` | not_applicable | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -5505,18 +5505,18 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `cpp` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `dotnet` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `erlang` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `general` | not_applicable | not_implemented | supported | unknown | supported | unknown |
-| `go` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `java` | not_applicable | not_implemented | supported | unknown | not_applicable | unknown |
-| `js` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `php` | not_applicable | not_implemented | not_applicable | unknown | supported | unknown |
-| `python` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `ruby` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `rust` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
-| `swift` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | unknown |
+| `cpp` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `dotnet` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `erlang` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `general` | not_applicable | not_implemented | supported | unknown | supported | ignored |
+| `go` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `java` | not_applicable | not_implemented | supported | unknown | not_applicable | ignored |
+| `js` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `php` | not_applicable | not_implemented | not_applicable | unknown | supported | ignored |
+| `python` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `ruby` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `rust` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
+| `swift` | not_applicable | not_implemented | not_applicable | unknown | not_applicable | ignored |
 </details>
 
 Constraints: 
@@ -5710,9 +5710,9 @@ swift:
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `endpoint` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
-| `initial_sampler` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
-| `interval` | not_implemented | not_implemented | supported | unknown | not_implemented | unknown |
+| `endpoint` | not_implemented | not_implemented | supported | unknown | not_implemented | ignored |
+| `initial_sampler` | not_implemented | not_implemented | supported | unknown | not_implemented | ignored |
+| `interval` | not_implemented | not_implemented | supported | unknown | not_implemented | ignored |
 </details>
 
 Constraints: 
@@ -5818,9 +5818,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `enabled` | not_implemented | unknown | supported | unknown | supported | unknown |
-| `minimum_severity` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
-| `trace_based` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `enabled` | not_implemented | unknown | supported | unknown | supported | ignored |
+| `minimum_severity` | not_implemented | unknown | supported | unknown | not_implemented | ignored |
+| `trace_based` | not_implemented | unknown | supported | unknown | not_implemented | ignored |
 </details>
 
 Constraints: 
@@ -5881,8 +5881,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
-| `loggers` | supported | not_implemented | supported | unknown | supported | unknown |
+| `default_config` | supported | not_implemented | supported | unknown | supported | ignored |
+| `loggers` | supported | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -5952,8 +5952,8 @@ loggers:
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported | unknown |
-| `name` | supported | unknown | supported | unknown | supported | unknown |
+| `config` | supported | unknown | supported | unknown | supported | ignored |
+| `name` | supported | unknown | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -6009,7 +6009,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -6052,7 +6052,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `enabled` | supported | unknown | supported | unknown | supported | unknown |
+| `enabled` | supported | unknown | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -6101,8 +6101,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
-| `meters` | supported | not_implemented | supported | unknown | supported | unknown |
+| `default_config` | supported | not_implemented | supported | unknown | supported | ignored |
+| `meters` | supported | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -6170,8 +6170,8 @@ meters:
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported | unknown |
-| `name` | supported | unknown | supported | unknown | supported | unknown |
+| `config` | supported | unknown | supported | unknown | supported | ignored |
+| `name` | supported | unknown | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -6227,7 +6227,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | unknown |
+| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -6315,9 +6315,9 @@ output_stream: stdout
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | unknown |
-| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | unknown |
-| `temporality_preference` | supported | not_implemented | supported | unknown | supported | unknown |
+| `default_histogram_aggregation` | supported | not_implemented | supported | unknown | not_implemented | ignored |
+| `output_stream` | supported | not_implemented | not_implemented | unknown | supported | ignored |
+| `temporality_preference` | supported | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -6396,7 +6396,7 @@ default_histogram_aggregation: explicit_bucket_histogram
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | unknown |
+| `ratio` | ignored | not_implemented | supported | unknown | not_implemented | ignored |
 </details>
 
 Constraints: 
@@ -6482,12 +6482,12 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `host` | supported | supported | supported | unknown | not_implemented | unknown |
-| `port` | supported | supported | supported | unknown | not_implemented | unknown |
-| `resource_constant_labels` | supported | supported | supported | unknown | not_implemented | unknown |
-| `scope_info_enabled` | supported | supported | supported | unknown | not_implemented | unknown |
-| `translation_strategy` | supported | supported | not_implemented | unknown | not_implemented | unknown |
-| `target_info_enabled/development` | supported | supported | supported | unknown | not_implemented | unknown |
+| `host` | supported | supported | supported | unknown | not_implemented | ignored |
+| `port` | supported | supported | supported | unknown | not_implemented | ignored |
+| `resource_constant_labels` | supported | supported | supported | unknown | not_implemented | ignored |
+| `scope_info_enabled` | supported | supported | supported | unknown | not_implemented | ignored |
+| `translation_strategy` | supported | supported | not_implemented | unknown | not_implemented | ignored |
+| `target_info_enabled/development` | supported | supported | supported | unknown | not_implemented | ignored |
 </details>
 
 Constraints: 
@@ -6588,10 +6588,10 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `no_translation/development` | not_implemented | supported | not_implemented | unknown | not_implemented | unknown |
-| `no_utf8_escaping_with_suffixes/development` | not_implemented | supported | not_implemented | unknown | not_implemented | unknown |
-| `underscore_escaping_with_suffixes` | supported | supported | not_implemented | unknown | not_implemented | unknown |
-| `underscore_escaping_without_suffixes/development` | supported | supported | not_implemented | unknown | not_implemented | unknown |
+| `no_translation/development` | not_implemented | supported | not_implemented | unknown | not_implemented | ignored |
+| `no_utf8_escaping_with_suffixes/development` | not_implemented | supported | not_implemented | unknown | not_implemented | ignored |
+| `underscore_escaping_with_suffixes` | supported | supported | not_implemented | unknown | not_implemented | ignored |
+| `underscore_escaping_without_suffixes/development` | supported | supported | not_implemented | unknown | not_implemented | ignored |
 </details>
 
 No constraints.
@@ -6635,8 +6635,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `attributes` | not_implemented | supported | supported | unknown | supported | unknown |
-| `detectors` | not_implemented | supported | supported | unknown | supported | unknown |
+| `attributes` | not_implemented | supported | supported | unknown | supported | supported |
+| `detectors` | not_implemented | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -6692,10 +6692,10 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `container` | not_implemented | supported | supported | unknown | ignored | unknown |
-| `host` | not_implemented | supported | supported | unknown | supported | unknown |
-| `process` | not_implemented | supported | supported | unknown | supported | unknown |
-| `service` | not_implemented | supported | supported | unknown | supported | unknown |
+| `container` | not_implemented | supported | supported | unknown | ignored | supported |
+| `host` | not_implemented | supported | supported | unknown | supported | supported |
+| `process` | not_implemented | supported | supported | unknown | supported | supported |
+| `service` | not_implemented | supported | supported | unknown | supported | supported |
 </details>
 
 Constraints: 
@@ -6759,7 +6759,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `semconv` | unknown | not_implemented | unknown | unknown | unknown | unknown |
+| `semconv` | unknown | not_implemented | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -6802,7 +6802,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `url` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `url` | unknown | unknown | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -6847,9 +6847,9 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `dual_emit` | unknown | unknown | unknown | unknown | unknown | unknown |
-| `experimental` | unknown | unknown | unknown | unknown | unknown | unknown |
-| `version` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `dual_emit` | unknown | unknown | unknown | unknown | unknown | ignored |
+| `experimental` | unknown | unknown | unknown | unknown | unknown | ignored |
+| `version` | unknown | unknown | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 
@@ -6949,9 +6949,9 @@ This is a enum type.
 
 | Value | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `local` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
-| `none` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
-| `remote` | not_implemented | unknown | supported | unknown | not_implemented | unknown |
+| `local` | not_implemented | unknown | supported | unknown | not_implemented | supported |
+| `none` | not_implemented | unknown | supported | unknown | not_implemented | supported |
+| `remote` | not_implemented | unknown | supported | unknown | not_implemented | supported |
 </details>
 
 No constraints.
@@ -6993,7 +6993,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `enabled` | supported | unknown | supported | unknown | supported | unknown |
+| `enabled` | supported | unknown | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -7042,8 +7042,8 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `default_config` | supported | not_implemented | supported | unknown | supported | unknown |
-| `tracers` | supported | not_implemented | supported | unknown | supported | unknown |
+| `default_config` | supported | not_implemented | supported | unknown | supported | ignored |
+| `tracers` | supported | not_implemented | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -7111,8 +7111,8 @@ tracers:
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `config` | supported | unknown | supported | unknown | supported | unknown |
-| `name` | supported | unknown | supported | unknown | supported | unknown |
+| `config` | supported | unknown | supported | unknown | supported | ignored |
+| `name` | supported | unknown | supported | unknown | supported | ignored |
 </details>
 
 Constraints: 
@@ -7168,7 +7168,7 @@ No snippets.
 
 | Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) | [python](language-support-status.md#python) |
 |---|---|---|---|---|---|---|
-| `sensitive_query_parameters` | unknown | unknown | unknown | unknown | unknown | unknown |
+| `sensitive_query_parameters` | unknown | unknown | unknown | unknown | unknown | ignored |
 </details>
 
 Constraints: 

--- a/schema/meta_schema_language_python.yaml
+++ b/schema/meta_schema_language_python.yaml
@@ -1,0 +1,341 @@
+latestSupportedFileFormat: 1.0.0
+typeSupportStatuses:
+  - type: Aggregation
+    status: unknown
+    propertyOverrides: []
+  - type: AlwaysOffSampler
+    status: unknown
+    propertyOverrides: []
+  - type: AlwaysOnSampler
+    status: unknown
+    propertyOverrides: []
+  - type: AttributeLimits
+    status: unknown
+    propertyOverrides: []
+  - type: AttributeNameValue
+    status: unknown
+    propertyOverrides: []
+  - type: AttributeType
+    status: unknown
+    enumOverrides: []
+  - type: B3MultiPropagator
+    status: unknown
+    propertyOverrides: []
+  - type: B3Propagator
+    status: unknown
+    propertyOverrides: []
+  - type: BaggagePropagator
+    status: unknown
+    propertyOverrides: []
+  - type: Base2ExponentialBucketHistogramAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: BatchLogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: BatchSpanProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: CardinalityLimits
+    status: unknown
+    propertyOverrides: []
+  - type: ConsoleExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ConsoleMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: DefaultAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: Distribution
+    status: unknown
+    propertyOverrides: []
+  - type: DropAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: ExemplarFilter
+    status: unknown
+    enumOverrides: []
+  - type: ExplicitBucketHistogramAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: ExporterDefaultHistogramAggregation
+    status: unknown
+    enumOverrides: []
+  - type: ExporterTemporalityPreference
+    status: unknown
+    enumOverrides: []
+  - type: GrpcTls
+    status: unknown
+    propertyOverrides: []
+  - type: HttpTls
+    status: unknown
+    propertyOverrides: []
+  - type: IdGenerator
+    status: unknown
+    propertyOverrides: []
+  - type: IncludeExclude
+    status: unknown
+    propertyOverrides: []
+  - type: InstrumentType
+    status: unknown
+    enumOverrides: []
+  - type: LastValueAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: LoggerProvider
+    status: unknown
+    propertyOverrides: []
+  - type: LogRecordExporter
+    status: unknown
+    propertyOverrides: []
+  - type: LogRecordLimits
+    status: unknown
+    propertyOverrides: []
+  - type: LogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: MeterProvider
+    status: unknown
+    propertyOverrides: []
+  - type: MetricProducer
+    status: unknown
+    propertyOverrides: []
+  - type: MetricReader
+    status: unknown
+    propertyOverrides: []
+  - type: NameStringValuePair
+    status: unknown
+    propertyOverrides: []
+  - type: OpenCensusMetricProducer
+    status: unknown
+    propertyOverrides: []
+  - type: OpenTelemetryConfiguration
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpGrpcExporter
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpGrpcMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpHttpEncoding
+    status: unknown
+    enumOverrides: []
+  - type: OtlpHttpExporter
+    status: unknown
+    propertyOverrides: []
+  - type: OtlpHttpMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ParentBasedSampler
+    status: unknown
+    propertyOverrides: []
+  - type: PeriodicMetricReader
+    status: unknown
+    propertyOverrides: []
+  - type: Propagator
+    status: unknown
+    propertyOverrides: []
+  - type: PullMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: PullMetricReader
+    status: unknown
+    propertyOverrides: []
+  - type: PushMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: RandomIdGenerator
+    status: unknown
+    propertyOverrides: []
+  - type: Resource
+    status: unknown
+    propertyOverrides: []
+  - type: Sampler
+    status: unknown
+    propertyOverrides: []
+  - type: SeverityNumber
+    status: unknown
+    enumOverrides: []
+  - type: SimpleLogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: SimpleSpanProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: SpanExporter
+    status: unknown
+    propertyOverrides: []
+  - type: SpanKind
+    status: unknown
+    enumOverrides: []
+  - type: SpanLimits
+    status: unknown
+    propertyOverrides: []
+  - type: SpanProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: SumAggregation
+    status: unknown
+    propertyOverrides: []
+  - type: TextMapPropagator
+    status: unknown
+    propertyOverrides: []
+  - type: TraceContextPropagator
+    status: unknown
+    propertyOverrides: []
+  - type: TraceIdRatioBasedSampler
+    status: unknown
+    propertyOverrides: []
+  - type: TracerProvider
+    status: unknown
+    propertyOverrides: []
+  - type: View
+    status: unknown
+    propertyOverrides: []
+  - type: ViewSelector
+    status: unknown
+    propertyOverrides: []
+  - type: ViewStream
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalCodeInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableAlwaysOffSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableAlwaysOnSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableParentThresholdSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableProbabilitySampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSamplerRule
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSamplerRuleAttributePatterns
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableRuleBasedSamplerRuleAttributeValues
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalComposableSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalContainerResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalDbInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalGenAiInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalGeneralInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHostResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHttpClientInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHttpInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalHttpServerInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalJaegerRemoteSampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLanguageSpecificInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLoggerConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLoggerConfigurator
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalLoggerMatcherAndConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMessagingInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMeterConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMeterConfigurator
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalMeterMatcherAndConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalOtlpFileExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalOtlpFileMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalProbabilitySampler
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalProcessResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalPrometheusMetricExporter
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalPrometheusTranslationStrategy
+    status: unknown
+    enumOverrides: []
+  - type: ExperimentalResourceDetection
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalRpcInstrumentation
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalSanitization
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalSemconvConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalServiceResourceDetector
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalSpanParent
+    status: unknown
+    enumOverrides: []
+  - type: ExperimentalTracerConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalTracerConfigurator
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalTracerMatcherAndConfig
+    status: unknown
+    propertyOverrides: []
+  - type: ExperimentalUrlSanitization
+    status: unknown
+    propertyOverrides: []

--- a/schema/meta_schema_language_python.yaml
+++ b/schema/meta_schema_language_python.yaml
@@ -1,341 +1,341 @@
 latestSupportedFileFormat: 1.0.0
 typeSupportStatuses:
   - type: Aggregation
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: AlwaysOffSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: AlwaysOnSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: AttributeLimits
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: AttributeNameValue
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: AttributeType
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: B3MultiPropagator
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: B3Propagator
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: BaggagePropagator
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: Base2ExponentialBucketHistogramAggregation
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: BatchLogRecordProcessor
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: BatchSpanProcessor
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: CardinalityLimits
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ConsoleExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ConsoleMetricExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: DefaultAggregation
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: Distribution
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: DropAggregation
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExemplarFilter
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: ExplicitBucketHistogramAggregation
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExporterDefaultHistogramAggregation
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: ExporterTemporalityPreference
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: GrpcTls
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: HttpTls
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: IdGenerator
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: IncludeExclude
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: InstrumentType
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: LastValueAggregation
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: LoggerProvider
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: LogRecordExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: LogRecordLimits
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: LogRecordProcessor
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: MeterProvider
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: MetricProducer
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: MetricReader
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: NameStringValuePair
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: OpenCensusMetricProducer
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: OpenTelemetryConfiguration
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: OtlpGrpcExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: OtlpGrpcMetricExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: OtlpHttpEncoding
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: OtlpHttpExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: OtlpHttpMetricExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ParentBasedSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: PeriodicMetricReader
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: Propagator
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: PullMetricExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: PullMetricReader
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: PushMetricExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: RandomIdGenerator
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: Resource
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: Sampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: SeverityNumber
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: SimpleLogRecordProcessor
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: SimpleSpanProcessor
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: SpanExporter
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: SpanKind
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: SpanLimits
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: SpanProcessor
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: SumAggregation
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: TextMapPropagator
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: TraceContextPropagator
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: TraceIdRatioBasedSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: TracerProvider
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: View
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ViewSelector
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ViewStream
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalCodeInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalComposableAlwaysOffSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableAlwaysOnSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableParentThresholdSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableProbabilitySampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableRuleBasedSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableRuleBasedSamplerRule
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableRuleBasedSamplerRuleAttributePatterns
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableRuleBasedSamplerRuleAttributeValues
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalComposableSampler
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalContainerResourceDetector
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalDbInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalGenAiInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalGeneralInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalHostResourceDetector
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalHttpClientInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalHttpInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalHttpServerInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalJaegerRemoteSampler
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalLanguageSpecificInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalLoggerConfig
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalLoggerConfigurator
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalLoggerMatcherAndConfig
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalMessagingInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalMeterConfig
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalMeterConfigurator
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalMeterMatcherAndConfig
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalOtlpFileExporter
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalOtlpFileMetricExporter
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalProbabilitySampler
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalProcessResourceDetector
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalPrometheusTranslationStrategy
-    status: unknown
+    status: ignored
     enumOverrides: []
   - type: ExperimentalResourceDetection
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalResourceDetector
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalRpcInstrumentation
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalSanitization
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalSemconvConfig
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalServiceResourceDetector
-    status: unknown
+    status: supported
     propertyOverrides: []
   - type: ExperimentalSpanParent
-    status: unknown
+    status: supported
     enumOverrides: []
   - type: ExperimentalTracerConfig
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalTracerConfigurator
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalTracerMatcherAndConfig
-    status: unknown
+    status: ignored
     propertyOverrides: []
   - type: ExperimentalUrlSanitization
-    status: unknown
+    status: ignored
     propertyOverrides: []

--- a/scripts/language-implementations.js
+++ b/scripts/language-implementations.js
@@ -10,11 +10,12 @@ import {
 import {readSourceTypesByType} from "./source-schema.js";
 
 export const KNOWN_LANGUAGES = [
-    'cpp', 
-    'go', 
+    'cpp',
+    'go',
     'java',
     'js',
     'php',
+    'python',
 ];
 
 const IMPLEMENTATION_STATUS_UNKNOWN = 'unknown';


### PR DESCRIPTION
## Description

Replaces the seeded `unknown` entries in `schema/meta_schema_language_python.yaml` with the actual runtime conformance status of the Python SDK against the v1.0 declarative configuration schema. Cross-checked row-by-row against the factory code under [`opentelemetry-sdk/src/opentelemetry/sdk/_configuration/_*.py`](https://github.com/open-telemetry/opentelemetry-python/tree/main/opentelemetry-sdk/src/opentelemetry/sdk/_configuration), not just the schema.

## Stacked on top of

- #668 — adds `python` to `KNOWN_LANGUAGES` and seeds the YAML. **Please review and merge that first** so this PR's diff stays clean.

## Highlights

Of the 113 types in the schema:

- **Supported** (≈80): every signal provider, all stable samplers, OTLP HTTP/gRPC and console exporters across all three signals, propagators (built-in and entry-point), views, exemplar filters, cardinality limits, resource detection (host, process, service), and the experimental composable samplers landed via [open-telemetry/opentelemetry-python#5201](https://github.com/open-telemetry/opentelemetry-python/pull/5201).
- **Ignored**: top-level `attribute_limits` and `log_record_limits` (parsed but not applied); `id_generator` (Python factory wiring tracked in [#5334](https://github.com/open-telemetry/opentelemetry-python/issues/5334)); `metric_producer` ([#5073](https://github.com/open-telemetry/opentelemetry-python/issues/5073)); the configurator extension points (`tracer_configurator/development`, `meter_configurator/development`, `logger_configurator/development`); the experimental file exporter (PR [#5311](https://github.com/open-telemetry/opentelemetry-python/pull/5311) in flight); `prometheus_metric_exporter` secondary flags; the `instrumentation/development` tree; container resource detector (needs contrib package).

The classification mapping is captured in the script used to generate this YAML (committed for review separately if useful).

## Related

- open-telemetry/opentelemetry-python#5347 (linking the Python SDK README at the shared matrix instead of duplicating per language)
- open-telemetry/opentelemetry-python#3631 (declarative config tracking)