### PR TITLE
Add config for entity aware resource detectors

### DIFF
--- a/language-support-status.md
+++ b/language-support-status.md
@@ -119,7 +119,7 @@ Latest supported file format: `1.0.0`
 | `ExperimentalProcessResourceDetector` | not_implemented |  |  |
 | `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
 | `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
-| `ExperimentalResourceDetection` | not_implemented |  | * `attributes`: not_implemented<br>* `detectors`: not_implemented<br> |
+| `ExperimentalResourceDetection` | not_implemented |  | * `attributes`: not_implemented<br>* `detectors`: not_implemented<br>* `entities_enabled`: not_implemented<br> |
 | `ExperimentalResourceDetector` | not_implemented |  | * `container`: not_implemented<br>* `host`: not_implemented<br>* `process`: not_implemented<br>* `service`: not_implemented<br> |
 | `ExperimentalRpcInstrumentation` | unknown |  | * `semconv`: unknown<br> |
 | `ExperimentalSanitization` | unknown |  | * `url`: unknown<br> |
@@ -240,7 +240,7 @@ Latest supported file format: `1.0.0`
 | `ExperimentalProcessResourceDetector` | supported |  |  |
 | `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
 | `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation/development`: supported<br>* `no_utf8_escaping_with_suffixes/development`: supported<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
-| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
+| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br>* `entities_enabled`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
 | `ExperimentalSanitization` | unknown |  | * `url`: unknown<br> |
@@ -361,7 +361,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalProcessResourceDetector` | supported |  |  |
 | `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: supported<br> |
 | `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
-| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
+| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br>* `entities_enabled`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | unknown |  | * `semconv`: unknown<br> |
 | `ExperimentalSanitization` | unknown |  | * `url`: unknown<br> |
@@ -482,7 +482,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalProcessResourceDetector` | supported |  |  |
 | `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
 | `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
-| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
+| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br>* `entities_enabled`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
 | `ExperimentalSanitization` | not_implemented |  | * `url`: not_implemented<br> |
@@ -603,7 +603,7 @@ Latest supported file format: `1.0.0-rc.2`
 | `ExperimentalProcessResourceDetector` | supported |  |  |
 | `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
 | `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
-| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
+| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br>* `entities_enabled`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: ignored<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | unknown |  | * `semconv`: unknown<br> |
 | `ExperimentalSanitization` | unknown |  | * `url`: unknown<br> |
@@ -724,7 +724,7 @@ Latest supported file format: `1.0.0`
 | `ExperimentalProcessResourceDetector` | supported |  |  |
 | `ExperimentalPrometheusMetricExporter` | ignored |  | * `host`: ignored<br>* `port`: ignored<br>* `resource_constant_labels`: ignored<br>* `scope_info_enabled`: ignored<br>* `translation_strategy`: ignored<br>* `target_info_enabled/development`: ignored<br> |
 | `ExperimentalPrometheusTranslationStrategy` | ignored |  | * `no_translation/development`: ignored<br>* `no_utf8_escaping_with_suffixes/development`: ignored<br>* `underscore_escaping_with_suffixes`: ignored<br>* `underscore_escaping_without_suffixes/development`: ignored<br> |
-| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
+| `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br>* `entities_enabled`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | ignored |  | * `semconv`: ignored<br> |
 | `ExperimentalSanitization` | ignored |  | * `url`: ignored<br> |

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -1184,6 +1184,13 @@
             "$ref": "#/$defs/ExperimentalResourceDetector"
           },
           "description": "Configure resource detectors.\nResource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. \nIf omitted, no resource detectors are enabled.\n"
+        },
+        "entities_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Configure whether resource detectors emit entity-aware resources.\n\nResource detectors always produce entity-aware output internally. When this option is\nnot true, the SDK erases entity information from detector results before merging\nthem into the resource.\nIf omitted or null, false is used.\n"
         }
       }
     },

--- a/schema/resource.yaml
+++ b/schema/resource.yaml
@@ -107,6 +107,17 @@ $defs:
           Configure resource detectors.
           Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
         defaultBehavior: no resource detectors are enabled
+      entities_enabled:
+        type:
+          - boolean
+          - "null"
+        description: |
+          Configure whether resource detectors emit entity-aware resources.
+
+          Resource detectors always produce entity-aware output internally. When this option is
+          not true, the SDK erases entity information from detector results before merging
+          them into the resource.
+        defaultBehavior: false is used
   ExperimentalResourceDetector:
     type: object
     additionalProperties:

--- a/snippets/Resource_kitchen_sink.yaml
+++ b/snippets/Resource_kitchen_sink.yaml
@@ -41,4 +41,5 @@ resource:
       - host:
       - process:
       - service:
+    entities_enabled: true
   schema_url: https://opentelemetry.io/schemas/1.16.0


### PR DESCRIPTION
Declarative config analog of `OTEL_EXPERIMENTAL_ENTITIES_ENALBED` as proposed in https://github.com/open-telemetry/opentelemetry-specification/pull/5210

Adds new `$.resource.detection/development.entities_enabled` property, defaulting to false. 

In the spec PR 5210, resource detectors are updated to always be emit entity aware resources. I.e. resources with entities attached. 

If `$.resource.detection/development.entities_enabled` is false, entity information is erased from resource detectors. If true, its retained.