### PR TITLE
schema: add AlwaysRecord sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `always_record` definition to `Sampler`
+  ([#698](https://github.com/open-telemetry/opentelemetry-configuration/pull/698))
 * Deprecate `MetricProducer.opencensus` and `OpenCensusMetricProducer`,
   following the deprecation of OpenCensus compatibility in the
   specification

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -20,6 +20,7 @@ Latest supported file format: `1.0.0`
 | `Aggregation` | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `default`: supported<br>* `drop`: supported<br>* `explicit_bucket_histogram`: supported<br>* `last_value`: supported<br>* `sum`: supported<br> |
 | `AlwaysOffSampler` | supported |  |  |
 | `AlwaysOnSampler` | supported |  |  |
+| `AlwaysRecordSampler` | unknown |  | * `root`: unknown<br> |
 | `AttributeLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
 | `AttributeNameValue` | supported |  | * `name`: supported<br>* `type`: supported<br>* `value`: supported<br> |
 | `AttributeType` | supported |  | * `bool`: supported<br>* `bool_array`: supported<br>* `double`: supported<br>* `double_array`: supported<br>* `int`: supported<br>* `int_array`: supported<br>* `string`: supported<br>* `string_array`: supported<br> |
@@ -68,7 +69,7 @@ Latest supported file format: `1.0.0`
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | unknown |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
@@ -141,6 +142,7 @@ Latest supported file format: `1.0.0`
 | `Aggregation` | unknown |  | * `base2_exponential_bucket_histogram`: unknown<br>* `default`: unknown<br>* `drop`: unknown<br>* `explicit_bucket_histogram`: unknown<br>* `last_value`: unknown<br>* `sum`: unknown<br> |
 | `AlwaysOffSampler` | supported |  |  |
 | `AlwaysOnSampler` | supported |  |  |
+| `AlwaysRecordSampler` | unknown |  | * `root`: unknown<br> |
 | `AttributeLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
 | `AttributeNameValue` | supported |  | * `name`: supported<br>* `type`: supported<br>* `value`: supported<br> |
 | `AttributeType` | supported |  | * `bool`: supported<br>* `bool_array`: supported<br>* `double`: supported<br>* `double_array`: supported<br>* `int`: supported<br>* `int_array`: supported<br>* `string`: supported<br>* `string_array`: supported<br> |
@@ -189,7 +191,7 @@ Latest supported file format: `1.0.0`
 | `PushMetricExporter` | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
 | `RandomIdGenerator` | unknown |  |  |
 | `Resource` | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
 | `SeverityNumber` | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
 | `SimpleLogRecordProcessor` | unknown |  | * `exporter`: unknown<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
@@ -262,6 +264,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `Aggregation` | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `default`: supported<br>* `drop`: supported<br>* `explicit_bucket_histogram`: supported<br>* `last_value`: supported<br>* `sum`: supported<br> |
 | `AlwaysOffSampler` | supported |  |  |
 | `AlwaysOnSampler` | supported |  |  |
+| `AlwaysRecordSampler` | unknown |  | * `root`: unknown<br> |
 | `AttributeLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
 | `AttributeNameValue` | supported |  | * `name`: supported<br>* `type`: supported<br>* `value`: supported<br> |
 | `AttributeType` | supported |  | * `bool`: supported<br>* `bool_array`: supported<br>* `double`: supported<br>* `double_array`: supported<br>* `int`: supported<br>* `int_array`: supported<br>* `string`: supported<br>* `string_array`: supported<br> |
@@ -310,7 +313,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | unknown |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
@@ -383,6 +386,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `Aggregation` | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `default`: supported<br>* `drop`: supported<br>* `explicit_bucket_histogram`: supported<br>* `last_value`: supported<br>* `sum`: supported<br> |
 | `AlwaysOffSampler` | supported |  |  |
 | `AlwaysOnSampler` | supported |  |  |
+| `AlwaysRecordSampler` | unknown |  | * `root`: unknown<br> |
 | `AttributeLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
 | `AttributeNameValue` | supported |  | * `name`: supported<br>* `type`: supported<br>* `value`: supported<br> |
 | `AttributeType` | supported |  | * `bool`: supported<br>* `bool_array`: supported<br>* `double`: supported<br>* `double_array`: supported<br>* `int`: supported<br>* `int_array`: supported<br>* `string`: supported<br>* `string_array`: supported<br> |
@@ -431,7 +435,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | supported |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
@@ -504,6 +508,7 @@ Latest supported file format: `1.0.0-rc.2`
 | `Aggregation` | ignored |  | * `base2_exponential_bucket_histogram`: ignored<br>* `default`: ignored<br>* `drop`: ignored<br>* `explicit_bucket_histogram`: ignored<br>* `last_value`: ignored<br>* `sum`: ignored<br> |
 | `AlwaysOffSampler` | supported |  |  |
 | `AlwaysOnSampler` | supported |  |  |
+| `AlwaysRecordSampler` | unknown |  | * `root`: unknown<br> |
 | `AttributeLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_length_limit`: supported<br> |
 | `AttributeNameValue` | supported |  | * `name`: supported<br>* `type`: not_implemented<br>* `value`: supported<br> |
 | `AttributeType` | not_implemented |  | * `bool`: not_implemented<br>* `bool_array`: not_implemented<br>* `double`: not_implemented<br>* `double_array`: not_implemented<br>* `int`: not_implemented<br>* `int_array`: not_implemented<br>* `string`: not_implemented<br>* `string_array`: not_implemented<br> |
@@ -552,7 +557,7 @@ Latest supported file format: `1.0.0-rc.2`
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | unknown |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
@@ -625,6 +630,7 @@ Latest supported file format: `1.0.0`
 | `Aggregation` | supported |  | * `base2_exponential_bucket_histogram`: supported<br>* `default`: supported<br>* `drop`: supported<br>* `explicit_bucket_histogram`: supported<br>* `last_value`: supported<br>* `sum`: supported<br> |
 | `AlwaysOffSampler` | supported |  |  |
 | `AlwaysOnSampler` | supported |  |  |
+| `AlwaysRecordSampler` | unknown |  | * `root`: unknown<br> |
 | `AttributeLimits` | ignored |  | * `attribute_count_limit`: ignored<br>* `attribute_value_length_limit`: ignored<br> |
 | `AttributeNameValue` | supported |  | * `name`: supported<br>* `type`: supported<br>* `value`: supported<br> |
 | `AttributeType` | supported |  | * `bool`: supported<br>* `bool_array`: supported<br>* `double`: supported<br>* `double_array`: supported<br>* `int`: supported<br>* `int_array`: supported<br>* `string`: supported<br>* `string_array`: supported<br> |
@@ -673,7 +679,7 @@ Latest supported file format: `1.0.0`
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | ignored |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -102,6 +102,21 @@
       ],
       "additionalProperties": false
     },
+    "AlwaysRecordSampler": {
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "root": {
+          "$ref": "#/$defs/Sampler",
+          "description": "Configure the wrapped sampler which provides the original sampling\ndecision that always_record modifies. DROP decisions are converted\nto RECORD_ONLY, so spans are passed to processors without being\nexported.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "root"
+      ]
+    },
     "AttributeLimits": {
       "type": "object",
       "additionalProperties": false,
@@ -2184,6 +2199,10 @@
         "always_on": {
           "$ref": "#/$defs/AlwaysOnSampler",
           "description": "Configure sampler to be always_on.\nIf omitted, ignore.\n"
+        },
+        "always_record": {
+          "$ref": "#/$defs/AlwaysRecordSampler",
+          "description": "Configure sampler to be always_record.\nIf omitted, ignore.\n"
         },
         "composite/development": {
           "$ref": "#/$defs/ExperimentalComposableSampler",

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -110,7 +110,7 @@
       "properties": {
         "root": {
           "$ref": "#/$defs/Sampler",
-          "description": "Configure the wrapped sampler which provides the original sampling\ndecision that always_record modifies. DROP decisions are converted\nto RECORD_ONLY, so spans are passed to processors without being\nexported.\nProperty is required and must be non-null.\n"
+          "description": "Configure the wrapped sampler which provides the original sampling\ndecision that AlwaysRecord modifies. DROP decisions are converted\nto RECORD_ONLY, allowing processors to see all spans without sending them to exporters.\nProperty is required and must be non-null.\n"
         }
       },
       "required": [

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -9,6 +9,9 @@ typeSupportStatuses:
   - type: AlwaysOnSampler
     status: supported
     propertyOverrides: []
+  - type: AlwaysRecordSampler
+    status: unknown
+    propertyOverrides: []
   - type: AttributeLimits
     status: supported
     propertyOverrides: []
@@ -159,7 +162,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: Sampler
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: always_record
+        status: unknown
   - type: SeverityNumber
     status: supported
     enumOverrides: []

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -9,6 +9,9 @@ typeSupportStatuses:
   - type: AlwaysOnSampler
     status: supported
     propertyOverrides: []
+  - type: AlwaysRecordSampler
+    status: unknown
+    propertyOverrides: []
   - type: AttributeLimits
     status: supported
     propertyOverrides: []
@@ -180,6 +183,8 @@ typeSupportStatuses:
   - type: Sampler
     status: supported
     propertyOverrides:
+      - property: always_record
+        status: unknown
       - property: composite/development
         status: not_implemented
       - property: jaeger_remote/development

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -9,6 +9,9 @@ typeSupportStatuses:
   - type: AlwaysOnSampler
     status: supported
     propertyOverrides: []
+  - type: AlwaysRecordSampler
+    status: unknown
+    propertyOverrides: []
   - type: AttributeLimits
     status: supported
     propertyOverrides: []
@@ -175,7 +178,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: Sampler
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: always_record
+        status: unknown
   - type: SeverityNumber
     status: supported
     enumOverrides: []

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -9,6 +9,9 @@ typeSupportStatuses:
   - type: AlwaysOnSampler
     status: supported
     propertyOverrides: []
+  - type: AlwaysRecordSampler
+    status: unknown
+    propertyOverrides: []
   - type: AttributeLimits
     status: supported
     propertyOverrides: []
@@ -161,7 +164,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: Sampler
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: always_record
+        status: unknown
   - type: SeverityNumber
     status: supported
     enumOverrides: []

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -9,6 +9,9 @@ typeSupportStatuses:
   - type: AlwaysOnSampler
     status: supported
     propertyOverrides: []
+  - type: AlwaysRecordSampler
+    status: unknown
+    propertyOverrides: []
   - type: AttributeLimits
     status: supported
     propertyOverrides: []
@@ -190,6 +193,8 @@ typeSupportStatuses:
   - type: Sampler
     status: supported
     propertyOverrides:
+      - property: always_record
+        status: unknown
       - property: composite/development
         status: not_implemented
       - property: jaeger_remote/development

--- a/schema/meta_schema_language_python.yaml
+++ b/schema/meta_schema_language_python.yaml
@@ -9,6 +9,9 @@ typeSupportStatuses:
   - type: AlwaysOnSampler
     status: supported
     propertyOverrides: []
+  - type: AlwaysRecordSampler
+    status: unknown
+    propertyOverrides: []
   - type: AttributeLimits
     status: ignored
     propertyOverrides: []
@@ -155,7 +158,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: Sampler
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: always_record
+        status: unknown
   - type: SeverityNumber
     status: supported
     enumOverrides: []

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -117,6 +117,10 @@ $defs:
         $ref: "#/$defs/AlwaysOnSampler"
         description: Configure sampler to be always_on.
         defaultBehavior: ignore
+      always_record:
+        $ref: "#/$defs/AlwaysRecordSampler"
+        description: Configure sampler to be always_record.
+        defaultBehavior: ignore
       composite/development:
         $ref: "#/$defs/ExperimentalComposableSampler"
         description: Configure sampler to be composite.
@@ -148,6 +152,20 @@ $defs:
       - object
       - "null"
     additionalProperties: false
+  AlwaysRecordSampler:
+    type:
+      - object
+    additionalProperties: false
+    properties:
+      root:
+        $ref: "#/$defs/Sampler"
+        description: |
+          Configure the wrapped sampler which provides the original sampling
+          decision that always_record modifies. DROP decisions are converted
+          to RECORD_ONLY, so spans are passed to processors without being
+          exported.
+    required:
+      - root
   ExperimentalJaegerRemoteSampler:
     type:
       - object

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -161,9 +161,8 @@ $defs:
         $ref: "#/$defs/Sampler"
         description: |
           Configure the wrapped sampler which provides the original sampling
-          decision that always_record modifies. DROP decisions are converted
-          to RECORD_ONLY, so spans are passed to processors without being
-          exported.
+          decision that AlwaysRecord modifies. DROP decisions are converted
+          to RECORD_ONLY, allowing processors to see all spans without sending them to exporters.
     required:
       - root
   ExperimentalJaegerRemoteSampler:

--- a/snippets/Sampler_always_record_typical.yaml
+++ b/snippets/Sampler_always_record_typical.yaml
@@ -1,0 +1,17 @@
+file_format: "1.1"
+
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  sampler:
+    # SNIPPET_START
+    # record all spans so processors see them (e.g. for span-to-metrics processing),
+    # while only exporting the spans sampled by the wrapped parent based sampler
+    always_record:
+      root:
+        parent_based:
+          root:
+            trace_id_ratio_based:
+              ratio: 0.01

--- a/snippets/Sampler_always_record_typical.yaml
+++ b/snippets/Sampler_always_record_typical.yaml
@@ -7,8 +7,9 @@ tracer_provider:
           console:
   sampler:
     # SNIPPET_START
-    # record all spans so processors see them (e.g. for span-to-metrics processing),
-    # while only exporting the spans sampled by the wrapped parent based sampler
+    # Record all spans so compatible processors can observe them, for example
+    # span-to-metrics processors. No such processor is configured in this
+    # snippet; the wrapped sampler still controls which spans are exported.
     always_record:
       root:
         parent_based:


### PR DESCRIPTION
## Summary

Add declarative configuration schema support for the stable OpenTelemetry `AlwaysRecord` sampler.

This change:

- adds `sampler.always_record`
- adds the `AlwaysRecordSampler` schema type with a required wrapped `root` sampler
- adds a focused configuration snippet
- regenerates the compiled schema and language-support documentation
- marks language-specific support for the new sampler as unknown pending confirmation from language maintainers

`AlwaysRecord` converts `DROP` decisions from the wrapped sampler to `RECORD_ONLY`, allowing all spans to reach span processors while only sampled spans are sent to exporters.

Fixes #83

## Validation

- `make all`
- `git diff --check`
- all examples validate
- all snippets validate
- compiled JSON schema validates
- repeated generation produces no additional changes
