### PR TITLE
schema: add SDK component names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Schema
 
 * Add optional experimental names for SDK processors, exporters, and metric readers.
+  ([#737](https://github.com/open-telemetry/opentelemetry-configuration/pull/737))
 
 ## v1.2.0 - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Schema
+
+* Add optional experimental names for SDK processors, exporters, and metric readers.
+
 ## v1.2.0 - 2026-09-11
 
 ### Schema

--- a/examples/otel-sdk-config.yaml
+++ b/examples/otel-sdk-config.yaml
@@ -25,12 +25,14 @@ propagator:
 tracer_provider:
   processors:
     - batch:
+        name/development: trace-batch
         schedule_delay: 5000
         export_timeout: 30000
         max_queue_size: 2048
         max_export_batch_size: 512
         exporter:
           otlp_http:
+            name/development: trace-otlp
             endpoint: http://localhost:4318/v1/traces
             tls:
               ca_file:
@@ -61,10 +63,12 @@ tracer_provider:
 meter_provider:
   readers:
     - periodic:
+        name/development: metrics-periodic
         interval: 60000
         timeout: 30000
         exporter:
           otlp_http:
+            name/development: metrics-otlp
             endpoint: http://localhost:4318/v1/metrics
             tls:
               ca_file:
@@ -78,12 +82,14 @@ meter_provider:
 logger_provider:
   processors:
     - batch:
+        name/development: logs-batch
         schedule_delay: 1000
         export_timeout: 30000
         max_queue_size: 2048
         max_export_batch_size: 512
         exporter:
           otlp_http:
+            name/development: logs-otlp
             endpoint: http://localhost:4318/v1/logs
             tls:
               ca_file:

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -28,11 +28,11 @@ Latest supported file format: `1.0.0`
 | `B3Propagator` | supported |  |  |
 | `BaggagePropagator` | supported |  |  |
 | `Base2ExponentialBucketHistogramAggregation` | supported |  | * `max_scale`: supported<br>* `max_size`: supported<br>* `record_min_max`: supported<br> |
-| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
-| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
+| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
 | `CardinalityLimits` | ignored |  | * `counter`: ignored<br>* `default`: ignored<br>* `gauge`: ignored<br>* `histogram`: ignored<br>* `observable_counter`: ignored<br>* `observable_gauge`: ignored<br>* `observable_up_down_counter`: ignored<br>* `up_down_counter`: ignored<br> |
-| `ConsoleExporter` | supported |  |  |
-| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `temporality_preference`: supported<br> |
+| `ConsoleExporter` | supported |  | * `name/development`: unknown<br> |
+| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `temporality_preference`: supported<br>* `name/development`: unknown<br> |
 | `DefaultAggregation` | supported |  |  |
 | `Distribution` | supported |  |  |
 | `DropAggregation` | supported |  |  |
@@ -56,23 +56,23 @@ Latest supported file format: `1.0.0`
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | supported |  |  |
 | `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
-| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
-| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br>* `name/development`: unknown<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
 | `PullMetricExporter` | supported |  | * `prometheus/development`: supported<br> |
-| `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br> |
+| `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br>* `name/development`: unknown<br> |
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | not_implemented |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: not_implemented<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
-| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
-| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
+| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
+| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
 | `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
@@ -97,7 +97,7 @@ Latest supported file format: `1.0.0`
 | `ExperimentalComposableSampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_threshold`: supported<br>* `probability`: supported<br>* `rule_based`: supported<br> |
 | `ExperimentalContainerResourceDetector` | supported |  |  |
 | `ExperimentalDbInstrumentation` | not_applicable |  | * `semconv`: not_applicable<br> |
-| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  |  |
+| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  | * `name/development`: not_implemented<br> |
 | `ExperimentalGenAiInstrumentation` | not_applicable |  | * `semconv`: not_applicable<br> |
 | `ExperimentalGeneralInstrumentation` | not_applicable |  | * `code`: not_applicable<br>* `db`: not_applicable<br>* `gen_ai`: not_applicable<br>* `http`: not_applicable<br>* `messaging`: not_applicable<br>* `rpc`: not_applicable<br>* `sanitization`: not_applicable<br>* `stability_opt_in_list`: not_applicable<br> |
 | `ExperimentalHostResourceDetector` | supported |  |  |
@@ -114,11 +114,11 @@ Latest supported file format: `1.0.0`
 | `ExperimentalMeterConfig` | supported |  | * `enabled`: supported<br> |
 | `ExperimentalMeterConfigurator` | supported |  | * `default_config`: supported<br>* `meters`: supported<br> |
 | `ExperimentalMeterMatcherAndConfig` | supported |  | * `config`: supported<br>* `name`: supported<br> |
-| `ExperimentalOtlpFileExporter` | supported |  | * `output_stream`: supported<br> |
-| `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br> |
+| `ExperimentalOtlpFileExporter` | supported |  | * `output_stream`: supported<br>* `name/development`: unknown<br> |
+| `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br>* `name/development`: unknown<br> |
 | `ExperimentalProbabilitySampler` | supported |  | * `ratio`: supported<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
+| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `name/development`: unknown<br>* `target_info_enabled/development`: supported<br> |
 | `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
@@ -151,11 +151,11 @@ Latest supported file format: `1.0.0`
 | `B3Propagator` | supported |  |  |
 | `BaggagePropagator` | supported |  |  |
 | `Base2ExponentialBucketHistogramAggregation` | unknown |  | * `max_scale`: unknown<br>* `max_size`: unknown<br>* `record_min_max`: unknown<br> |
-| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
-| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
+| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
 | `CardinalityLimits` | unknown |  | * `counter`: unknown<br>* `default`: unknown<br>* `gauge`: unknown<br>* `histogram`: unknown<br>* `observable_counter`: unknown<br>* `observable_gauge`: unknown<br>* `observable_up_down_counter`: unknown<br>* `up_down_counter`: unknown<br> |
-| `ConsoleExporter` | supported |  |  |
-| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
+| `ConsoleExporter` | supported |  | * `name/development`: unknown<br> |
+| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: not_implemented<br>* `name/development`: unknown<br> |
 | `DefaultAggregation` | unknown |  |  |
 | `Distribution` | unknown |  |  |
 | `DropAggregation` | unknown |  |  |
@@ -179,23 +179,23 @@ Latest supported file format: `1.0.0`
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | unknown |  |  |
 | `OpenTelemetryConfiguration` | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation/development`: unknown<br> |
-| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `OtlpHttpEncoding` | not_implemented |  | * `json`: not_implemented<br>* `protobuf`: not_implemented<br> |
-| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: not_implemented<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: not_implemented<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br>* `name/development`: unknown<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
 | `PullMetricExporter` | unknown |  | * `prometheus/development`: unknown<br> |
-| `PullMetricReader` | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br> |
+| `PullMetricReader` | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br>* `name/development`: unknown<br> |
 | `PushMetricExporter` | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
 | `RandomIdGenerator` | unknown |  |  |
 | `Resource` | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
 | `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
 | `SeverityNumber` | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
-| `SimpleLogRecordProcessor` | unknown |  | * `exporter`: unknown<br> |
-| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
+| `SimpleLogRecordProcessor` | unknown |  | * `exporter`: unknown<br>* `name/development`: unknown<br> |
+| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
 | `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: not_implemented<br> |
 | `SpanKind` | unknown |  | * `client`: unknown<br>* `consumer`: unknown<br>* `internal`: unknown<br>* `producer`: unknown<br>* `server`: unknown<br> |
 | `SpanLimits` | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_depth_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br>* `event_attribute_count_limit`: unknown<br>* `event_count_limit`: unknown<br>* `link_attribute_count_limit`: unknown<br>* `link_count_limit`: unknown<br> |
@@ -220,7 +220,7 @@ Latest supported file format: `1.0.0`
 | `ExperimentalComposableSampler` | not_implemented |  | * `always_off`: not_implemented<br>* `always_on`: not_implemented<br>* `parent_threshold`: not_implemented<br>* `probability`: not_implemented<br>* `rule_based`: not_implemented<br> |
 | `ExperimentalContainerResourceDetector` | supported |  |  |
 | `ExperimentalDbInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
-| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  |  |
+| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  | * `name/development`: not_implemented<br> |
 | `ExperimentalGenAiInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
 | `ExperimentalGeneralInstrumentation` | not_implemented |  | * `code`: not_implemented<br>* `db`: not_implemented<br>* `gen_ai`: not_implemented<br>* `http`: not_implemented<br>* `messaging`: not_implemented<br>* `rpc`: not_implemented<br>* `sanitization`: not_implemented<br>* `stability_opt_in_list`: not_implemented<br> |
 | `ExperimentalHostResourceDetector` | supported |  |  |
@@ -237,11 +237,11 @@ Latest supported file format: `1.0.0`
 | `ExperimentalMeterConfig` | unknown |  | * `enabled`: unknown<br> |
 | `ExperimentalMeterConfigurator` | not_implemented |  | * `default_config`: not_implemented<br>* `meters`: not_implemented<br> |
 | `ExperimentalMeterMatcherAndConfig` | unknown |  | * `config`: unknown<br>* `name`: unknown<br> |
-| `ExperimentalOtlpFileExporter` | not_implemented |  | * `output_stream`: not_implemented<br> |
-| `ExperimentalOtlpFileMetricExporter` | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
+| `ExperimentalOtlpFileExporter` | not_implemented |  | * `output_stream`: not_implemented<br>* `name/development`: not_implemented<br> |
+| `ExperimentalOtlpFileMetricExporter` | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br>* `name/development`: not_implemented<br> |
 | `ExperimentalProbabilitySampler` | not_implemented |  | * `ratio`: not_implemented<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
+| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `name/development`: unknown<br>* `target_info_enabled/development`: supported<br> |
 | `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation/development`: supported<br>* `no_utf8_escaping_with_suffixes/development`: supported<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
@@ -274,11 +274,11 @@ Latest supported file format: `1.0.0-rc.3`
 | `B3Propagator` | supported |  |  |
 | `BaggagePropagator` | supported |  |  |
 | `Base2ExponentialBucketHistogramAggregation` | supported |  | * `max_scale`: supported<br>* `max_size`: supported<br>* `record_min_max`: supported<br> |
-| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
-| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
+| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
 | `CardinalityLimits` | supported |  | * `counter`: supported<br>* `default`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
-| `ConsoleExporter` | supported |  |  |
-| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: ignored<br> |
+| `ConsoleExporter` | supported |  | * `name/development`: unknown<br> |
+| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: ignored<br>* `name/development`: unknown<br> |
 | `DefaultAggregation` | supported |  |  |
 | `Distribution` | supported |  |  |
 | `DropAggregation` | supported |  |  |
@@ -302,23 +302,23 @@ Latest supported file format: `1.0.0-rc.3`
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | ignored |  |  |
 | `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
-| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `OtlpHttpEncoding` | not_implemented |  | * `json`: not_implemented<br>* `protobuf`: not_implemented<br> |
-| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br>* `name/development`: unknown<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
 | `PullMetricExporter` | supported |  | * `prometheus/development`: supported<br> |
-| `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: not_implemented<br> |
+| `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: not_implemented<br>* `name/development`: unknown<br> |
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | unknown |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
-| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
-| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
+| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
+| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
 | `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
@@ -343,7 +343,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalComposableSampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_threshold`: supported<br>* `probability`: supported<br>* `rule_based`: supported<br> |
 | `ExperimentalContainerResourceDetector` | supported |  |  |
 | `ExperimentalDbInstrumentation` | unknown |  | * `semconv`: unknown<br> |
-| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | supported |  |  |
+| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | supported |  | * `name/development`: unknown<br> |
 | `ExperimentalGenAiInstrumentation` | unknown |  | * `semconv`: unknown<br> |
 | `ExperimentalGeneralInstrumentation` | supported |  | * `code`: supported<br>* `db`: supported<br>* `gen_ai`: supported<br>* `http`: supported<br>* `messaging`: supported<br>* `rpc`: supported<br>* `sanitization`: supported<br>* `stability_opt_in_list`: supported<br> |
 | `ExperimentalHostResourceDetector` | supported |  |  |
@@ -360,11 +360,11 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalMeterConfig` | supported |  | * `enabled`: supported<br> |
 | `ExperimentalMeterConfigurator` | supported |  | * `default_config`: supported<br>* `meters`: supported<br> |
 | `ExperimentalMeterMatcherAndConfig` | supported |  | * `config`: supported<br>* `name`: supported<br> |
-| `ExperimentalOtlpFileExporter` | supported |  | * `output_stream`: not_implemented<br> |
-| `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: not_implemented<br>* `temporality_preference`: supported<br> |
+| `ExperimentalOtlpFileExporter` | supported |  | * `output_stream`: not_implemented<br>* `name/development`: unknown<br> |
+| `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: not_implemented<br>* `temporality_preference`: supported<br>* `name/development`: unknown<br> |
 | `ExperimentalProbabilitySampler` | supported |  | * `ratio`: supported<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: supported<br> |
+| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: not_implemented<br>* `name/development`: unknown<br>* `target_info_enabled/development`: supported<br> |
 | `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
@@ -397,11 +397,11 @@ Latest supported file format: `1.0.0-rc.3`
 | `B3Propagator` | supported |  |  |
 | `BaggagePropagator` | supported |  |  |
 | `Base2ExponentialBucketHistogramAggregation` | supported |  | * `max_scale`: supported<br>* `max_size`: supported<br>* `record_min_max`: supported<br> |
-| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
-| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
+| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
 | `CardinalityLimits` | not_implemented |  | * `counter`: not_implemented<br>* `default`: not_implemented<br>* `gauge`: not_implemented<br>* `histogram`: not_implemented<br>* `observable_counter`: not_implemented<br>* `observable_gauge`: not_implemented<br>* `observable_up_down_counter`: not_implemented<br>* `up_down_counter`: not_implemented<br> |
-| `ConsoleExporter` | supported |  |  |
-| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
+| `ConsoleExporter` | supported |  | * `name/development`: unknown<br> |
+| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: not_implemented<br>* `name/development`: unknown<br> |
 | `DefaultAggregation` | supported |  |  |
 | `Distribution` | not_implemented |  |  |
 | `DropAggregation` | supported |  |  |
@@ -425,23 +425,23 @@ Latest supported file format: `1.0.0-rc.3`
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | not_implemented |  |  |
 | `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
-| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
-| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br>* `name/development`: unknown<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
 | `PullMetricExporter` | not_implemented |  | * `prometheus/development`: not_implemented<br> |
-| `PullMetricReader` | not_implemented |  | * `cardinality_limits`: not_implemented<br>* `exporter`: not_implemented<br>* `producers`: not_implemented<br> |
+| `PullMetricReader` | not_implemented |  | * `cardinality_limits`: not_implemented<br>* `exporter`: not_implemented<br>* `producers`: not_implemented<br>* `name/development`: not_implemented<br> |
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | supported |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
-| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
-| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
+| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
+| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
 | `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
@@ -466,7 +466,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalComposableSampler` | not_implemented |  | * `always_off`: not_implemented<br>* `always_on`: not_implemented<br>* `parent_threshold`: not_implemented<br>* `probability`: not_implemented<br>* `rule_based`: not_implemented<br> |
 | `ExperimentalContainerResourceDetector` | not_implemented |  |  |
 | `ExperimentalDbInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
-| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  |  |
+| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  | * `name/development`: not_implemented<br> |
 | `ExperimentalGenAiInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
 | `ExperimentalGeneralInstrumentation` | not_implemented |  | * `code`: not_implemented<br>* `db`: not_implemented<br>* `gen_ai`: not_implemented<br>* `http`: not_implemented<br>* `messaging`: not_implemented<br>* `rpc`: not_implemented<br>* `sanitization`: not_implemented<br>* `stability_opt_in_list`: not_implemented<br> |
 | `ExperimentalHostResourceDetector` | supported |  |  |
@@ -483,11 +483,11 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalMeterConfig` | not_implemented |  | * `enabled`: not_implemented<br> |
 | `ExperimentalMeterConfigurator` | not_implemented |  | * `default_config`: not_implemented<br>* `meters`: not_implemented<br> |
 | `ExperimentalMeterMatcherAndConfig` | not_implemented |  | * `config`: not_implemented<br>* `name`: not_implemented<br> |
-| `ExperimentalOtlpFileExporter` | not_implemented |  | * `output_stream`: not_implemented<br> |
-| `ExperimentalOtlpFileMetricExporter` | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
+| `ExperimentalOtlpFileExporter` | not_implemented |  | * `output_stream`: not_implemented<br>* `name/development`: not_implemented<br> |
+| `ExperimentalOtlpFileMetricExporter` | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br>* `name/development`: not_implemented<br> |
 | `ExperimentalProbabilitySampler` | not_implemented |  | * `ratio`: not_implemented<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
+| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `name/development`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
 | `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
@@ -520,11 +520,11 @@ Latest supported file format: `1.0.0-rc.2`
 | `B3Propagator` | supported |  |  |
 | `BaggagePropagator` | supported |  |  |
 | `Base2ExponentialBucketHistogramAggregation` | not_implemented |  | * `max_scale`: not_implemented<br>* `max_size`: not_implemented<br>* `record_min_max`: not_implemented<br> |
-| `BatchLogRecordProcessor` | supported | `schedule_delay` is only checked on `::onEmit()`. | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
-| `BatchSpanProcessor` | supported | `schedule_delay` is only checked on `::onEnd()`. | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| `BatchLogRecordProcessor` | supported | `schedule_delay` is only checked on `::onEmit()`. | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
+| `BatchSpanProcessor` | supported | `schedule_delay` is only checked on `::onEnd()`. | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
 | `CardinalityLimits` | not_implemented |  | * `counter`: not_implemented<br>* `default`: not_implemented<br>* `gauge`: not_implemented<br>* `histogram`: not_implemented<br>* `observable_counter`: not_implemented<br>* `observable_gauge`: not_implemented<br>* `observable_up_down_counter`: not_implemented<br>* `up_down_counter`: not_implemented<br> |
-| `ConsoleExporter` | supported |  |  |
-| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: ignored<br> |
+| `ConsoleExporter` | supported |  | * `name/development`: unknown<br> |
+| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `temporality_preference`: ignored<br>* `name/development`: unknown<br> |
 | `DefaultAggregation` | ignored |  |  |
 | `Distribution` | not_implemented |  |  |
 | `DropAggregation` | ignored |  |  |
@@ -548,23 +548,23 @@ Latest supported file format: `1.0.0-rc.2`
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | not_implemented |  |  |
 | `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: not_implemented<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
-| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: ignored<br> |
-| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: ignored<br> |
+| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: ignored<br>* `name/development`: unknown<br> |
+| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: ignored<br>* `name/development`: unknown<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
-| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: ignored<br> |
-| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: ignored<br> |
+| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: ignored<br>* `name/development`: unknown<br> |
+| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: ignored<br>* `name/development`: unknown<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: not_implemented<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: not_implemented<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br>* `name/development`: unknown<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
 | `PullMetricExporter` | not_implemented |  | * `prometheus/development`: not_implemented<br> |
-| `PullMetricReader` | not_implemented |  | * `cardinality_limits`: not_implemented<br>* `exporter`: not_implemented<br>* `producers`: not_implemented<br> |
+| `PullMetricReader` | not_implemented |  | * `cardinality_limits`: not_implemented<br>* `exporter`: not_implemented<br>* `producers`: not_implemented<br>* `name/development`: not_implemented<br> |
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | unknown |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
-| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
-| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
+| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
+| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
 | `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `SpanKind` | not_implemented |  | * `client`: not_implemented<br>* `consumer`: not_implemented<br>* `internal`: not_implemented<br>* `producer`: not_implemented<br>* `server`: not_implemented<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
@@ -589,7 +589,7 @@ Latest supported file format: `1.0.0-rc.2`
 | `ExperimentalComposableSampler` | not_implemented |  | * `always_off`: not_implemented<br>* `always_on`: not_implemented<br>* `parent_threshold`: not_implemented<br>* `probability`: not_implemented<br>* `rule_based`: not_implemented<br> |
 | `ExperimentalContainerResourceDetector` | ignored |  |  |
 | `ExperimentalDbInstrumentation` | unknown |  | * `semconv`: unknown<br> |
-| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  |  |
+| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | not_implemented |  | * `name/development`: not_implemented<br> |
 | `ExperimentalGenAiInstrumentation` | unknown |  | * `semconv`: unknown<br> |
 | `ExperimentalGeneralInstrumentation` | supported |  | * `code`: supported<br>* `db`: supported<br>* `gen_ai`: supported<br>* `http`: supported<br>* `messaging`: supported<br>* `rpc`: supported<br>* `sanitization`: supported<br>* `stability_opt_in_list`: supported<br> |
 | `ExperimentalHostResourceDetector` | supported |  |  |
@@ -606,11 +606,11 @@ Latest supported file format: `1.0.0-rc.2`
 | `ExperimentalMeterConfig` | supported |  | * `enabled`: supported<br> |
 | `ExperimentalMeterConfigurator` | supported |  | * `default_config`: supported<br>* `meters`: supported<br> |
 | `ExperimentalMeterMatcherAndConfig` | supported |  | * `config`: supported<br>* `name`: supported<br> |
-| `ExperimentalOtlpFileExporter` | supported |  | * `output_stream`: supported<br> |
-| `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br> |
+| `ExperimentalOtlpFileExporter` | supported |  | * `output_stream`: supported<br>* `name/development`: unknown<br> |
+| `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br>* `name/development`: unknown<br> |
 | `ExperimentalProbabilitySampler` | not_implemented |  | * `ratio`: not_implemented<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
+| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `name/development`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
 | `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: ignored<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
@@ -643,11 +643,11 @@ Latest supported file format: `1.0.0`
 | `B3Propagator` | supported |  |  |
 | `BaggagePropagator` | supported |  |  |
 | `Base2ExponentialBucketHistogramAggregation` | supported |  | * `max_scale`: supported<br>* `max_size`: supported<br>* `record_min_max`: supported<br> |
-| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
-| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br> |
+| `BatchLogRecordProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
+| `BatchSpanProcessor` | supported |  | * `export_timeout`: supported<br>* `exporter`: supported<br>* `max_export_batch_size`: supported<br>* `max_queue_size`: supported<br>* `schedule_delay`: supported<br>* `name/development`: unknown<br> |
 | `CardinalityLimits` | supported |  | * `counter`: supported<br>* `default`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
-| `ConsoleExporter` | supported |  |  |
-| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `temporality_preference`: supported<br> |
+| `ConsoleExporter` | supported |  | * `name/development`: unknown<br> |
+| `ConsoleMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `temporality_preference`: supported<br>* `name/development`: unknown<br> |
 | `DefaultAggregation` | supported |  |  |
 | `Distribution` | ignored |  |  |
 | `DropAggregation` | supported |  |  |
@@ -671,23 +671,23 @@ Latest supported file format: `1.0.0`
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | ignored |  |  |
 | `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
-| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
-| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
-| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
+| `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
+| `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br>* `name/development`: unknown<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: supported<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: supported<br>* `name/development`: unknown<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
 | `PullMetricExporter` | supported |  | * `prometheus/development`: supported<br> |
-| `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br> |
+| `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br>* `name/development`: unknown<br> |
 | `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `RandomIdGenerator` | ignored |  |  |
 | `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
 | `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
-| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
-| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
+| `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
+| `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br>* `name/development`: unknown<br> |
 | `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
@@ -712,7 +712,7 @@ Latest supported file format: `1.0.0`
 | `ExperimentalComposableSampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `parent_threshold`: supported<br>* `probability`: supported<br>* `rule_based`: supported<br> |
 | `ExperimentalContainerResourceDetector` | ignored |  |  |
 | `ExperimentalDbInstrumentation` | ignored |  | * `semconv`: ignored<br> |
-| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | ignored |  |  |
+| `ExperimentalEventToSpanEventBridgeLogRecordProcessor` | ignored |  | * `name/development`: ignored<br> |
 | `ExperimentalGenAiInstrumentation` | ignored |  | * `semconv`: ignored<br> |
 | `ExperimentalGeneralInstrumentation` | ignored |  | * `code`: ignored<br>* `db`: ignored<br>* `gen_ai`: ignored<br>* `http`: ignored<br>* `messaging`: ignored<br>* `rpc`: ignored<br>* `sanitization`: ignored<br>* `stability_opt_in_list`: ignored<br> |
 | `ExperimentalHostResourceDetector` | supported |  |  |
@@ -729,11 +729,11 @@ Latest supported file format: `1.0.0`
 | `ExperimentalMeterConfig` | ignored |  | * `enabled`: ignored<br> |
 | `ExperimentalMeterConfigurator` | ignored |  | * `default_config`: ignored<br>* `meters`: ignored<br> |
 | `ExperimentalMeterMatcherAndConfig` | ignored |  | * `config`: ignored<br>* `name`: ignored<br> |
-| `ExperimentalOtlpFileExporter` | ignored |  | * `output_stream`: ignored<br> |
-| `ExperimentalOtlpFileMetricExporter` | ignored |  | * `default_histogram_aggregation`: ignored<br>* `output_stream`: ignored<br>* `temporality_preference`: ignored<br> |
+| `ExperimentalOtlpFileExporter` | ignored |  | * `output_stream`: ignored<br>* `name/development`: ignored<br> |
+| `ExperimentalOtlpFileMetricExporter` | ignored |  | * `default_histogram_aggregation`: ignored<br>* `output_stream`: ignored<br>* `temporality_preference`: ignored<br>* `name/development`: ignored<br> |
 | `ExperimentalProbabilitySampler` | ignored |  | * `ratio`: ignored<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | ignored |  | * `host`: ignored<br>* `port`: ignored<br>* `resource_constant_labels`: ignored<br>* `scope_info_enabled`: ignored<br>* `translation_strategy`: ignored<br>* `target_info_enabled/development`: ignored<br> |
+| `ExperimentalPrometheusMetricExporter` | ignored |  | * `host`: ignored<br>* `port`: ignored<br>* `resource_constant_labels`: ignored<br>* `scope_info_enabled`: ignored<br>* `translation_strategy`: ignored<br>* `name/development`: ignored<br>* `target_info_enabled/development`: ignored<br> |
 | `ExperimentalPrometheusTranslationStrategy` | ignored |  | * `no_translation/development`: ignored<br>* `no_utf8_escaping_with_suffixes/development`: ignored<br>* `underscore_escaping_with_suffixes`: ignored<br>* `underscore_escaping_without_suffixes/development`: ignored<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -282,7 +282,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "schedule_delay": {
           "type": [
@@ -334,7 +334,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "schedule_delay": {
           "type": [
@@ -459,7 +459,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         }
       }
     },
@@ -475,7 +475,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "temporality_preference": {
           "$ref": "#/$defs/ExporterTemporalityPreference",
@@ -744,7 +744,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         }
       }
     },
@@ -1121,7 +1121,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "output_stream": {
           "type": [
@@ -1144,7 +1144,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "output_stream": {
           "type": [
@@ -1200,7 +1200,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "host": {
           "type": [
@@ -1840,7 +1840,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "endpoint": {
           "type": [
@@ -1913,7 +1913,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "endpoint": {
           "type": [
@@ -2004,7 +2004,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "endpoint": {
           "type": [
@@ -2081,7 +2081,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "endpoint": {
           "type": [
@@ -2192,7 +2192,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "interval": {
           "type": [
@@ -2286,7 +2286,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "exporter": {
           "$ref": "#/$defs/PullMetricExporter",
@@ -2463,7 +2463,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "exporter": {
           "$ref": "#/$defs/LogRecordExporter",
@@ -2483,7 +2483,7 @@
             "string",
             "null"
           ],
-          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
         },
         "exporter": {
           "$ref": "#/$defs/SpanExporter",

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -277,6 +277,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "schedule_delay": {
           "type": [
             "integer",
@@ -322,6 +329,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "schedule_delay": {
           "type": [
             "integer",
@@ -438,7 +452,16 @@
         "object",
         "null"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        }
+      }
     },
     "ConsoleMetricExporter": {
       "type": [
@@ -447,6 +470,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "temporality_preference": {
           "$ref": "#/$defs/ExporterTemporalityPreference",
           "description": "Configure temporality preference.\nValues include:\n* cumulative: Use cumulative aggregation temporality for all instrument types.\n* delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter.\n* low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types.\nIf omitted, cumulative is used.\n"
@@ -707,7 +737,16 @@
         "object",
         "null"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        }
+      }
     },
     "ExperimentalGenAiInstrumentation": {
       "type": "object",
@@ -1077,6 +1116,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "output_stream": {
           "type": [
             "string",
@@ -1093,6 +1139,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "output_stream": {
           "type": [
             "string",
@@ -1142,6 +1195,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "host": {
           "type": [
             "string",
@@ -1775,6 +1835,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "endpoint": {
           "type": [
             "string",
@@ -1841,6 +1908,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "endpoint": {
           "type": [
             "string",
@@ -1925,6 +1999,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "endpoint": {
           "type": [
             "string",
@@ -1995,6 +2076,13 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "endpoint": {
           "type": [
             "string",
@@ -2099,6 +2187,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "interval": {
           "type": [
             "integer",
@@ -2186,6 +2281,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "exporter": {
           "$ref": "#/$defs/PullMetricExporter",
           "description": "Configure exporter.\nProperty is required and must be non-null.\n"
@@ -2356,6 +2458,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "exporter": {
           "$ref": "#/$defs/LogRecordExporter",
           "description": "Configure exporter.\nProperty is required and must be non-null.\n"
@@ -2369,6 +2478,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "name/development": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure the name used as `otel.component.name` in SDK self-observability telemetry.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+        },
         "exporter": {
           "$ref": "#/$defs/SpanExporter",
           "description": "Configure exporter.\nProperty is required and must be non-null.\n"

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -282,7 +282,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "schedule_delay": {
           "type": [
@@ -334,7 +334,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "schedule_delay": {
           "type": [
@@ -459,7 +459,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         }
       }
     },
@@ -475,7 +475,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "temporality_preference": {
           "$ref": "#/$defs/ExporterTemporalityPreference",
@@ -744,7 +744,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         }
       }
     },
@@ -1121,7 +1121,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "output_stream": {
           "type": [
@@ -1144,7 +1144,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "output_stream": {
           "type": [
@@ -1200,7 +1200,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "host": {
           "type": [
@@ -1840,7 +1840,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "endpoint": {
           "type": [
@@ -1913,7 +1913,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "endpoint": {
           "type": [
@@ -2004,7 +2004,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "endpoint": {
           "type": [
@@ -2081,7 +2081,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "endpoint": {
           "type": [
@@ -2192,7 +2192,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "interval": {
           "type": [
@@ -2286,7 +2286,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "exporter": {
           "$ref": "#/$defs/PullMetricExporter",
@@ -2463,7 +2463,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "exporter": {
           "$ref": "#/$defs/LogRecordExporter",
@@ -2483,7 +2483,7 @@
             "string",
             "null"
           ],
-          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an automatically assigned name is used. If present and null, an automatically assigned name is used.\n"
+          "description": "Configure a name that uniquely identifies this component within its containing SDK instance. When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.\nIf omitted, an implementation-defined component name is automatically assigned. If present and null, an implementation-defined component name is automatically assigned.\n"
         },
         "exporter": {
           "$ref": "#/$defs/SpanExporter",

--- a/schema/common.yaml
+++ b/schema/common.yaml
@@ -47,6 +47,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       endpoint:
         type:
           - string
@@ -132,6 +139,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       endpoint:
         type:
           - string
@@ -201,6 +215,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       output_stream:
         type:
           - string
@@ -214,6 +235,14 @@ $defs:
       - object
       - "null"
     additionalProperties: false
+    properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
   HttpTls:
     type:
       - object

--- a/schema/common.yaml
+++ b/schema/common.yaml
@@ -54,8 +54,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       endpoint:
         type:
           - string
@@ -148,8 +148,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       endpoint:
         type:
           - string
@@ -226,8 +226,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       output_stream:
         type:
           - string
@@ -249,8 +249,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
   HttpTls:
     type:
       - object

--- a/schema/common.yaml
+++ b/schema/common.yaml
@@ -51,7 +51,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       endpoint:
@@ -143,7 +145,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       endpoint:
@@ -219,7 +223,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       output_stream:
@@ -240,7 +246,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
   HttpTls:

--- a/schema/logger_provider.yaml
+++ b/schema/logger_provider.yaml
@@ -23,6 +23,13 @@ $defs:
     type: object
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       exporter:
         $ref: "#/$defs/LogRecordExporter"
         description: Configure exporter.
@@ -32,6 +39,13 @@ $defs:
     type: object
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       schedule_delay:
         type:
           - integer
@@ -76,6 +90,14 @@ $defs:
       - object
       - "null"
     additionalProperties: false
+    properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
   LogRecordExporter:
     type: object
     additionalProperties:

--- a/schema/logger_provider.yaml
+++ b/schema/logger_provider.yaml
@@ -27,7 +27,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       exporter:
@@ -43,7 +45,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       schedule_delay:
@@ -95,7 +99,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
   LogRecordExporter:

--- a/schema/logger_provider.yaml
+++ b/schema/logger_provider.yaml
@@ -30,8 +30,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       exporter:
         $ref: "#/$defs/LogRecordExporter"
         description: Configure exporter.
@@ -48,8 +48,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       schedule_delay:
         type:
           - integer
@@ -102,8 +102,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
   LogRecordExporter:
     type: object
     additionalProperties:

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -37,19 +37,27 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: BatchLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: BatchSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: CardinalityLimits
     status: ignored
     propertyOverrides: []
   - type: ConsoleExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ConsoleMetricExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: DefaultAggregation
     status: supported
     propertyOverrides: []
@@ -132,6 +140,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpGrpcMetricExporter
     status: supported
     propertyOverrides:
@@ -139,6 +149,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpEncoding
     status: supported
     enumOverrides: []
@@ -149,6 +161,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpMetricExporter
     status: supported
     propertyOverrides:
@@ -156,6 +170,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: ParentBasedSampler
     status: supported
     propertyOverrides: []
@@ -164,6 +180,8 @@ typeSupportStatuses:
     propertyOverrides:
       - property: max_export_batch_size/development
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: Propagator
     status: supported
     propertyOverrides: []
@@ -172,7 +190,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: PullMetricReader
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: PushMetricExporter
     status: supported
     propertyOverrides: []
@@ -192,10 +212,14 @@ typeSupportStatuses:
     enumOverrides: []
   - type: SimpleLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SimpleSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SpanExporter
     status: supported
     propertyOverrides: []
@@ -323,10 +347,14 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalOtlpFileExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ExperimentalOtlpFileMetricExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ExperimentalProbabilitySampler
     status: supported
     propertyOverrides: []
@@ -335,7 +363,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ExperimentalPrometheusTranslationStrategy
     status: supported
     enumOverrides:

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -37,21 +37,29 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: BatchLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: BatchSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: CardinalityLimits
     status: unknown
     propertyOverrides: []
   - type: ConsoleExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ConsoleMetricExporter
     status: supported
     propertyOverrides:
       - property: default_histogram_aggregation
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: temporality_preference
         status: not_implemented
   - type: DefaultAggregation
@@ -140,6 +148,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpGrpcMetricExporter
     status: supported
     propertyOverrides:
@@ -149,6 +159,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpEncoding
     status: not_implemented
     enumOverrides: []
@@ -161,6 +173,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpMetricExporter
     status: supported
     propertyOverrides:
@@ -172,6 +186,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: ParentBasedSampler
     status: supported
     propertyOverrides: []
@@ -182,6 +198,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_export_batch_size/development
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: producers
         status: not_implemented
   - type: Propagator
@@ -221,7 +239,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: SimpleSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SpanExporter
     status: supported
     propertyOverrides:
@@ -361,7 +381,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalPrometheusMetricExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ExperimentalPrometheusTranslationStrategy
     status: supported
     enumOverrides: []

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -37,21 +37,29 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: BatchLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: BatchSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: CardinalityLimits
     status: supported
     propertyOverrides: []
   - type: ConsoleExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ConsoleMetricExporter
     status: supported
     propertyOverrides:
       - property: default_histogram_aggregation
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: temporality_preference
         status: ignored
   - type: DefaultAggregation
@@ -140,6 +148,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpGrpcMetricExporter
     status: supported
     propertyOverrides:
@@ -147,6 +157,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpEncoding
     status: not_implemented
     enumOverrides: []
@@ -159,6 +171,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpMetricExporter
     status: supported
     propertyOverrides:
@@ -168,6 +182,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: ParentBasedSampler
     status: supported
     propertyOverrides: []
@@ -176,6 +192,8 @@ typeSupportStatuses:
     propertyOverrides:
       - property: max_export_batch_size/development
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: producers
         status: not_implemented
   - type: Propagator
@@ -187,6 +205,8 @@ typeSupportStatuses:
   - type: PullMetricReader
     status: supported
     propertyOverrides:
+      - property: name/development
+        status: unknown
       - property: producers
         status: not_implemented
   - type: PushMetricExporter
@@ -208,10 +228,14 @@ typeSupportStatuses:
     enumOverrides: []
   - type: SimpleLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SimpleSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SpanExporter
     status: supported
     propertyOverrides: []
@@ -288,7 +312,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalEventToSpanEventBridgeLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ExperimentalGenAiInstrumentation
     status: unknown
     propertyOverrides: []
@@ -360,11 +386,15 @@ typeSupportStatuses:
   - type: ExperimentalOtlpFileExporter
     status: supported
     propertyOverrides:
+      - property: name/development
+        status: unknown
       - property: output_stream
         status: not_implemented
   - type: ExperimentalOtlpFileMetricExporter
     status: supported
     propertyOverrides:
+      - property: name/development
+        status: unknown
       - property: output_stream
         status: not_implemented
   - type: ExperimentalProbabilitySampler
@@ -376,6 +406,8 @@ typeSupportStatuses:
   - type: ExperimentalPrometheusMetricExporter
     status: supported
     propertyOverrides:
+      - property: name/development
+        status: unknown
       - property: translation_strategy
         status: not_implemented
   - type: ExperimentalPrometheusTranslationStrategy

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -37,21 +37,29 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: BatchLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: BatchSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: CardinalityLimits
     status: not_implemented
     propertyOverrides: []
   - type: ConsoleExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ConsoleMetricExporter
     status: supported
     propertyOverrides:
       - property: default_histogram_aggregation
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: temporality_preference
         status: not_implemented
   - type: DefaultAggregation
@@ -134,6 +142,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpGrpcMetricExporter
     status: supported
     propertyOverrides:
@@ -141,6 +151,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpEncoding
     status: supported
     enumOverrides: []
@@ -151,6 +163,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpMetricExporter
     status: supported
     propertyOverrides:
@@ -158,6 +172,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: ParentBasedSampler
     status: supported
     propertyOverrides: []
@@ -166,6 +182,8 @@ typeSupportStatuses:
     propertyOverrides:
       - property: max_export_batch_size/development
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: Propagator
     status: supported
     propertyOverrides: []
@@ -194,10 +212,14 @@ typeSupportStatuses:
     enumOverrides: []
   - type: SimpleLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SimpleSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SpanExporter
     status: supported
     propertyOverrides: []

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -39,23 +39,31 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: BatchLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
     notes: "`schedule_delay` is only checked on `::onEmit()`."
   - type: BatchSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
     notes: "`schedule_delay` is only checked on `::onEnd()`."
   - type: CardinalityLimits
     status: not_implemented
     propertyOverrides: []
   - type: ConsoleExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ConsoleMetricExporter
     status: supported
     propertyOverrides:
       - property: default_histogram_aggregation
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: temporality_preference
         status: ignored
   - type: DefaultAggregation
@@ -146,6 +154,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: tls
         status: ignored
   - type: OtlpGrpcMetricExporter
@@ -157,6 +167,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: tls
         status: ignored
   - type: OtlpHttpEncoding
@@ -169,6 +181,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: tls
         status: ignored
   - type: OtlpHttpMetricExporter
@@ -180,6 +194,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: tls
         status: ignored
   - type: ParentBasedSampler
@@ -192,6 +208,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_export_batch_size/development
         status: not_implemented
+      - property: name/development
+        status: unknown
       - property: producers
         status: not_implemented
   - type: Propagator
@@ -228,10 +246,14 @@ typeSupportStatuses:
     enumOverrides: []
   - type: SimpleLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SimpleSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SpanExporter
     status: supported
     propertyOverrides: []
@@ -390,12 +412,16 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: ExperimentalOtlpFileExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ExperimentalOtlpFileMetricExporter
     status: supported
     propertyOverrides:
       - property: default_histogram_aggregation
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: ExperimentalProbabilitySampler
     status: not_implemented
     propertyOverrides: []

--- a/schema/meta_schema_language_python.yaml
+++ b/schema/meta_schema_language_python.yaml
@@ -35,19 +35,27 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: BatchLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: BatchSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: CardinalityLimits
     status: supported
     propertyOverrides: []
   - type: ConsoleExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: ConsoleMetricExporter
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: DefaultAggregation
     status: supported
     propertyOverrides: []
@@ -126,6 +134,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpGrpcMetricExporter
     status: supported
     propertyOverrides:
@@ -133,6 +143,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpEncoding
     status: supported
     enumOverrides: []
@@ -143,6 +155,8 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: OtlpHttpMetricExporter
     status: supported
     propertyOverrides:
@@ -150,12 +164,16 @@ typeSupportStatuses:
         status: not_implemented
       - property: max_response_size
         status: not_implemented
+      - property: name/development
+        status: unknown
   - type: ParentBasedSampler
     status: supported
     propertyOverrides: []
   - type: PeriodicMetricReader
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: Propagator
     status: supported
     propertyOverrides: []
@@ -164,7 +182,9 @@ typeSupportStatuses:
     propertyOverrides: []
   - type: PullMetricReader
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: PushMetricExporter
     status: supported
     propertyOverrides: []
@@ -184,10 +204,14 @@ typeSupportStatuses:
     enumOverrides: []
   - type: SimpleLogRecordProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SimpleSpanProcessor
     status: supported
-    propertyOverrides: []
+    propertyOverrides:
+      - property: name/development
+        status: unknown
   - type: SpanExporter
     status: supported
     propertyOverrides: []

--- a/schema/meter_provider.yaml
+++ b/schema/meter_provider.yaml
@@ -57,8 +57,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       interval:
         type:
           - integer
@@ -112,8 +112,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       exporter:
         $ref: "#/$defs/PullMetricExporter"
         description: Configure exporter.
@@ -291,8 +291,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       host:
         type:
           - string
@@ -392,8 +392,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       endpoint:
         type:
           - string
@@ -486,8 +486,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       endpoint:
         type:
           - string
@@ -574,8 +574,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       output_stream:
         type:
           - string
@@ -607,8 +607,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       temporality_preference:
         $ref: "#/$defs/ExporterTemporalityPreference"
         description: |

--- a/schema/meter_provider.yaml
+++ b/schema/meter_provider.yaml
@@ -54,7 +54,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       interval:
@@ -107,7 +109,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       exporter:
@@ -284,7 +288,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       host:
@@ -383,7 +389,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       endpoint:
@@ -475,7 +483,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       endpoint:
@@ -561,7 +571,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       output_stream:
@@ -592,7 +604,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       temporality_preference:

--- a/schema/meter_provider.yaml
+++ b/schema/meter_provider.yaml
@@ -50,6 +50,13 @@ $defs:
     type: object
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       interval:
         type:
           - integer
@@ -96,6 +103,13 @@ $defs:
     type: object
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       exporter:
         $ref: "#/$defs/PullMetricExporter"
         description: Configure exporter.
@@ -266,6 +280,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       host:
         type:
           - string
@@ -358,6 +379,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       endpoint:
         type:
           - string
@@ -443,6 +471,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       endpoint:
         type:
           - string
@@ -522,6 +557,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       output_stream:
         type:
           - string
@@ -546,6 +588,13 @@ $defs:
       - "null"
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       temporality_preference:
         $ref: "#/$defs/ExporterTemporalityPreference"
         description: |

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -65,7 +65,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       schedule_delay:
@@ -452,7 +454,9 @@ $defs:
         type:
           - string
           - "null"
-        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        description: >
+          Configure a name that uniquely identifies this component within its containing SDK instance.
+          When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
         defaultBehavior: an automatically assigned name is used
         nullBehavior: an automatically assigned name is used
       exporter:

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -61,6 +61,13 @@ $defs:
     type: object
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       schedule_delay:
         type:
           - integer
@@ -441,6 +448,13 @@ $defs:
     type: object
     additionalProperties: false
     properties:
+      name/development:
+        type:
+          - string
+          - "null"
+        description: Configure the name used as `otel.component.name` in SDK self-observability telemetry.
+        defaultBehavior: an automatically assigned name is used
+        nullBehavior: an automatically assigned name is used
       exporter:
         $ref: "#/$defs/SpanExporter"
         description: Configure exporter.

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -68,8 +68,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       schedule_delay:
         type:
           - integer
@@ -457,8 +457,8 @@ $defs:
         description: >
           Configure a name that uniquely identifies this component within its containing SDK instance.
           When the component emits SDK self-observability telemetry, this name is used as `otel.component.name`.
-        defaultBehavior: an automatically assigned name is used
-        nullBehavior: an automatically assigned name is used
+        defaultBehavior: an implementation-defined component name is automatically assigned
+        nullBehavior: an implementation-defined component name is automatically assigned
       exporter:
         $ref: "#/$defs/SpanExporter"
         description: Configure exporter.


### PR DESCRIPTION
## Summary

Add an experimental `name/development` property to built-in SDK processors, exporters, and metric readers. The name uniquely identifies the component within its containing SDK instance.

SDK self-observability is the first standardized consumer of component names: when a named component emits self-observability telemetry, the configured name is used as `otel.component.name`. Component names may also support configuration and management mechanisms that need to refer to individual component instances. Remote addressing and update semantics are outside the scope of this PR.

## Related changes

Together, these changes define configurable SDK component names, their fallback naming convention, and declarative configuration support.

- open-telemetry/opentelemetry-specification#5300
- open-telemetry/semantic-conventions#4082

This PR will remain a draft while those companion changes are under review.

## Changes

- Add `name/development` to built-in span and log record processors.
- Add `name/development` to built-in span, log, and metric exporters.
- Add `name/development` to periodic and pull metric readers.
- Preserve automatically assigned component names when the property is omitted or null.
- Update the comprehensive SDK configuration example with distinct component names.
- Regenerate the compiled JSON schema and language-support documentation.
- Record language implementation support as unknown pending confirmation from language maintainers.

This initial schema change is intentionally limited to built-in processors, exporters, and metric readers. Other component types can adopt the same naming model when independently addressable instances are needed. Provider identity and remote update semantics are outside the scope of this PR.

## Example

```yaml
tracer_provider:
  processors:
    - batch:
        name/development: trace-batch
        exporter:
          otlp_http:
            name/development: trace-otlp
            endpoint: http://localhost:4318/v1/traces
```
