### PR TITLE
Read the declared `file_format` in the validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 * Add `max_request_size` and `max_response_size` to OTLP exporters
   ([#700](https://github.com/open-telemetry/opentelemetry-configuration/pull/700))
 
+### Tooling
+
+* Validator: read the `file_format` a configuration file declares and check it
+  against the schema version the binary embeds
+  ([#739](https://github.com/open-telemetry/opentelemetry-configuration/pull/739))
+
 ## v1.1.0 - 2026-06-05
 
 ### Schema

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,3 +43,7 @@ make update-file-format
 ```
 
 Merge a PR with the changes to `main`.
+
+Also update `supportedFileFormat` in [validator/main.go](./validator/main.go) to the same
+version, so the validator keeps rejecting configuration it cannot describe. `go test` in
+`./validator` fails while the two disagree.

--- a/validator/README.md
+++ b/validator/README.md
@@ -64,6 +64,23 @@ Environment variable substitution is supported with the syntax `${VARIABLE}` or
 found in the
 [opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#environment-variable-substitution).
 
+#### File Format Version
+
+The embedded schema describes one version of the file format, and the validator
+compares it against the `file_format` a configuration file declares, following
+[VERSIONING.md](../VERSIONING.md#file-format):
+
+- A different `MAJOR` version is an error, because the embedded schema does not
+  describe that version of the format.
+- A newer `MINOR` version is a warning, because the configuration may use
+  properties the embedded schema does not contain.
+- A `file_format` that is not `MAJOR.MINOR`, optionally followed by a meta tag
+  such as `1.0-rc.2`, is an error.
+
+Passing `-s`/`--schema` does not change the version the validator expects, so a
+schema for a different `MAJOR` version has to be used with a build of the
+validator that targets it.
+
 #### Using a Different Schema Version
 
 To use a version of of the schema other than the one builtin to the

--- a/validator/main.go
+++ b/validator/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"fmt"
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/urfave/cli/v3"
 	yaml "gopkg.in/yaml.v3"
@@ -157,6 +158,66 @@ func add_resources_from_embed(c *jsonschema.Compiler) {
 }
 
 
+// splitFileFormat splits a file format version into its major and minor
+// numbers, discarding any meta tag, so that "1.0-rc.2" yields 1 and 0.
+func splitFileFormat(fileFormat string) (int, int, error) {
+	numbers := strings.SplitN(strings.SplitN(fileFormat, "-", 2)[0], ".", 2)
+
+	major, err := strconv.Atoi(numbers[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("expected MAJOR.MINOR version numbers, got %q", fileFormat)
+	}
+
+	if len(numbers) < 2 {
+		return major, 0, nil
+	}
+
+	minor, err := strconv.Atoi(numbers[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("expected MAJOR.MINOR version numbers, got %q", fileFormat)
+	}
+
+	return major, minor, nil
+}
+
+// checkFileFormat compares the file format version a configuration declares
+// against the version the embedded schema describes, following the rules in
+// VERSIONING.md: a major version the schema does not describe is an error, and
+// a newer minor version is a warning.
+func checkFileFormat(expandedConfig interface{}) error {
+	config, ok := expandedConfig.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// The schema makes file_format required and constrains it to a string, so a
+	// configuration that has already validated against it carries one.
+	declared, ok := config["file_format"].(string)
+	if !ok {
+		return nil
+	}
+
+	declaredMajor, declaredMinor, err := splitFileFormat(declared)
+	if err != nil {
+		return fmt.Errorf("Invalid file_format: %v", err)
+	}
+
+	supportedMajor, supportedMinor, err := splitFileFormat(supportedFileFormat)
+	if err != nil {
+		return fmt.Errorf("Invalid supported file format %q: %v", supportedFileFormat, err)
+	}
+
+	if declaredMajor != supportedMajor {
+		return fmt.Errorf("Unsupported file_format %q: this validator embeds the schema for version %d.x", declared, supportedMajor)
+	}
+
+	if declaredMinor > supportedMinor {
+		log.Printf("Warning: file_format %q is newer than the schema this validator embeds (%q), which may not describe everything the configuration uses", declared, supportedFileFormat)
+	}
+
+	return nil
+}
+
 func validateConfiguration(configFile string, outfileExt string, schemaDir *string) []byte {
 	c := jsonschema.NewCompiler()
 	if schemaDir != nil {
@@ -178,6 +239,10 @@ func validateConfiguration(configFile string, outfileExt string, schemaDir *stri
 		} else {
 			log.Fatalf("%+v", err)
 		}
+	}
+
+	if err = checkFileFormat(expandedConfig); err != nil {
+		log.Fatalf("%v", err)
 	}
 
 	return outFile

--- a/validator/main.go
+++ b/validator/main.go
@@ -21,6 +21,13 @@ import (
 //go:embed schema/*
 var schemaFS embed.FS
 
+// The file format version described by the embedded schema. A configuration
+// file declaring a different major version is not described by that schema at
+// all, and one declaring a newer minor version may use configuration the schema
+// does not contain. Kept in step with the rest of the repository by
+// TestSupportedFileFormatMatchesExamples.
+const supportedFileFormat = "1.1"
+
 func main() {
 	log.SetFlags(0)
 

--- a/validator/main_test.go
+++ b/validator/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	yaml "gopkg.in/yaml.v3"
 
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,6 +106,63 @@ func TestSupportedFileFormatMatchesExamples(t *testing.T) {
 
 		if declared.FileFormat != supportedFileFormat {
 			t.Errorf("%v declares file_format %q, but the validator supports %q", example, declared.FileFormat, supportedFileFormat)
+		}
+	}
+}
+
+func TestSplitFileFormat(t *testing.T) {
+	valid := map[string][2]int{
+		"1.1":      {1, 1},
+		"0.4":      {0, 4},
+		"1.0-rc.2": {1, 0},
+		"2":        {2, 0},
+		"10.23":    {10, 23},
+	}
+
+	for fileFormat, expected := range valid {
+		major, minor, err := splitFileFormat(fileFormat)
+		if err != nil {
+			t.Errorf("splitFileFormat(%q) returned %v", fileFormat, err)
+		}
+		if major != expected[0] || minor != expected[1] {
+			t.Errorf("splitFileFormat(%q) returned %v.%v, expected %v.%v", fileFormat, major, minor, expected[0], expected[1])
+		}
+	}
+
+	for _, fileFormat := range []string{"", "banana", "1.x", "x.1", "1.1.0", " 1.1"} {
+		if _, _, err := splitFileFormat(fileFormat); err == nil {
+			t.Errorf("splitFileFormat(%q) was accepted, expected an error", fileFormat)
+		}
+	}
+}
+
+func TestCheckFileFormat(t *testing.T) {
+	supportedMajor, supportedMinor, err := splitFileFormat(supportedFileFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	accepted := []string{
+		supportedFileFormat,
+		fmt.Sprintf("%v.0", supportedMajor),
+		fmt.Sprintf("%v.%v", supportedMajor, supportedMinor+1),
+		fmt.Sprintf("%v.%v-rc.1", supportedMajor, supportedMinor),
+	}
+	for _, fileFormat := range accepted {
+		if err := checkFileFormat(map[string]interface{}{"file_format": fileFormat}); err != nil {
+			t.Errorf("checkFileFormat(%q) returned %v, expected it to be accepted", fileFormat, err)
+		}
+	}
+
+	rejected := []string{
+		fmt.Sprintf("%v.0", supportedMajor+1),
+		fmt.Sprintf("%v.0", supportedMajor-1),
+		"banana",
+		"",
+	}
+	for _, fileFormat := range rejected {
+		if err := checkFileFormat(map[string]interface{}{"file_format": fileFormat}); err == nil {
+			t.Errorf("checkFileFormat(%q) was accepted, expected an error", fileFormat)
 		}
 	}
 }

--- a/validator/main_test.go
+++ b/validator/main_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	yaml "gopkg.in/yaml.v3"
+
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -71,5 +74,37 @@ func TestExpandString(t *testing.T) {
 	s = expandString("${UNDEFINED:-firstdefault} ${UNDEFINED:-seconddefault}")
 	if !strings.EqualFold(s, "firstdefault seconddefault") {
 		t.Errorf("String \"%s\" should be \"firstdefault seconddefault\"", s)
+	}
+}
+
+// The embedded schema is copied from the repository at build time, and
+// ./examples and ./snippets are rewritten to the current file format version on
+// release, so the two have to agree.
+func TestSupportedFileFormatMatchesExamples(t *testing.T) {
+	examples, err := filepath.Glob(filepath.Join("..", "examples", "*.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(examples) == 0 {
+		t.Fatal("No examples found to compare the supported file format against")
+	}
+
+	for _, example := range examples {
+		body, err := os.ReadFile(example)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var declared struct {
+			FileFormat string `yaml:"file_format"`
+		}
+		if err := yaml.Unmarshal(body, &declared); err != nil {
+			t.Fatal(err)
+		}
+
+		if declared.FileFormat != supportedFileFormat {
+			t.Errorf("%v declares file_format %q, but the validator supports %q", example, declared.FileFormat, supportedFileFormat)
+		}
 	}
 }

--- a/validator/shelltests/env_prefix.test
+++ b/validator/shelltests/env_prefix.test
@@ -1,3 +1,3 @@
-otel_config_validator -o out/out.json shelltests/env_prefix.yaml
+FILE_FORMAT=1.1 otel_config_validator -o out/out.json shelltests/env_prefix.yaml
 >>>
 >>>= 0

--- a/validator/shelltests/hex_integer.yaml
+++ b/validator/shelltests/hex_integer.yaml
@@ -1,5 +1,5 @@
 # The file format version
-file_format: "0.1"
+file_format: "1.1"
 
 # Configure if the SDK is disabled or not.
 disabled: ${OTEL_SDK_DISABLED:-false}

--- a/validator/shelltests/invalid_file_format.test
+++ b/validator/shelltests/invalid_file_format.test
@@ -1,0 +1,4 @@
+otel_config_validator shelltests/invalid_file_format.yaml
+>>>2
+Invalid file_format: expected MAJOR.MINOR version numbers, got "banana"
+>>>= 1

--- a/validator/shelltests/invalid_file_format.yaml
+++ b/validator/shelltests/invalid_file_format.yaml
@@ -1,0 +1,5 @@
+file_format: "banana"
+resource:
+  attributes:
+    - name: service.name
+      value: my-service

--- a/validator/shelltests/json_out.test
+++ b/validator/shelltests/json_out.test
@@ -1,8 +1,8 @@
-FILE_FORMAT=0.1 otel_config_validator -o out/out.json shelltests/test.yaml
+FILE_FORMAT=1.1 otel_config_validator -o out/out.json shelltests/test.yaml
 >>>
 >>>= 0
 
 jq '.file_format' out/out.json
 >>>
-"0.1"
+"1.1"
 >>>= 0

--- a/validator/shelltests/multiple_defaults.yaml
+++ b/validator/shelltests/multiple_defaults.yaml
@@ -1,1 +1,1 @@
-file_format: ${FILE_FORMAT}${BLANK:-}${FILE_FORMAT:-0.1}
+file_format: ${FILE_FORMAT}${BLANK:-}${FILE_FORMAT:-1.1}

--- a/validator/shelltests/newer_minor_file_format.test
+++ b/validator/shelltests/newer_minor_file_format.test
@@ -1,0 +1,4 @@
+otel_config_validator shelltests/newer_minor_file_format.yaml
+>>>2
+Warning: file_format "1.99" is newer than the schema this validator embeds ("1.1"), which may not describe everything the configuration uses
+>>>= 0

--- a/validator/shelltests/newer_minor_file_format.yaml
+++ b/validator/shelltests/newer_minor_file_format.yaml
@@ -1,0 +1,5 @@
+file_format: "1.99"
+resource:
+  attributes:
+    - name: service.name
+      value: my-service

--- a/validator/shelltests/no_expected_key.test
+++ b/validator/shelltests/no_expected_key.test
@@ -1,2 +1,2 @@
-FILE_FORMAT=0.1 otel_config_validator shelltests/no_expected_key.yaml
+FILE_FORMAT=1.1 otel_config_validator shelltests/no_expected_key.yaml
 >>>= 1

--- a/validator/shelltests/schema_option.yaml
+++ b/validator/shelltests/schema_option.yaml
@@ -1,1 +1,1 @@
-file_format: "0.1"
+file_format: "1.1"

--- a/validator/shelltests/string_for_int.yaml
+++ b/validator/shelltests/string_for_int.yaml
@@ -1,5 +1,5 @@
 # The file format version
-file_format: "0.1"
+file_format: "1.1"
 
 # Configure if the SDK is disabled or not.
 disabled: ${OTEL_SDK_DISABLED:-false}

--- a/validator/shelltests/unsupported_file_format.test
+++ b/validator/shelltests/unsupported_file_format.test
@@ -1,0 +1,4 @@
+otel_config_validator shelltests/unsupported_file_format.yaml
+>>>2
+Unsupported file_format "0.4": this validator embeds the schema for version 1.x
+>>>= 1

--- a/validator/shelltests/unsupported_file_format.yaml
+++ b/validator/shelltests/unsupported_file_format.yaml
@@ -1,0 +1,5 @@
+file_format: "0.4"
+resource:
+  attributes:
+    - name: service.name
+      value: my-service

--- a/validator/shelltests/yaml_out.test
+++ b/validator/shelltests/yaml_out.test
@@ -1,8 +1,8 @@
-FILE_FORMAT=0.1 otel_config_validator -o out/out.yaml shelltests/test.yaml
+FILE_FORMAT=1.1 otel_config_validator -o out/out.yaml shelltests/test.yaml
 >>>
 >>>= 0
 
 cat out/out.yaml
 >>>
-file_format: "0.1"
+file_format: "1.1"
 >>>= 0


### PR DESCRIPTION
Fixes #738.

`otel_config_validator` never read the `file_format` a configuration file declares, so a file claiming `0.1`, `99.7` or `banana` validated against the current schema and exited 0. This makes it read that value and follow the rules already written in [VERSIONING.md](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md#file-format).

## Behaviour

| `file_format` | before | after |
| --- | --- | --- |
| `"1.1"` | accepted | accepted |
| `"1.9"` | accepted silently | accepted, warns that it is newer than the embedded schema |
| `"1.1-rc.2"` | accepted | accepted, the meta tag is discarded |
| `"0.1"` | accepted silently | rejected, exit 1 |
| `"99.7"` | accepted silently | rejected, exit 1 |
| `"banana"` | accepted silently | rejected, exit 1 |

A newer `MINOR` is a warning on stderr and still exits 0, so a file written for a later release keeps validating.

## Commits

* `Record which file format version the embedded schema describes` adds the `supportedFileFormat` constant, plus a test that fails if it drifts from what `./examples` declare.
* `Reject a configuration whose major version the schema does not describe` adds the check and wires it in after schema validation, so existing schema errors still surface first.
* `Bring the shelltest fixtures onto a version the schema describes` updates fixtures that had drifted to `0.1` and adds three shelltests for the new outcomes.
* `Document the version check and the constant a release has to bump` covers `validator/README.md` and `RELEASING.md`.

## A note on the fixtures

Four fixtures declared `file_format: "0.1"` and two asserted `"0.1"` in the validator's output. They passed only because the value was never read. `env_prefix.test` also needed `FILE_FORMAT=1.1`, because with the variable unset the field expanded to an empty string, which is a string and so satisfied the schema.

These drifted because `make update-file-format` rewrites `./examples` and `./snippets` but not `./validator/shelltests`. Rather than extend that target, this adds `TestSupportedFileFormatMatchesExamples`, so `go test` in `./validator` fails whenever the constant and the examples disagree, and `RELEASING.md` now says the constant has to be bumped alongside the rest.

## Verification

* `go vet ./...` clean.
* `go test .` passes, including `TestSplitFileFormat`, `TestCheckFileFormat` and `TestSupportedFileFormatMatchesExamples`.
* `make validator-run-shelltests` passes 19 of 19, 0 failures.

## Out of scope

This does not let the validator hold more than one schema version. It records the single version it embeds and reports honestly when a file does not match it. Serving several versions from one binary would be a larger change.
