### PR TITLE
Group all patch and minor updates into weekly update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,12 +7,12 @@
   ],
   "packageRules": [
     {
-      "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
-      "schedule": ["before 8am every weekday"]
+      "groupName": "non-major dependencies",
+      "matchUpdateTypes": ["patch", "minor"],
+      "schedule": ["before 8am on Monday"]
     },
     {
-      "matchUpdateTypes": ["minor", "major"],
+      "matchUpdateTypes": ["major"],
       "schedule": ["before 8am on Monday"]
     }
   ],


### PR DESCRIPTION
Trying to reduce the clutter of renovate updates by grouping minor updates into a weekly update with the patches. 