### PR TITLE
Add process resource detector attribute toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Unreleased
 
+### Schema
+
 * Deprecate `MetricProducer.opencensus` and `OpenCensusMetricProducer`,
   following the deprecation of OpenCensus compatibility in the
   specification
   ([#655](https://github.com/open-telemetry/opentelemetry-configuration/pull/655))
+* Add `command_args/development` and `command_line/development` configuration
+  to `ExperimentalProcessResourceDetector`, defaulting to `false`.
+  ([#673](https://github.com/open-telemetry/opentelemetry-configuration/pull/673))
 
 ## v1.1.0 - 2026-06-05
 

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -115,7 +115,8 @@ Latest supported file format: `1.0.0`
 | [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | supported |  | * `output_stream`: supported<br> |
 | [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br> |
 | [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | ignored |  | * `ratio`: ignored<br> |
-| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | not_implemented |  |  |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | not_implemented |  | * `command_args/development`: not_implemented<br>* `command_line/development`: not_implemented<br> |
+| [`ExperimentalProcessResourceDetectorAttribute`](schema-docs.md#experimentalprocessresourcedetectorattribute) | not_implemented |  | * `enabled`: not_implemented<br> |
 | [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
 | [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | supported |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
 | [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | not_implemented |  | * `attributes`: not_implemented<br>* `detectors`: not_implemented<br> |
@@ -236,7 +237,8 @@ Latest supported file format: `1.0.0`
 | [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | not_implemented |  | * `output_stream`: not_implemented<br> |
 | [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
 | [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | not_implemented |  | * `ratio`: not_implemented<br> |
-| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  |  |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  | * `command_args/development`: not_implemented<br>* `command_line/development`: not_implemented<br> |
+| [`ExperimentalProcessResourceDetectorAttribute`](schema-docs.md#experimentalprocessresourcedetectorattribute) | not_implemented |  | * `enabled`: not_implemented<br> |
 | [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
 | [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | supported |  | * `no_translation/development`: supported<br>* `no_utf8_escaping_with_suffixes/development`: supported<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
 | [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
@@ -357,7 +359,8 @@ Latest supported file format: `1.0.0-rc.3`
 | [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | supported |  | * `output_stream`: not_implemented<br> |
 | [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: not_implemented<br>* `temporality_preference`: supported<br> |
 | [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | supported |  | * `ratio`: supported<br> |
-| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  |  |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  | * `command_args/development`: not_implemented<br>* `command_line/development`: not_implemented<br> |
+| [`ExperimentalProcessResourceDetectorAttribute`](schema-docs.md#experimentalprocessresourcedetectorattribute) | not_implemented |  | * `enabled`: not_implemented<br> |
 | [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: supported<br> |
 | [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
 | [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
@@ -478,7 +481,8 @@ Latest supported file format: `1.0.0-rc.3`
 | [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | not_implemented |  | * `output_stream`: not_implemented<br> |
 | [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
 | [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | not_implemented |  | * `ratio`: not_implemented<br> |
-| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  |  |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  | * `command_args/development`: not_implemented<br>* `command_line/development`: not_implemented<br> |
+| [`ExperimentalProcessResourceDetectorAttribute`](schema-docs.md#experimentalprocessresourcedetectorattribute) | not_implemented |  | * `enabled`: not_implemented<br> |
 | [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
 | [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
 | [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
@@ -599,7 +603,8 @@ Latest supported file format: `1.0.0-rc.2`
 | [`ExperimentalOtlpFileExporter`](schema-docs.md#experimentalotlpfileexporter) | supported |  | * `output_stream`: supported<br> |
 | [`ExperimentalOtlpFileMetricExporter`](schema-docs.md#experimentalotlpfilemetricexporter) | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br> |
 | [`ExperimentalProbabilitySampler`](schema-docs.md#experimentalprobabilitysampler) | not_implemented |  | * `ratio`: not_implemented<br> |
-| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  |  |
+| [`ExperimentalProcessResourceDetector`](schema-docs.md#experimentalprocessresourcedetector) | supported |  | * `command_args/development`: not_implemented<br>* `command_line/development`: not_implemented<br> |
+| [`ExperimentalProcessResourceDetectorAttribute`](schema-docs.md#experimentalprocessresourcedetectorattribute) | not_implemented |  | * `enabled`: not_implemented<br> |
 | [`ExperimentalPrometheusMetricExporter`](schema-docs.md#experimentalprometheusmetricexporter) | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
 | [`ExperimentalPrometheusTranslationStrategy`](schema-docs.md#experimentalprometheustranslationstrategy) | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
 | [`ExperimentalResourceDetection`](schema-docs.md#experimentalresourcedetection) | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -1110,7 +1110,31 @@
         "object",
         "null"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "properties": {
+        "command_args/development": {
+          "$ref": "#/$defs/ExperimentalProcessResourceDetectorAttribute",
+          "description": "Configure whether process.command_args is collected.\nIf omitted, process.command_args is not collected.\n"
+        },
+        "command_line/development": {
+          "$ref": "#/$defs/ExperimentalProcessResourceDetectorAttribute",
+          "description": "Configure whether process.command_line is collected.\nIf omitted, process.command_line is not collected.\n"
+        }
+      }
+    },
+    "ExperimentalProcessResourceDetectorAttribute": {
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean"
+          ],
+          "description": "Set to true to collect this attribute.\nIf omitted, false is used.\n"
+        }
+      }
     },
     "ExperimentalPrometheusMetricExporter": {
       "type": [
@@ -1208,7 +1232,7 @@
         },
         "process": {
           "$ref": "#/$defs/ExperimentalProcessResourceDetector",
-          "description": "Enable the process resource detector, which populates process.* attributes.\nIf omitted, ignore.\n"
+          "description": "Enable the process resource detector, which populates process.* attributes except process.command_args and process.command_line unless they are explicitly enabled.\nIf omitted, ignore.\n"
         },
         "service": {
           "$ref": "#/$defs/ExperimentalServiceResourceDetector",

--- a/schema-docs.md
+++ b/schema-docs.md
@@ -3218,6 +3218,10 @@ detection/development:
     - container:
     - host:
     - process:
+        command_args/development:
+          enabled: false
+        command_line/development:
+          enabled: false
     - service:
 schema_url: https://opentelemetry.io/schemas/1.16.0
 ```
@@ -6438,7 +6442,19 @@ No snippets.
 > [!WARNING]
 > This type is [experimental](VERSIONING.md#experimental-features).
 
-No properties.
+| Property | Type | Required? | Default and Null Behavior | Constraints | Description |
+|---|---|---|---|---|---|
+| `command_args/development`<br>**WARNING:** This property is [experimental](VERSIONING.md#experimental-features). | [`ExperimentalProcessResourceDetectorAttribute`](#experimentalprocessresourcedetectorattribute) | `false` | If omitted, process.command_args is not collected. | No constraints. | Configure whether process.command_args is collected.<br> |
+| `command_line/development`<br>**WARNING:** This property is [experimental](VERSIONING.md#experimental-features). | [`ExperimentalProcessResourceDetectorAttribute`](#experimentalprocessresourcedetectorattribute) | `false` | If omitted, process.command_line is not collected. | No constraints. | Configure whether process.command_line is collected.<br> |
+
+<details>
+<summary>Language support status</summary>
+
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
+|---|---|---|---|---|---|
+| `command_args/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented |
+| `command_line/development` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented |
+</details>
 
 Constraints: 
 
@@ -6459,7 +6475,65 @@ No snippets.
     "object",
     "null"
   ],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "properties": {
+    "command_args/development": {
+      "$ref": "#/$defs/ExperimentalProcessResourceDetectorAttribute",
+      "description": "Configure whether process.command_args is collected.\nIf omitted, process.command_args is not collected.\n"
+    },
+    "command_line/development": {
+      "$ref": "#/$defs/ExperimentalProcessResourceDetectorAttribute",
+      "description": "Configure whether process.command_line is collected.\nIf omitted, process.command_line is not collected.\n"
+    }
+  }
+}</pre>
+</details>
+
+## ExperimentalProcessResourceDetectorAttribute <a id="experimentalprocessresourcedetectorattribute"></a>
+
+> [!WARNING]
+> This type is [experimental](VERSIONING.md#experimental-features).
+
+| Property | Type | Required? | Default and Null Behavior | Constraints | Description |
+|---|---|---|---|---|---|
+| `enabled` | `boolean` | `false` | If omitted, false is used. | No constraints. | Set to true to collect this attribute. |
+
+<details>
+<summary>Language support status</summary>
+
+| Property | [cpp](language-support-status.md#cpp) | [go](language-support-status.md#go) | [java](language-support-status.md#java) | [js](language-support-status.md#js) | [php](language-support-status.md#php) |
+|---|---|---|---|---|---|
+| `enabled` | not_implemented | not_implemented | not_implemented | not_implemented | not_implemented |
+</details>
+
+Constraints: 
+
+* `additionalProperties`: `false`
+
+Usages:
+
+* [`ExperimentalProcessResourceDetector.command_args/development`](#experimentalprocessresourcedetector)
+* [`ExperimentalProcessResourceDetector.command_line/development`](#experimentalprocessresourcedetector)
+
+No snippets.
+
+<details>
+<summary>JSON Schema</summary>
+
+[JSON Schema Source File](./schema/resource.yaml)
+<pre>{
+  "type": [
+    "object"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "enabled": {
+      "type": [
+        "boolean"
+      ],
+      "description": "Set to true to collect this attribute.\nIf omitted, false is used.\n"
+    }
+  }
 }</pre>
 </details>
 
@@ -6684,7 +6758,7 @@ No snippets.
 |---|---|---|---|---|---|
 | `container` | [`ExperimentalContainerResourceDetector`](#experimentalcontainerresourcedetector) | `false` | If omitted, ignore. | No constraints. | Enable the container resource detector, which populates container.* attributes.<br> |
 | `host` | [`ExperimentalHostResourceDetector`](#experimentalhostresourcedetector) | `false` | If omitted, ignore. | No constraints. | Enable the host resource detector, which populates host.* and os.* attributes.<br> |
-| `process` | [`ExperimentalProcessResourceDetector`](#experimentalprocessresourcedetector) | `false` | If omitted, ignore. | No constraints. | Enable the process resource detector, which populates process.* attributes.<br> |
+| `process` | [`ExperimentalProcessResourceDetector`](#experimentalprocessresourcedetector) | `false` | If omitted, ignore. | No constraints. | Enable the process resource detector, which populates process.* attributes except process.command_args and process.command_line unless they are explicitly enabled.<br> |
 | `service` | [`ExperimentalServiceResourceDetector`](#experimentalserviceresourcedetector) | `false` | If omitted, ignore. | No constraints. | Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.<br> |
 
 <details>
@@ -6735,7 +6809,7 @@ No snippets.
     },
     "process": {
       "$ref": "#/$defs/ExperimentalProcessResourceDetector",
-      "description": "Enable the process resource detector, which populates process.* attributes.\nIf omitted, ignore.\n"
+      "description": "Enable the process resource detector, which populates process.* attributes except process.command_args and process.command_line unless they are explicitly enabled.\nIf omitted, ignore.\n"
     },
     "service": {
       "$ref": "#/$defs/ExperimentalServiceResourceDetector",

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -304,6 +304,9 @@ typeSupportStatuses:
   - type: ExperimentalProcessResourceDetector
     status: not_implemented
     propertyOverrides: []
+  - type: ExperimentalProcessResourceDetectorAttribute
+    status: not_implemented
+    propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
     status: supported
     propertyOverrides: []

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -331,6 +331,13 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalProcessResourceDetector
     status: supported
+    propertyOverrides:
+      - property: command_args/development
+        status: not_implemented
+      - property: command_line/development
+        status: not_implemented
+  - type: ExperimentalProcessResourceDetectorAttribute
+    status: not_implemented
     propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
     status: supported

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -343,6 +343,13 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalProcessResourceDetector
     status: supported
+    propertyOverrides:
+      - property: command_args/development
+        status: not_implemented
+      - property: command_line/development
+        status: not_implemented
+  - type: ExperimentalProcessResourceDetectorAttribute
+    status: not_implemented
     propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
     status: supported

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -305,6 +305,13 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalProcessResourceDetector
     status: supported
+    propertyOverrides:
+      - property: command_args/development
+        status: not_implemented
+      - property: command_line/development
+        status: not_implemented
+  - type: ExperimentalProcessResourceDetectorAttribute
+    status: not_implemented
     propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
     status: not_implemented

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -372,6 +372,13 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalProcessResourceDetector
     status: supported
+    propertyOverrides:
+      - property: command_args/development
+        status: not_implemented
+      - property: command_line/development
+        status: not_implemented
+  - type: ExperimentalProcessResourceDetectorAttribute
+    status: not_implemented
     propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
     status: not_implemented

--- a/schema/resource.yaml
+++ b/schema/resource.yaml
@@ -129,7 +129,7 @@ $defs:
       process:
         $ref: "#/$defs/ExperimentalProcessResourceDetector"
         description: |
-          Enable the process resource detector, which populates process.* attributes.
+          Enable the process resource detector, which populates process.* attributes except process.command_args and process.command_line unless they are explicitly enabled.
         defaultBehavior: ignore
       service:
         $ref: "#/$defs/ExperimentalServiceResourceDetector"
@@ -152,6 +152,27 @@ $defs:
       - object
       - "null"
     additionalProperties: false
+    properties:
+      command_args/development:
+        $ref: "#/$defs/ExperimentalProcessResourceDetectorAttribute"
+        description: |
+          Configure whether process.command_args is collected.
+        defaultBehavior: process.command_args is not collected
+      command_line/development:
+        $ref: "#/$defs/ExperimentalProcessResourceDetectorAttribute"
+        description: |
+          Configure whether process.command_line is collected.
+        defaultBehavior: process.command_line is not collected
+  ExperimentalProcessResourceDetectorAttribute:
+    type:
+      - object
+    additionalProperties: false
+    properties:
+      enabled:
+        type:
+          - boolean
+        description: Set to true to collect this attribute.
+        defaultBehavior: false is used
   ExperimentalServiceResourceDetector:
     type:
       - object

--- a/snippets/Resource_kitchen_sink.yaml
+++ b/snippets/Resource_kitchen_sink.yaml
@@ -40,5 +40,9 @@ resource:
       - container:
       - host:
       - process:
+          command_args/development:
+            enabled: false
+          command_line/development:
+            enabled: false
       - service:
   schema_url: https://opentelemetry.io/schemas/1.16.0


### PR DESCRIPTION
Add explicit `command_args/development` and `command_line/development` toggles to `ExperimentalProcessResourceDetector` so `process.command_args` and `process.command_line` are not emitted unless configured. The PR updates the compiled schema, resource snippet, generated schema docs, language support metadata, and changelog.

Resolves #671.