### PR TITLE
Record stability as an annotation and compile a stable and a development schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,11 +58,24 @@ Properties defined in the schema should be lower [snake case](https://en.wikiped
 
 ### Property name and enum value character set
 
-Property names and enum values must match `^[A-Za-z_][A-Za-z0-9_]*$`. This facilitates usage as identifiers in generated code. Experimental properties are an exception, and are [denoted with a `/(development|alpha|beta)` suffix](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md#experimental-features) (e.g. `detection/development`).
+Property names and enum values must match `^[A-Za-z_][A-Za-z0-9_]*$`, with no exceptions. This facilitates usage as identifiers in generated code. The maturity of a property or an enum value is [recorded in an annotation](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md#experimental-features), never in its name, so a property keeps the same name when it stabilizes.
 
 ### Type name case
 
-Type names (the top-level types defined under `$defs`, e.g. `BatchSpanProcessor`) should be [PascalCase](https://en.wikipedia.org/wiki/Camel_case): they must match `^[A-Z][A-Za-z0-9]*$`. This facilitates usage as identifiers in generated code. Experimental types are [denoted with an `Experimental` prefix](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md#experimental-features).
+Type names (the top-level types defined under `$defs`, e.g. `BatchSpanProcessor`) should be [PascalCase](https://en.wikipedia.org/wiki/Camel_case): they must match `^[A-Z][A-Za-z0-9]*$`. This facilitates usage as identifiers in generated code. The maturity of a type is [recorded in an annotation](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md#experimental-features) as well.
+
+### Maturity
+
+The maturity of a node is metadata about that node, so it is recorded beside the node rather than inside its name:
+
+* `stability: development` on a property or a type.
+* `enumStability: {<enum value>: development}` on an enum type, which records the maturity of one value of that enum.
+
+Both are stripped when the schema is compiled, the way `enumDescriptions` and `defaultBehavior` are. Omitting them means stable.
+
+`make compile-schema` produces two schemas from this one source. `opentelemetry_configuration.json` holds nothing under development. `opentelemetry_configuration_development.json` holds everything and keeps the annotations. A config file selects one with its `maturity_level` property, and a file that omits it is read with the stable schema.
+
+Note that the split cannot be enforced at an [extension point](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md#extension-points). Those types accept any property name so that an SDK plugin can be configured, so the stable schema cannot tell a component that is under development from a plugin it has never heard of.
 
 ### Properties requiring pattern matching
 

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,19 @@ compile-schema:
 	npm run-script compile-schema || exit 1;
 	@if ! npm ls ajv-cli; then npm install; fi
 	npx --no ajv-cli compile --spec=draft2020 --allow-matching-properties -s ./opentelemetry_configuration.json;
+	@# The development schema keeps the stability annotation, which the strict mode of ajv rejects.
+	npx --no ajv-cli compile --spec=draft2020 --strict=false --allow-matching-properties -s ./opentelemetry_configuration_development.json;
 
 .PHONY: validate-examples
 validate-examples: compile-schema
 	@if ! npm ls ajv-cli; then npm install; fi
 	@for f in $(EXAMPLE_FILES); do \
 	    npx envsub ./examples/$$f ./out/$$f || exit 1; \
-		npx --no ajv-cli validate --spec=draft2020 --allow-matching-properties --errors=text -s ./opentelemetry_configuration.json -d ./out/$$f \
+		schema=./opentelemetry_configuration.json; strict=; \
+		if grep -q '^maturity_level: *development' ./out/$$f; then \
+			schema=./opentelemetry_configuration_development.json; strict=--strict=false; \
+		fi; \
+		npx --no ajv-cli validate --spec=draft2020 $$strict --allow-matching-properties --errors=text -s $$schema -d ./out/$$f \
 		    || exit 1; \
 	done
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -74,11 +74,22 @@ The versioning policy guarantees do not apply to [experimental features](#experi
 
 Sometimes we need to experiment with new types, properties, and enum values, e.g. when evaluating the configuration experience for experimental features in [opentelemetry-specification](https://github.com/open-telemetry/opentelemetry-specification).
 
-Experimental properties and enum values are denoted by a `*/(development|alpha|beta)` suffix (e.g.`foo/development`). The suffix indicates the property value and all types nested within it are exempt from versioning policy guarantees and are subject to breaking changes in minor versions. Experimental type key values in `$defs` should be prefixed with `Experimental*` (e.g. `ExperimentalFoo`). Note that because we [omit the title annotation](./CONTRIBUTING.md#annotations---title-and-description), the `$defs` key value effectively acts as the type title for code generation tools.
+The maturity of a property, an enum value or a type is recorded in the source schema as an annotation beside it, and never in its name. A property carries `stability: development`, one value of an enum is recorded in the `enumStability` map of that enum, and a type carries `stability: development` too. A node marked this way, and everything nested within it, is exempt from versioning policy guarantees and is subject to breaking changes in minor versions.
 
-Maintainers are not obligated to implement support for experimental properties and types. When they do, they are not obligated to maintain any versioning policy guarantees.
+A name is therefore an identifier and nothing else, and a property keeps the same name when it stabilizes. Nothing in a config file has to be rewritten on the day a property becomes stable, and no SDK has to accept two spellings of one property.
 
-End users should be cautious of adopting experimental properties and types, since in doing so they are subject to breaking changes in `MINOR` versions.
+Two schemas are compiled from that one source:
+
+* `opentelemetry_configuration.json` holds nothing that is under development.
+* `opentelemetry_configuration_development.json` holds everything, and keeps the annotations so that a reader of the schema can still tell which parts are under development.
+
+A config file selects one with the `maturity_level` property. A file that omits it, which is every file written so far, is read with the stable schema and may use stable properties only. A file that declares `maturity_level: development` is read with the development schema and may also use properties that are under development. Declaring it is the only way to reach them, so nobody adopts an unstable property without saying so.
+
+This cannot be enforced at an [extension point](#extension-points): those types accept any property name so that an SDK plugin can be configured, so the stable schema cannot tell a component that is under development from a plugin it has never heard of.
+
+Maintainers are not obligated to implement support for properties and types that are under development. When they do, they are not obligated to maintain any versioning policy guarantees.
+
+End users should be cautious of adopting them, since in doing so they are subject to breaking changes in `MINOR` versions.
 
 ### Extension points
 

--- a/examples/otel-getting-started.yaml
+++ b/examples/otel-getting-started.yaml
@@ -9,6 +9,7 @@
 # see: https://opentelemetry.io/docs/specs/otel-config/types/
 
 file_format: "1.1"
+maturity_level: development
 
 resource:
   # Read resource attributes from the OTEL_RESOURCE_ATTRIBUTES environment variable.

--- a/examples/otel-getting-started.yaml
+++ b/examples/otel-getting-started.yaml
@@ -14,7 +14,7 @@ resource:
   # Read resource attributes from the OTEL_RESOURCE_ATTRIBUTES environment variable.
   # This aligns well with the OpenTelemetry Operator and other deployment methods.
   attributes_list: ${OTEL_RESOURCE_ATTRIBUTES}
-  detection/development: # /development properties may not be supported in all SDKs
+  detection: # development properties may not be supported in all SDKs
     detectors:
       - service: # will add "service.instance.id" and "service.name" from the OTEL_SERVICE_NAME env var
       - host:

--- a/examples/otel-sdk-config.yaml
+++ b/examples/otel-sdk-config.yaml
@@ -8,6 +8,7 @@
 # For schema documentation, including required properties, semantics, default behavior, etc,
 # see: https://opentelemetry.io/docs/specs/otel-config/types/
 file_format: "1.1"
+maturity_level: development
 disabled: false
 log_level: info
 resource:

--- a/examples/otel-sdk-migration-config.yaml
+++ b/examples/otel-sdk-migration-config.yaml
@@ -122,6 +122,6 @@ logger_provider:
   limits:
     attribute_value_length_limit: ${OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT}
     attribute_count_limit: ${OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT:-128}
-instrumentation/development:
+instrumentation:
   general:
     stability_opt_in_list: ${OTEL_SEMCONV_STABILITY_OPT_IN}

--- a/examples/otel-sdk-migration-config.yaml
+++ b/examples/otel-sdk-migration-config.yaml
@@ -36,6 +36,7 @@
 # For schema documentation, including required properties, semantics, default behavior, etc,
 # see: https://opentelemetry.io/docs/specs/otel-config/types/
 file_format: "1.1"
+maturity_level: development
 disabled: ${OTEL_SDK_DISABLED:-false}
 log_level: info
 resource:

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -46,34 +46,34 @@ Latest supported file format: `1.0.0`
 | `IncludeExclude` | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | `InstrumentType` | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | `LastValueAggregation` | supported |  |  |
-| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
-| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator`: supported<br> |
+| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
-| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: not_implemented<br> |
-| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br>* `view_matching_mode/development`: not_implemented<br> |
+| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: not_implemented<br> |
+| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | supported |  | * `opencensus`: supported<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | supported |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
 | `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size`: not_implemented<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
-| `PullMetricExporter` | supported |  | * `prometheus/development`: supported<br> |
+| `PullMetricExporter` | supported |  | * `prometheus`: supported<br> |
 | `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br> |
-| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `RandomIdGenerator` | not_implemented |  |  |
-| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: not_implemented<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: not_implemented<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite`: supported<br>* `jaeger_remote`: supported<br>* `probability`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
-| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
 | `SpanProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
@@ -81,7 +81,7 @@ Latest supported file format: `1.0.0`
 | `TextMapPropagator` | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | `TraceContextPropagator` | supported |  |  |
 | `TraceIdRatioBasedSampler` | supported |  | * `ratio`: supported<br> |
-| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator`: supported<br> |
 | `View` | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | `ViewSelector` | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: supported<br> |
 | `ViewStream` | supported |  | * `aggregation`: supported<br>* `aggregation_cardinality_limit`: supported<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
@@ -118,8 +118,8 @@ Latest supported file format: `1.0.0`
 | `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br> |
 | `ExperimentalProbabilitySampler` | supported |  | * `ratio`: supported<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
-| `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
+| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled`: supported<br> |
+| `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation`: not_implemented<br>* `no_utf8_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes`: supported<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | not_applicable |  | * `semconv`: not_applicable<br> |
@@ -169,34 +169,34 @@ Latest supported file format: `1.0.0`
 | `IncludeExclude` | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | `InstrumentType` | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | `LastValueAggregation` | supported |  |  |
-| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: not_implemented<br> |
-| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: not_implemented<br> |
+| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator`: not_implemented<br> |
+| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: not_implemented<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
-| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: unknown<br> |
-| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br>* `view_matching_mode/development`: not_implemented<br> |
+| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: unknown<br> |
+| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | unknown |  | * `opencensus`: unknown<br> |
 | `MetricReader` | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | unknown |  |  |
-| `OpenTelemetryConfiguration` | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation/development`: unknown<br> |
+| `OpenTelemetryConfiguration` | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation`: unknown<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | not_implemented |  | * `json`: not_implemented<br>* `protobuf`: not_implemented<br> |
 | `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: not_implemented<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: not_implemented<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size`: not_implemented<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
-| `PullMetricExporter` | unknown |  | * `prometheus/development`: unknown<br> |
+| `PullMetricExporter` | unknown |  | * `prometheus`: unknown<br> |
 | `PullMetricReader` | unknown |  | * `cardinality_limits`: unknown<br>* `exporter`: unknown<br>* `producers`: unknown<br> |
-| `PushMetricExporter` | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file/development`: unknown<br> |
+| `PushMetricExporter` | unknown |  | * `console`: unknown<br>* `otlp_grpc`: unknown<br>* `otlp_http`: unknown<br>* `otlp_file`: unknown<br> |
 | `RandomIdGenerator` | unknown |  |  |
-| `Resource` | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection/development`: unknown<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
+| `Resource` | unknown |  | * `attributes`: unknown<br>* `attributes_list`: unknown<br>* `schema_url`: unknown<br>* `detection`: unknown<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite`: not_implemented<br>* `jaeger_remote`: not_implemented<br>* `probability`: not_implemented<br> |
 | `SeverityNumber` | unknown |  | * `debug`: unknown<br>* `debug2`: unknown<br>* `debug3`: unknown<br>* `debug4`: unknown<br>* `error`: unknown<br>* `error2`: unknown<br>* `error3`: unknown<br>* `error4`: unknown<br>* `fatal`: unknown<br>* `fatal2`: unknown<br>* `fatal3`: unknown<br>* `fatal4`: unknown<br>* `info`: unknown<br>* `info2`: unknown<br>* `info3`: unknown<br>* `info4`: unknown<br>* `trace`: unknown<br>* `trace2`: unknown<br>* `trace3`: unknown<br>* `trace4`: unknown<br>* `warn`: unknown<br>* `warn2`: unknown<br>* `warn3`: unknown<br>* `warn4`: unknown<br> |
 | `SimpleLogRecordProcessor` | unknown |  | * `exporter`: unknown<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
-| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: not_implemented<br> |
+| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: not_implemented<br> |
 | `SpanKind` | unknown |  | * `client`: unknown<br>* `consumer`: unknown<br>* `internal`: unknown<br>* `producer`: unknown<br>* `server`: unknown<br> |
 | `SpanLimits` | unknown |  | * `attribute_count_limit`: unknown<br>* `attribute_value_depth_limit`: unknown<br>* `attribute_value_length_limit`: unknown<br>* `event_attribute_count_limit`: unknown<br>* `event_count_limit`: unknown<br>* `link_attribute_count_limit`: unknown<br>* `link_count_limit`: unknown<br> |
 | `SpanProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
@@ -204,7 +204,7 @@ Latest supported file format: `1.0.0`
 | `TextMapPropagator` | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | `TraceContextPropagator` | supported |  |  |
 | `TraceIdRatioBasedSampler` | supported |  | * `ratio`: supported<br> |
-| `TracerProvider` | unknown |  | * `id_generator`: unknown<br>* `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator/development`: unknown<br> |
+| `TracerProvider` | unknown |  | * `id_generator`: unknown<br>* `limits`: unknown<br>* `processors`: unknown<br>* `sampler`: unknown<br>* `tracer_configurator`: unknown<br> |
 | `View` | unknown |  | * `selector`: unknown<br>* `stream`: unknown<br> |
 | `ViewSelector` | unknown |  | * `instrument_name`: unknown<br>* `instrument_type`: unknown<br>* `meter_name`: unknown<br>* `meter_schema_url`: unknown<br>* `meter_version`: unknown<br>* `unit`: unknown<br> |
 | `ViewStream` | unknown |  | * `aggregation`: unknown<br>* `aggregation_cardinality_limit`: unknown<br>* `attribute_keys`: unknown<br>* `description`: unknown<br>* `name`: unknown<br> |
@@ -241,8 +241,8 @@ Latest supported file format: `1.0.0`
 | `ExperimentalOtlpFileMetricExporter` | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
 | `ExperimentalProbabilitySampler` | not_implemented |  | * `ratio`: not_implemented<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled/development`: supported<br> |
-| `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation/development`: supported<br>* `no_utf8_escaping_with_suffixes/development`: supported<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes/development`: supported<br> |
+| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: supported<br>* `target_info_enabled`: supported<br> |
+| `ExperimentalPrometheusTranslationStrategy` | supported |  | * `no_translation`: supported<br>* `no_utf8_escaping_with_suffixes`: supported<br>* `underscore_escaping_with_suffixes`: supported<br>* `underscore_escaping_without_suffixes`: supported<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
@@ -292,34 +292,34 @@ Latest supported file format: `1.0.0-rc.3`
 | `IncludeExclude` | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | `InstrumentType` | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | `LastValueAggregation` | supported |  |  |
-| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
-| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator`: supported<br> |
+| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
-| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: unknown<br> |
-| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br>* `view_matching_mode/development`: not_implemented<br> |
+| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: unknown<br> |
+| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | ignored |  | * `opencensus`: ignored<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | ignored |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | not_implemented |  | * `json`: not_implemented<br>* `protobuf`: not_implemented<br> |
 | `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size`: not_implemented<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
-| `PullMetricExporter` | supported |  | * `prometheus/development`: supported<br> |
+| `PullMetricExporter` | supported |  | * `prometheus`: supported<br> |
 | `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: not_implemented<br> |
-| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `RandomIdGenerator` | unknown |  |  |
-| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite`: supported<br>* `jaeger_remote`: supported<br>* `probability`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
-| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
 | `SpanProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
@@ -327,7 +327,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `TextMapPropagator` | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | `TraceContextPropagator` | supported |  |  |
 | `TraceIdRatioBasedSampler` | supported |  | * `ratio`: supported<br> |
-| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator`: supported<br> |
 | `View` | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | `ViewSelector` | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: supported<br> |
 | `ViewStream` | supported |  | * `aggregation`: supported<br>* `aggregation_cardinality_limit`: supported<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
@@ -364,8 +364,8 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: supported<br>* `output_stream`: not_implemented<br>* `temporality_preference`: supported<br> |
 | `ExperimentalProbabilitySampler` | supported |  | * `ratio`: supported<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: supported<br> |
-| `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
+| `ExperimentalPrometheusMetricExporter` | supported |  | * `host`: supported<br>* `port`: supported<br>* `resource_constant_labels`: supported<br>* `scope_info_enabled`: supported<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled`: supported<br> |
+| `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation`: not_implemented<br>* `no_utf8_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes`: not_implemented<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | unknown |  | * `semconv`: unknown<br> |
@@ -415,34 +415,34 @@ Latest supported file format: `1.0.0-rc.3`
 | `IncludeExclude` | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | `InstrumentType` | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | `LastValueAggregation` | supported |  |  |
-| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
-| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator`: supported<br> |
+| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
-| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: supported<br> |
-| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br>* `view_matching_mode/development`: not_implemented<br> |
+| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: supported<br> |
+| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | supported |  | * `opencensus`: supported<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | not_implemented |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
 | `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size`: not_implemented<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
-| `PullMetricExporter` | not_implemented |  | * `prometheus/development`: not_implemented<br> |
+| `PullMetricExporter` | not_implemented |  | * `prometheus`: not_implemented<br> |
 | `PullMetricReader` | not_implemented |  | * `cardinality_limits`: not_implemented<br>* `exporter`: not_implemented<br>* `producers`: not_implemented<br> |
-| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `RandomIdGenerator` | supported |  |  |
-| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite`: supported<br>* `jaeger_remote`: supported<br>* `probability`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
-| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
 | `SpanProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
@@ -450,7 +450,7 @@ Latest supported file format: `1.0.0-rc.3`
 | `TextMapPropagator` | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | `TraceContextPropagator` | supported |  |  |
 | `TraceIdRatioBasedSampler` | supported |  | * `ratio`: supported<br> |
-| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator`: supported<br> |
 | `View` | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | `ViewSelector` | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: supported<br> |
 | `ViewStream` | supported |  | * `aggregation`: supported<br>* `aggregation_cardinality_limit`: supported<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
@@ -487,8 +487,8 @@ Latest supported file format: `1.0.0-rc.3`
 | `ExperimentalOtlpFileMetricExporter` | not_implemented |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: not_implemented<br>* `temporality_preference`: not_implemented<br> |
 | `ExperimentalProbabilitySampler` | not_implemented |  | * `ratio`: not_implemented<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
-| `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
+| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled`: not_implemented<br> |
+| `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation`: not_implemented<br>* `no_utf8_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes`: not_implemented<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | not_implemented |  | * `semconv`: not_implemented<br> |
@@ -538,34 +538,34 @@ Latest supported file format: `1.0.0-rc.2`
 | `IncludeExclude` | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | `InstrumentType` | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | `LastValueAggregation` | ignored |  |  |
-| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
-| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator`: supported<br> |
+| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
-| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: unknown<br> |
-| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br>* `view_matching_mode/development`: not_implemented<br> |
+| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: unknown<br> |
+| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | not_implemented |  | * `opencensus`: not_implemented<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: not_implemented<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | not_implemented |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: not_implemented<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: not_implemented<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: ignored<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: ignored<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
 | `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: ignored<br> |
 | `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: ignored<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: not_implemented<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size/development`: not_implemented<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: not_implemented<br>* `producers`: not_implemented<br>* `timeout`: supported<br>* `max_export_batch_size`: not_implemented<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
-| `PullMetricExporter` | not_implemented |  | * `prometheus/development`: not_implemented<br> |
+| `PullMetricExporter` | not_implemented |  | * `prometheus`: not_implemented<br> |
 | `PullMetricReader` | not_implemented |  | * `cardinality_limits`: not_implemented<br>* `exporter`: not_implemented<br>* `producers`: not_implemented<br> |
-| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `RandomIdGenerator` | unknown |  |  |
-| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: not_implemented<br>* `jaeger_remote/development`: not_implemented<br>* `probability/development`: not_implemented<br> |
+| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite`: not_implemented<br>* `jaeger_remote`: not_implemented<br>* `probability`: not_implemented<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
-| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `SpanKind` | not_implemented |  | * `client`: not_implemented<br>* `consumer`: not_implemented<br>* `internal`: not_implemented<br>* `producer`: not_implemented<br>* `server`: not_implemented<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
 | `SpanProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
@@ -573,7 +573,7 @@ Latest supported file format: `1.0.0-rc.2`
 | `TextMapPropagator` | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | `TraceContextPropagator` | supported |  |  |
 | `TraceIdRatioBasedSampler` | supported |  | * `ratio`: supported<br> |
-| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator`: supported<br> |
 | `View` | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | `ViewSelector` | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: not_implemented<br> |
 | `ViewStream` | supported | `attribute_keys.excluded` is not implemented, only `attribute_keys.included` is supported. | * `aggregation`: ignored<br>* `aggregation_cardinality_limit`: not_implemented<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
@@ -610,8 +610,8 @@ Latest supported file format: `1.0.0-rc.2`
 | `ExperimentalOtlpFileMetricExporter` | supported |  | * `default_histogram_aggregation`: not_implemented<br>* `output_stream`: supported<br>* `temporality_preference`: supported<br> |
 | `ExperimentalProbabilitySampler` | not_implemented |  | * `ratio`: not_implemented<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled/development`: not_implemented<br> |
-| `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation/development`: not_implemented<br>* `no_utf8_escaping_with_suffixes/development`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes/development`: not_implemented<br> |
+| `ExperimentalPrometheusMetricExporter` | not_implemented |  | * `host`: not_implemented<br>* `port`: not_implemented<br>* `resource_constant_labels`: not_implemented<br>* `scope_info_enabled`: not_implemented<br>* `translation_strategy`: not_implemented<br>* `target_info_enabled`: not_implemented<br> |
+| `ExperimentalPrometheusTranslationStrategy` | not_implemented |  | * `no_translation`: not_implemented<br>* `no_utf8_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_with_suffixes`: not_implemented<br>* `underscore_escaping_without_suffixes`: not_implemented<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: ignored<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | unknown |  | * `semconv`: unknown<br> |
@@ -661,34 +661,34 @@ Latest supported file format: `1.0.0`
 | `IncludeExclude` | supported |  | * `excluded`: supported<br>* `included`: supported<br> |
 | `InstrumentType` | supported |  | * `counter`: supported<br>* `gauge`: supported<br>* `histogram`: supported<br>* `observable_counter`: supported<br>* `observable_gauge`: supported<br>* `observable_up_down_counter`: supported<br>* `up_down_counter`: supported<br> |
 | `LastValueAggregation` | supported |  |  |
-| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator/development`: supported<br> |
-| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `LoggerProvider` | supported |  | * `limits`: supported<br>* `processors`: supported<br>* `logger_configurator`: supported<br> |
+| `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | ignored |  | * `attribute_count_limit`: ignored<br>* `attribute_value_depth_limit`: ignored<br>* `attribute_value_length_limit`: ignored<br> |
-| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge/development`: supported<br> |
-| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator/development`: supported<br>* `view_matching_mode/development`: not_implemented<br> |
+| `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: supported<br> |
+| `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | ignored |  | * `opencensus`: ignored<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | ignored |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation/development`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
 | `OtlpHttpExporter` | supported |  | * `compression`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `encoding`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `ParentBasedSampler` | supported |  | * `local_parent_not_sampled`: supported<br>* `local_parent_sampled`: supported<br>* `remote_parent_not_sampled`: supported<br>* `remote_parent_sampled`: supported<br>* `root`: supported<br> |
-| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size/development`: supported<br> |
+| `PeriodicMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `interval`: supported<br>* `producers`: supported<br>* `timeout`: supported<br>* `max_export_batch_size`: supported<br> |
 | `Propagator` | supported |  | * `composite`: supported<br>* `composite_list`: supported<br> |
-| `PullMetricExporter` | supported |  | * `prometheus/development`: supported<br> |
+| `PullMetricExporter` | supported |  | * `prometheus`: supported<br> |
 | `PullMetricReader` | supported |  | * `cardinality_limits`: supported<br>* `exporter`: supported<br>* `producers`: supported<br> |
-| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `PushMetricExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `RandomIdGenerator` | ignored |  |  |
-| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection/development`: supported<br> |
-| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite/development`: supported<br>* `jaeger_remote/development`: supported<br>* `probability/development`: supported<br> |
+| `Resource` | supported |  | * `attributes`: supported<br>* `attributes_list`: supported<br>* `schema_url`: supported<br>* `detection`: supported<br> |
+| `Sampler` | supported |  | * `always_off`: supported<br>* `always_on`: supported<br>* `always_record`: unknown<br>* `parent_based`: supported<br>* `trace_id_ratio_based`: supported<br>* `composite`: supported<br>* `jaeger_remote`: supported<br>* `probability`: supported<br> |
 | `SeverityNumber` | supported |  | * `debug`: supported<br>* `debug2`: supported<br>* `debug3`: supported<br>* `debug4`: supported<br>* `error`: supported<br>* `error2`: supported<br>* `error3`: supported<br>* `error4`: supported<br>* `fatal`: supported<br>* `fatal2`: supported<br>* `fatal3`: supported<br>* `fatal4`: supported<br>* `info`: supported<br>* `info2`: supported<br>* `info3`: supported<br>* `info4`: supported<br>* `trace`: supported<br>* `trace2`: supported<br>* `trace3`: supported<br>* `trace4`: supported<br>* `warn`: supported<br>* `warn2`: supported<br>* `warn3`: supported<br>* `warn4`: supported<br> |
 | `SimpleLogRecordProcessor` | supported |  | * `exporter`: supported<br> |
 | `SimpleSpanProcessor` | supported |  | * `exporter`: supported<br> |
-| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file/development`: supported<br> |
+| `SpanExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `SpanKind` | supported |  | * `client`: supported<br>* `consumer`: supported<br>* `internal`: supported<br>* `producer`: supported<br>* `server`: supported<br> |
 | `SpanLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br>* `event_attribute_count_limit`: supported<br>* `event_count_limit`: supported<br>* `link_attribute_count_limit`: supported<br>* `link_count_limit`: supported<br> |
 | `SpanProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br> |
@@ -696,7 +696,7 @@ Latest supported file format: `1.0.0`
 | `TextMapPropagator` | supported |  | * `b3`: supported<br>* `b3multi`: supported<br>* `baggage`: supported<br>* `tracecontext`: supported<br> |
 | `TraceContextPropagator` | supported |  |  |
 | `TraceIdRatioBasedSampler` | supported |  | * `ratio`: supported<br> |
-| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator/development`: supported<br> |
+| `TracerProvider` | supported |  | * `id_generator`: supported<br>* `limits`: supported<br>* `processors`: supported<br>* `sampler`: supported<br>* `tracer_configurator`: supported<br> |
 | `View` | supported |  | * `selector`: supported<br>* `stream`: supported<br> |
 | `ViewSelector` | supported |  | * `instrument_name`: supported<br>* `instrument_type`: supported<br>* `meter_name`: supported<br>* `meter_schema_url`: supported<br>* `meter_version`: supported<br>* `unit`: supported<br> |
 | `ViewStream` | supported |  | * `aggregation`: supported<br>* `aggregation_cardinality_limit`: supported<br>* `attribute_keys`: supported<br>* `description`: supported<br>* `name`: supported<br> |
@@ -733,8 +733,8 @@ Latest supported file format: `1.0.0`
 | `ExperimentalOtlpFileMetricExporter` | ignored |  | * `default_histogram_aggregation`: ignored<br>* `output_stream`: ignored<br>* `temporality_preference`: ignored<br> |
 | `ExperimentalProbabilitySampler` | ignored |  | * `ratio`: ignored<br> |
 | `ExperimentalProcessResourceDetector` | supported |  |  |
-| `ExperimentalPrometheusMetricExporter` | ignored |  | * `host`: ignored<br>* `port`: ignored<br>* `resource_constant_labels`: ignored<br>* `scope_info_enabled`: ignored<br>* `translation_strategy`: ignored<br>* `target_info_enabled/development`: ignored<br> |
-| `ExperimentalPrometheusTranslationStrategy` | ignored |  | * `no_translation/development`: ignored<br>* `no_utf8_escaping_with_suffixes/development`: ignored<br>* `underscore_escaping_with_suffixes`: ignored<br>* `underscore_escaping_without_suffixes/development`: ignored<br> |
+| `ExperimentalPrometheusMetricExporter` | ignored |  | * `host`: ignored<br>* `port`: ignored<br>* `resource_constant_labels`: ignored<br>* `scope_info_enabled`: ignored<br>* `translation_strategy`: ignored<br>* `target_info_enabled`: ignored<br> |
+| `ExperimentalPrometheusTranslationStrategy` | ignored |  | * `no_translation`: ignored<br>* `no_utf8_escaping_with_suffixes`: ignored<br>* `underscore_escaping_with_suffixes`: ignored<br>* `underscore_escaping_without_suffixes`: ignored<br> |
 | `ExperimentalResourceDetection` | supported |  | * `attributes`: supported<br>* `detectors`: supported<br> |
 | `ExperimentalResourceDetector` | supported |  | * `container`: supported<br>* `host`: supported<br>* `process`: supported<br>* `service`: supported<br> |
 | `ExperimentalRpcInstrumentation` | ignored |  | * `semconv`: ignored<br> |

--- a/language-support-status.md
+++ b/language-support-status.md
@@ -50,12 +50,13 @@ Latest supported file format: `1.0.0`
 | `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
 | `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: not_implemented<br> |
+| `MaturityLevel` | unknown |  | * `development`: unknown<br>* `stable`: unknown<br> |
 | `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | supported |  | * `opencensus`: supported<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | supported |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `maturity_level`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
@@ -173,12 +174,13 @@ Latest supported file format: `1.0.0`
 | `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: not_implemented<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
 | `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: unknown<br> |
+| `MaturityLevel` | unknown |  | * `development`: unknown<br>* `stable`: unknown<br> |
 | `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | unknown |  | * `opencensus`: unknown<br> |
 | `MetricReader` | unknown |  | * `periodic`: unknown<br>* `pull`: unknown<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | unknown |  |  |
-| `OpenTelemetryConfiguration` | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation`: unknown<br> |
+| `OpenTelemetryConfiguration` | unknown |  | * `attribute_limits`: unknown<br>* `disabled`: unknown<br>* `distribution`: unknown<br>* `file_format`: unknown<br>* `log_level`: unknown<br>* `logger_provider`: unknown<br>* `maturity_level`: unknown<br>* `meter_provider`: unknown<br>* `propagator`: unknown<br>* `resource`: unknown<br>* `tracer_provider`: unknown<br>* `instrumentation`: unknown<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | not_implemented |  | * `json`: not_implemented<br>* `protobuf`: not_implemented<br> |
@@ -296,12 +298,13 @@ Latest supported file format: `1.0.0-rc.3`
 | `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
 | `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: unknown<br> |
+| `MaturityLevel` | unknown |  | * `development`: unknown<br>* `stable`: unknown<br> |
 | `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | ignored |  | * `opencensus`: ignored<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | ignored |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `maturity_level`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | not_implemented |  | * `json`: not_implemented<br>* `protobuf`: not_implemented<br> |
@@ -419,12 +422,13 @@ Latest supported file format: `1.0.0-rc.3`
 | `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
 | `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: supported<br> |
+| `MaturityLevel` | unknown |  | * `development`: unknown<br>* `stable`: unknown<br> |
 | `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | supported |  | * `opencensus`: supported<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | not_implemented |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `maturity_level`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
@@ -542,12 +546,13 @@ Latest supported file format: `1.0.0-rc.2`
 | `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | supported |  | * `attribute_count_limit`: supported<br>* `attribute_value_depth_limit`: not_implemented<br>* `attribute_value_length_limit`: supported<br> |
 | `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: unknown<br> |
+| `MaturityLevel` | unknown |  | * `development`: unknown<br>* `stable`: unknown<br> |
 | `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | not_implemented |  | * `opencensus`: not_implemented<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: not_implemented<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | not_implemented |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: not_implemented<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: not_implemented<br>* `file_format`: supported<br>* `log_level`: not_implemented<br>* `logger_provider`: supported<br>* `maturity_level`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: ignored<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: not_implemented<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: ignored<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |
@@ -665,12 +670,13 @@ Latest supported file format: `1.0.0`
 | `LogRecordExporter` | supported |  | * `console`: supported<br>* `otlp_grpc`: supported<br>* `otlp_http`: supported<br>* `otlp_file`: supported<br> |
 | `LogRecordLimits` | ignored |  | * `attribute_count_limit`: ignored<br>* `attribute_value_depth_limit`: ignored<br>* `attribute_value_length_limit`: ignored<br> |
 | `LogRecordProcessor` | supported |  | * `batch`: supported<br>* `simple`: supported<br>* `event_to_span_event_bridge`: supported<br> |
+| `MaturityLevel` | unknown |  | * `development`: unknown<br>* `stable`: unknown<br> |
 | `MeterProvider` | supported |  | * `exemplar_filter`: supported<br>* `readers`: supported<br>* `views`: supported<br>* `meter_configurator`: supported<br>* `view_matching_mode`: not_implemented<br> |
 | `MetricProducer` | ignored |  | * `opencensus`: ignored<br> |
 | `MetricReader` | supported |  | * `periodic`: supported<br>* `pull`: supported<br> |
 | `NameStringValuePair` | supported |  | * `name`: supported<br>* `value`: supported<br> |
 | `OpenCensusMetricProducer` | ignored |  |  |
-| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
+| `OpenTelemetryConfiguration` | supported |  | * `attribute_limits`: supported<br>* `disabled`: supported<br>* `distribution`: supported<br>* `file_format`: supported<br>* `log_level`: supported<br>* `logger_provider`: supported<br>* `maturity_level`: supported<br>* `meter_provider`: supported<br>* `propagator`: supported<br>* `resource`: supported<br>* `tracer_provider`: supported<br>* `instrumentation`: supported<br> |
 | `OtlpGrpcExporter` | supported |  | * `compression`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpGrpcMetricExporter` | supported |  | * `compression`: supported<br>* `default_histogram_aggregation`: supported<br>* `endpoint`: supported<br>* `headers`: supported<br>* `headers_list`: supported<br>* `max_request_size`: not_implemented<br>* `max_response_size`: not_implemented<br>* `temporality_preference`: supported<br>* `timeout`: supported<br>* `tls`: supported<br> |
 | `OtlpHttpEncoding` | supported |  | * `json`: supported<br>* `protobuf`: supported<br> |

--- a/opentelemetry_configuration.json
+++ b/opentelemetry_configuration.json
@@ -43,7 +43,7 @@
       "$ref": "#/$defs/Resource",
       "description": "Configure resource for all signals.\nIf omitted, the default resource is used.\n"
     },
-    "instrumentation/development": {
+    "instrumentation": {
       "$ref": "#/$defs/ExperimentalInstrumentation",
       "description": "Configure instrumentation.\nIf omitted, instrumentation defaults are used.\n"
     },
@@ -495,7 +495,7 @@
       "properties": {
         "semconv": {
           "$ref": "#/$defs/ExperimentalSemconvConfig",
-          "description": "Configure code semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+          "description": "Configure code semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
         }
       }
     },
@@ -698,7 +698,7 @@
       "properties": {
         "semconv": {
           "$ref": "#/$defs/ExperimentalSemconvConfig",
-          "description": "Configure database semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee database migration: https://opentelemetry.io/docs/specs/semconv/database/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+          "description": "Configure database semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee database migration: https://opentelemetry.io/docs/specs/semconv/database/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
         }
       }
     },
@@ -715,7 +715,7 @@
       "properties": {
         "semconv": {
           "$ref": "#/$defs/ExperimentalSemconvConfig",
-          "description": "Configure GenAI semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+          "description": "Configure GenAI semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
         }
       }
     },
@@ -756,7 +756,7 @@
             "string",
             "null"
           ],
-          "description": "Configure semantic convention stability opt-in as a comma-separated list.\nThis property follows the format and semantics of the OTEL_SEMCONV_STABILITY_OPT_IN environment variable.\nControls the emission of stable vs. experimental semantic conventions for instrumentation.\nThis setting is only intended for migrating from experimental to stable semantic conventions.\n\nKnown values include:\n- http: Emit stable HTTP and networking conventions only\n- http/dup: Emit both old and stable HTTP and networking conventions (for phased migration)\n- database: Emit stable database conventions only\n- database/dup: Emit both old and stable database conventions (for phased migration)\n- rpc: Emit stable RPC conventions only\n- rpc/dup: Emit both experimental and stable RPC conventions (for phased migration)\n- messaging: Emit stable messaging conventions only\n- messaging/dup: Emit both old and stable messaging conventions (for phased migration)\n- code: Emit stable code conventions only\n- code/dup: Emit both old and stable code conventions (for phased migration)\n\nMultiple values can be specified as a comma-separated list (e.g., \"http,database/dup\").\nAdditional signal types may be supported in future versions.\n\nDomain-specific semconv properties (e.g., .instrumentation/development.general.db.semconv) take precedence over this general setting.\n\nSee:\n- HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/\n- Database migration: https://opentelemetry.io/docs/specs/semconv/database/\n- RPC: https://opentelemetry.io/docs/specs/semconv/rpc/\n- Messaging: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/\nIf omitted or null, no opt-in is configured and instrumentations continue emitting their default semantic convention version.\n"
+          "description": "Configure semantic convention stability opt-in as a comma-separated list.\nThis property follows the format and semantics of the OTEL_SEMCONV_STABILITY_OPT_IN environment variable.\nControls the emission of stable vs. experimental semantic conventions for instrumentation.\nThis setting is only intended for migrating from experimental to stable semantic conventions.\n\nKnown values include:\n- http: Emit stable HTTP and networking conventions only\n- http/dup: Emit both old and stable HTTP and networking conventions (for phased migration)\n- database: Emit stable database conventions only\n- database/dup: Emit both old and stable database conventions (for phased migration)\n- rpc: Emit stable RPC conventions only\n- rpc/dup: Emit both experimental and stable RPC conventions (for phased migration)\n- messaging: Emit stable messaging conventions only\n- messaging/dup: Emit both old and stable messaging conventions (for phased migration)\n- code: Emit stable code conventions only\n- code/dup: Emit both old and stable code conventions (for phased migration)\n\nMultiple values can be specified as a comma-separated list (e.g., \"http,database/dup\").\nAdditional signal types may be supported in future versions.\n\nDomain-specific semconv properties (e.g., .instrumentation.general.db.semconv) take precedence over this general setting.\n\nSee:\n- HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/\n- Database migration: https://opentelemetry.io/docs/specs/semconv/database/\n- RPC: https://opentelemetry.io/docs/specs/semconv/rpc/\n- Messaging: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/\nIf omitted or null, no opt-in is configured and instrumentations continue emitting their default semantic convention version.\n"
         }
       }
     },
@@ -803,7 +803,7 @@
       "properties": {
         "semconv": {
           "$ref": "#/$defs/ExperimentalSemconvConfig",
-          "description": "Configure HTTP semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+          "description": "Configure HTTP semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
         },
         "client": {
           "$ref": "#/$defs/ExperimentalHttpClientInstrumentation",
@@ -970,7 +970,7 @@
       "properties": {
         "default_config": {
           "$ref": "#/$defs/ExperimentalLoggerConfig",
-          "description": "Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.\nIf omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig.\n"
+          "description": "Configure the default logger config used there is no matching entry in .logger_configurator.loggers.\nIf omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig.\n"
         },
         "loggers": {
           "type": "array",
@@ -1010,7 +1010,7 @@
       "properties": {
         "semconv": {
           "$ref": "#/$defs/ExperimentalSemconvConfig",
-          "description": "Configure messaging semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+          "description": "Configure messaging semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
         }
       }
     },
@@ -1036,7 +1036,7 @@
       "properties": {
         "default_config": {
           "$ref": "#/$defs/ExperimentalMeterConfig",
-          "description": "Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.\nIf omitted, unmatched .meters use default values as described in ExperimentalMeterConfig.\n"
+          "description": "Configure the default meter config used there is no matching entry in .meter_configurator.meters.\nIf omitted, unmatched .meters use default values as described in ExperimentalMeterConfig.\n"
         },
         "meters": {
           "type": "array",
@@ -1163,7 +1163,7 @@
           ],
           "description": "Configure Prometheus Exporter to produce metrics with scope labels.\nIf omitted or null, true is used.\n"
         },
-        "target_info_enabled/development": {
+        "target_info_enabled": {
           "type": [
             "boolean",
             "null"
@@ -1176,7 +1176,7 @@
         },
         "translation_strategy": {
           "$ref": "#/$defs/ExperimentalPrometheusTranslationStrategy",
-          "description": "Configure how metric names are translated to Prometheus metric names.\nValues include:\n* no_translation/development: Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered.\n* no_utf8_escaping_with_suffixes/development: Special character escaping is disabled. Type and unit suffixes are enabled.\n* underscore_escaping_with_suffixes: Special character escaping is enabled. Type and unit suffixes are enabled.\n* underscore_escaping_without_suffixes/development: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility.\nIf omitted, underscore_escaping_with_suffixes is used.\n"
+          "description": "Configure how metric names are translated to Prometheus metric names.\nValues include:\n* no_translation: Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered.\n* no_utf8_escaping_with_suffixes: Special character escaping is disabled. Type and unit suffixes are enabled.\n* underscore_escaping_with_suffixes: Special character escaping is enabled. Type and unit suffixes are enabled.\n* underscore_escaping_without_suffixes: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility.\nIf omitted, underscore_escaping_with_suffixes is used.\n"
         }
       }
     },
@@ -1187,9 +1187,9 @@
       ],
       "enum": [
         "underscore_escaping_with_suffixes",
-        "underscore_escaping_without_suffixes/development",
-        "no_utf8_escaping_with_suffixes/development",
-        "no_translation/development"
+        "underscore_escaping_without_suffixes",
+        "no_utf8_escaping_with_suffixes",
+        "no_translation"
       ]
     },
     "ExperimentalResourceDetection": {
@@ -1245,7 +1245,7 @@
       "properties": {
         "semconv": {
           "$ref": "#/$defs/ExperimentalSemconvConfig",
-          "description": "Configure RPC semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.\n\nSee RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+          "description": "Configure RPC semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
         }
       }
     },
@@ -1327,7 +1327,7 @@
       "properties": {
         "default_config": {
           "$ref": "#/$defs/ExperimentalTracerConfig",
-          "description": "Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.\nIf omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig.\n"
+          "description": "Configure the default tracer config used there is no matching entry in .tracer_configurator.tracers.\nIf omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig.\n"
         },
         "tracers": {
           "type": "array",
@@ -1574,7 +1574,7 @@
           "$ref": "#/$defs/LogRecordLimits",
           "description": "Configure log record limits. See also attribute_limits.\nIf omitted, default values as described in LogRecordLimits are used.\n"
         },
-        "logger_configurator/development": {
+        "logger_configurator": {
           "$ref": "#/$defs/ExperimentalLoggerConfigurator",
           "description": "Configure loggers.\nIf omitted, all loggers use default values as described in ExperimentalLoggerConfig.\n"
         }
@@ -1602,7 +1602,7 @@
           "$ref": "#/$defs/OtlpGrpcExporter",
           "description": "Configure exporter to be OTLP with gRPC transport.\nIf omitted, ignore.\n"
         },
-        "otlp_file/development": {
+        "otlp_file": {
           "$ref": "#/$defs/ExperimentalOtlpFileExporter",
           "description": "Configure exporter to be OTLP with file transport.\nIf omitted, ignore.\n"
         },
@@ -1661,7 +1661,7 @@
           "$ref": "#/$defs/SimpleLogRecordProcessor",
           "description": "Configure a simple log record processor.\nIf omitted, ignore.\n"
         },
-        "event_to_span_event_bridge/development": {
+        "event_to_span_event_bridge": {
           "$ref": "#/$defs/ExperimentalEventToSpanEventBridgeLogRecordProcessor",
           "description": "Configure an event to span event bridge log record processor.\nIf omitted, ignore.\n"
         }
@@ -1691,11 +1691,11 @@
           "$ref": "#/$defs/ExemplarFilter",
           "description": "Configure the exemplar filter.\nValues include:\n* always_off: ExemplarFilter which makes no measurements eligible for being an Exemplar.\n* always_on: ExemplarFilter which makes all measurements eligible for being an Exemplar.\n* trace_based: ExemplarFilter which makes measurements recorded in the context of a sampled parent span eligible for being an Exemplar.\nIf omitted, trace_based is used.\n"
         },
-        "meter_configurator/development": {
+        "meter_configurator": {
           "$ref": "#/$defs/ExperimentalMeterConfigurator",
           "description": "Configure meters.\nIf omitted, all meters use default values as described in ExperimentalMeterConfig.\n"
         },
-        "view_matching_mode/development": {
+        "view_matching_mode": {
           "$ref": "#/$defs/ExperimentalViewMatchingMode",
           "description": "Controls how multiple matching Views are applied to an Instrument.\nValues include:\n* composable: Combines (merges) matching Views into unified metric streams unless distinct stream names are configured.\n* independent: Creates separate metric streams independently for each matching View.\nIf omitted, independent is used.\n"
         }
@@ -2115,7 +2115,7 @@
           "minimum": 0,
           "description": "Configure maximum allowed time (in milliseconds) to export data. \nValue must be non-negative. A value of 0 indicates no limit (infinity).\nIf omitted or null, 30000 is used.\n"
         },
-        "max_export_batch_size/development": {
+        "max_export_batch_size": {
           "type": [
             "integer",
             "null"
@@ -2176,7 +2176,7 @@
       "minProperties": 1,
       "maxProperties": 1,
       "properties": {
-        "prometheus/development": {
+        "prometheus": {
           "$ref": "#/$defs/ExperimentalPrometheusMetricExporter",
           "description": "Configure exporter to be prometheus.\nIf omitted, ignore.\n"
         }
@@ -2226,7 +2226,7 @@
           "$ref": "#/$defs/OtlpGrpcMetricExporter",
           "description": "Configure exporter to be OTLP with gRPC transport.\nIf omitted, ignore.\n"
         },
-        "otlp_file/development": {
+        "otlp_file": {
           "$ref": "#/$defs/ExperimentalOtlpFileMetricExporter",
           "description": "Configure exporter to be OTLP with file transport.\nIf omitted, ignore.\n"
         },
@@ -2255,7 +2255,7 @@
           },
           "description": "Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.\nIf omitted, no resource attributes are added.\n"
         },
-        "detection/development": {
+        "detection": {
           "$ref": "#/$defs/ExperimentalResourceDetection",
           "description": "Configure resource detection.\nIf omitted, resource detection is disabled.\n"
         },
@@ -2298,11 +2298,11 @@
           "$ref": "#/$defs/AlwaysRecordSampler",
           "description": "Configure sampler to be always_record.\nIf omitted, ignore.\n"
         },
-        "composite/development": {
+        "composite": {
           "$ref": "#/$defs/ExperimentalComposableSampler",
           "description": "Configure sampler to be composite.\nIf omitted, ignore.\n"
         },
-        "jaeger_remote/development": {
+        "jaeger_remote": {
           "$ref": "#/$defs/ExperimentalJaegerRemoteSampler",
           "description": "Configure sampler to be jaeger_remote.\nIf omitted, ignore.\n"
         },
@@ -2310,7 +2310,7 @@
           "$ref": "#/$defs/ParentBasedSampler",
           "description": "Configure sampler to be parent_based.\nIf omitted, ignore.\n"
         },
-        "probability/development": {
+        "probability": {
           "$ref": "#/$defs/ExperimentalProbabilitySampler",
           "description": "Configure sampler to be probability.\nIf omitted, ignore.\n"
         },
@@ -2397,7 +2397,7 @@
           "$ref": "#/$defs/OtlpGrpcExporter",
           "description": "Configure exporter to be OTLP with gRPC transport.\nIf omitted, ignore.\n"
         },
-        "otlp_file/development": {
+        "otlp_file": {
           "$ref": "#/$defs/ExperimentalOtlpFileExporter",
           "description": "Configure exporter to be OTLP with file transport.\nIf omitted, ignore.\n"
         },
@@ -2588,7 +2588,7 @@
           "$ref": "#/$defs/IdGenerator",
           "description": "Configure the trace and span ID generator.\nIf omitted, RandomIdGenerator is used.\n"
         },
-        "tracer_configurator/development": {
+        "tracer_configurator": {
           "$ref": "#/$defs/ExperimentalTracerConfigurator",
           "description": "Configure tracers.\nIf omitted, all tracers use default values as described in ExperimentalTracerConfig.\n"
         }

--- a/opentelemetry_configuration_development.json
+++ b/opentelemetry_configuration_development.json
@@ -10,7 +10,7 @@
     },
     "maturity_level": {
       "$ref": "#/$defs/MaturityLevel",
-      "description": "The maturity level of the schema this file is written against.\nA file that omits this property is read with the stable schema and may use stable properties only. A file that declares development is read with the development schema and may also use properties that are under development.\nSee https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md for more details.\nValues include:\n* stable: The file is read with the stable schema and may use stable properties only.\nIf omitted, stable is used.\n"
+      "description": "The maturity level of the schema this file is written against.\nA file that omits this property is read with the stable schema and may use stable properties only. A file that declares development is read with the development schema and may also use properties that are under development.\nSee https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md for more details.\nValues include:\n* development: The file is read with the development schema and may also use properties that are under development, which may change or be removed in any release.\n* stable: The file is read with the stable schema and may use stable properties only.\nIf omitted, stable is used.\n"
     },
     "disabled": {
       "type": [
@@ -46,6 +46,11 @@
     "resource": {
       "$ref": "#/$defs/Resource",
       "description": "Configure resource for all signals.\nIf omitted, the default resource is used.\n"
+    },
+    "instrumentation": {
+      "stability": "development",
+      "$ref": "#/$defs/ExperimentalInstrumentation",
+      "description": "Configure instrumentation.\nIf omitted, instrumentation defaults are used.\n"
     },
     "distribution": {
       "$ref": "#/$defs/Distribution",
@@ -489,6 +494,955 @@
         "trace_based"
       ]
     },
+    "ExperimentalCodeInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "semconv": {
+          "$ref": "#/$defs/ExperimentalSemconvConfig",
+          "description": "Configure code semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+        }
+      }
+    },
+    "ExperimentalComposableAlwaysOffSampler": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
+    "ExperimentalComposableAlwaysOnSampler": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
+    "ExperimentalComposableParentThresholdSampler": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "root": {
+          "$ref": "#/$defs/ExperimentalComposableSampler",
+          "description": "Sampler to use when there is no parent.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "root"
+      ]
+    },
+    "ExperimentalComposableProbabilitySampler": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Configure ratio.\nIf omitted or null, 1.0 is used.\n"
+        }
+      }
+    },
+    "ExperimentalComposableRuleBasedSampler": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ExperimentalComposableRuleBasedSamplerRule"
+          },
+          "description": "The rules for the sampler, matched in order.\nEach rule can have multiple match conditions. All conditions must match for the rule to match.\nIf no conditions are specified, the rule matches all spans that reach it.\nIf no rules match, the span is not sampled.\nIf omitted, no span is sampled.\n"
+        }
+      }
+    },
+    "ExperimentalComposableRuleBasedSamplerRule": {
+      "stability": "development",
+      "type": "object",
+      "description": "A rule for ExperimentalComposableRuleBasedSampler. A rule can have multiple match conditions - the sampler will be applied if all match. \nIf no conditions are specified, the rule matches all spans that reach it.\n",
+      "additionalProperties": false,
+      "properties": {
+        "attribute_values": {
+          "$ref": "#/$defs/ExperimentalComposableRuleBasedSamplerRuleAttributeValues",
+          "description": "Values to match against a single attribute. Non-string attributes are matched using their string representation:\nfor example, a value of \"404\" would match the http.response.status_code 404. For array attributes, if any\nitem matches, it is considered a match.\nIf omitted, ignore.\n"
+        },
+        "attribute_patterns": {
+          "$ref": "#/$defs/ExperimentalComposableRuleBasedSamplerRuleAttributePatterns",
+          "description": "Patterns to match against a single attribute. Non-string attributes are matched using their string representation:\nfor example, a pattern of \"4*\" would match any http.response.status_code in 400-499. For array attributes, if any\nitem matches, it is considered a match.\nIf omitted, ignore.\n"
+        },
+        "span_kinds": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/SpanKind"
+          },
+          "description": "The span kinds to match. If the span's kind matches any of these, it matches.\nValues include:\n* client: client, a client span.\n* consumer: consumer, a consumer span.\n* internal: internal, an internal span.\n* producer: producer, a producer span.\n* server: server, a server span.\nIf omitted, ignore.\n"
+        },
+        "parent": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ExperimentalSpanParent"
+          },
+          "description": "The parent span types to match.\nValues include:\n* local: local, a local parent.\n* none: none, no parent, i.e., the trace root.\n* remote: remote, a remote parent.\nIf omitted, ignore.\n"
+        },
+        "sampler": {
+          "$ref": "#/$defs/ExperimentalComposableSampler",
+          "description": "The sampler to use for matching spans.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "sampler"
+      ]
+    },
+    "ExperimentalComposableRuleBasedSamplerRuleAttributePatterns": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The attribute key to match against.\nProperty is required and must be non-null.\n"
+        },
+        "included": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "Configure list of value patterns to include.\nMatching is case-sensitive. Values are evaluated to match as follows:\n * If the value exactly matches.\n * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.\nIf omitted, all values are included.\n"
+        },
+        "excluded": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "Configure list of value patterns to exclude. Applies after .included (i.e. excluded has higher priority than included).\nMatching is case-sensitive. Values are evaluated to match as follows:\n * If the value exactly matches.\n * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.\nIf omitted, .included attributes are included.\n"
+        }
+      },
+      "required": [
+        "key"
+      ]
+    },
+    "ExperimentalComposableRuleBasedSamplerRuleAttributeValues": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The attribute key to match against.\nProperty is required and must be non-null.\n"
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "The attribute values to match against. If the attribute's value matches any of these, it matches.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "key",
+        "values"
+      ]
+    },
+    "ExperimentalComposableSampler": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "object",
+          "null"
+        ]
+      },
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "always_off": {
+          "$ref": "#/$defs/ExperimentalComposableAlwaysOffSampler",
+          "description": "Configure sampler to be always_off.\nIf omitted, ignore.\n"
+        },
+        "always_on": {
+          "$ref": "#/$defs/ExperimentalComposableAlwaysOnSampler",
+          "description": "Configure sampler to be always_on.\nIf omitted, ignore.\n"
+        },
+        "parent_threshold": {
+          "$ref": "#/$defs/ExperimentalComposableParentThresholdSampler",
+          "description": "Configure sampler to be parent_threshold.\nIf omitted, ignore.\n"
+        },
+        "probability": {
+          "$ref": "#/$defs/ExperimentalComposableProbabilitySampler",
+          "description": "Configure sampler to be probability.\nIf omitted, ignore.\n"
+        },
+        "rule_based": {
+          "$ref": "#/$defs/ExperimentalComposableRuleBasedSampler",
+          "description": "Configure sampler to be rule_based.\nIf omitted, ignore.\n"
+        }
+      }
+    },
+    "ExperimentalContainerResourceDetector": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
+    "ExperimentalDbInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "semconv": {
+          "$ref": "#/$defs/ExperimentalSemconvConfig",
+          "description": "Configure database semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee database migration: https://opentelemetry.io/docs/specs/semconv/database/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+        }
+      }
+    },
+    "ExperimentalEventToSpanEventBridgeLogRecordProcessor": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
+    "ExperimentalGenAiInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "semconv": {
+          "$ref": "#/$defs/ExperimentalSemconvConfig",
+          "description": "Configure GenAI semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+        }
+      }
+    },
+    "ExperimentalGeneralInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "http": {
+          "$ref": "#/$defs/ExperimentalHttpInstrumentation",
+          "description": "Configure instrumentations following the http semantic conventions.\nSee http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/\nIf omitted, defaults as described in ExperimentalHttpInstrumentation are used.\n"
+        },
+        "code": {
+          "$ref": "#/$defs/ExperimentalCodeInstrumentation",
+          "description": "Configure instrumentations following the code semantic conventions.\nSee code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/\nIf omitted, defaults as described in ExperimentalCodeInstrumentation are used.\n"
+        },
+        "db": {
+          "$ref": "#/$defs/ExperimentalDbInstrumentation",
+          "description": "Configure instrumentations following the database semantic conventions.\nSee database semantic conventions: https://opentelemetry.io/docs/specs/semconv/database/\nIf omitted, defaults as described in ExperimentalDbInstrumentation are used.\n"
+        },
+        "gen_ai": {
+          "$ref": "#/$defs/ExperimentalGenAiInstrumentation",
+          "description": "Configure instrumentations following the GenAI semantic conventions.\nSee GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/\nIf omitted, defaults as described in ExperimentalGenAiInstrumentation are used.\n"
+        },
+        "messaging": {
+          "$ref": "#/$defs/ExperimentalMessagingInstrumentation",
+          "description": "Configure instrumentations following the messaging semantic conventions.\nSee messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/\nIf omitted, defaults as described in ExperimentalMessagingInstrumentation are used.\n"
+        },
+        "rpc": {
+          "$ref": "#/$defs/ExperimentalRpcInstrumentation",
+          "description": "Configure instrumentations following the RPC semantic conventions.\nSee RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/\nIf omitted, defaults as described in ExperimentalRpcInstrumentation are used.\n"
+        },
+        "sanitization": {
+          "$ref": "#/$defs/ExperimentalSanitization",
+          "description": "Configure general sanitization options.\nIf omitted, defaults as described in ExperimentalSanitization are used.\n"
+        },
+        "stability_opt_in_list": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure semantic convention stability opt-in as a comma-separated list.\nThis property follows the format and semantics of the OTEL_SEMCONV_STABILITY_OPT_IN environment variable.\nControls the emission of stable vs. experimental semantic conventions for instrumentation.\nThis setting is only intended for migrating from experimental to stable semantic conventions.\n\nKnown values include:\n- http: Emit stable HTTP and networking conventions only\n- http/dup: Emit both old and stable HTTP and networking conventions (for phased migration)\n- database: Emit stable database conventions only\n- database/dup: Emit both old and stable database conventions (for phased migration)\n- rpc: Emit stable RPC conventions only\n- rpc/dup: Emit both experimental and stable RPC conventions (for phased migration)\n- messaging: Emit stable messaging conventions only\n- messaging/dup: Emit both old and stable messaging conventions (for phased migration)\n- code: Emit stable code conventions only\n- code/dup: Emit both old and stable code conventions (for phased migration)\n\nMultiple values can be specified as a comma-separated list (e.g., \"http,database/dup\").\nAdditional signal types may be supported in future versions.\n\nDomain-specific semconv properties (e.g., .instrumentation.general.db.semconv) take precedence over this general setting.\n\nSee:\n- HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/\n- Database migration: https://opentelemetry.io/docs/specs/semconv/database/\n- RPC: https://opentelemetry.io/docs/specs/semconv/rpc/\n- Messaging: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/\nIf omitted or null, no opt-in is configured and instrumentations continue emitting their default semantic convention version.\n"
+        }
+      }
+    },
+    "ExperimentalHostResourceDetector": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
+    "ExperimentalHttpClientInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "request_captured_headers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "Configure headers to capture for outbound http requests.\nIf omitted, no outbound request headers are captured.\n"
+        },
+        "response_captured_headers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "Configure headers to capture for inbound http responses.\nIf omitted, no inbound response headers are captured.\n"
+        },
+        "known_methods": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string"
+          },
+          "description": "Override the default list of known HTTP methods.\nKnown methods are case-sensitive.\nThis is a full override of the default known methods, not a list of known methods in addition to the defaults.\nIf omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known.\n"
+        }
+      }
+    },
+    "ExperimentalHttpInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "semconv": {
+          "$ref": "#/$defs/ExperimentalSemconvConfig",
+          "description": "Configure HTTP semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+        },
+        "client": {
+          "$ref": "#/$defs/ExperimentalHttpClientInstrumentation",
+          "description": "Configure instrumentations following the http client semantic conventions.\nIf omitted, defaults as described in ExperimentalHttpClientInstrumentation are used.\n"
+        },
+        "server": {
+          "$ref": "#/$defs/ExperimentalHttpServerInstrumentation",
+          "description": "Configure instrumentations following the http server semantic conventions.\nIf omitted, defaults as described in ExperimentalHttpServerInstrumentation are used.\n"
+        }
+      }
+    },
+    "ExperimentalHttpServerInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "request_captured_headers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "Configure headers to capture for inbound http requests.\nIf omitted, no request headers are captured.\n"
+        },
+        "response_captured_headers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          },
+          "description": "Configure headers to capture for outbound http responses.\nIf omitted, no response headers are captures.\n"
+        },
+        "known_methods": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string"
+          },
+          "description": "Override the default list of known HTTP methods.\nKnown methods are case-sensitive.\nThis is a full override of the default known methods, not a list of known methods in addition to the defaults.\nIf omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known.\n"
+        }
+      }
+    },
+    "ExperimentalInstrumentation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "general": {
+          "$ref": "#/$defs/ExperimentalGeneralInstrumentation",
+          "description": "Configure general SemConv options that may apply to multiple languages and instrumentations.\nInstrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.\nIf omitted, default values as described in ExperimentalGeneralInstrumentation are used.\n"
+        },
+        "cpp": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure C++ language-specific instrumentation libraries.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "dotnet": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure .NET language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "erlang": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure Erlang language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "go": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure Go language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "java": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure Java language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "js": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure JavaScript language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "php": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure PHP language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "python": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure Python language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "ruby": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure Ruby language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "rust": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure Rust language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        },
+        "swift": {
+          "$ref": "#/$defs/ExperimentalLanguageSpecificInstrumentation",
+          "description": "Configure Swift language-specific instrumentation libraries.\nEach entry's key identifies a particular instrumentation library. The corresponding value configures it.\nIf omitted, instrumentation defaults are used.\n"
+        }
+      },
+      "stability": "development"
+    },
+    "ExperimentalJaegerRemoteSampler": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "endpoint": {
+          "type": [
+            "string"
+          ],
+          "description": "Configure the endpoint of the jaeger remote sampling service.\nProperty is required and must be non-null.\n"
+        },
+        "interval": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "Configure the polling interval (in milliseconds) to fetch from the remote sampling service.\nIf omitted or null, 60000 is used.\n"
+        },
+        "initial_sampler": {
+          "$ref": "#/$defs/Sampler",
+          "description": "Configure the initial sampler used before first configuration is fetched.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "endpoint",
+        "initial_sampler"
+      ]
+    },
+    "ExperimentalLanguageSpecificInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object"
+      }
+    },
+    "ExperimentalLoggerConfig": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Configure if the logger is enabled or not.\nIf omitted or null, true is used.\n"
+        },
+        "minimum_severity": {
+          "$ref": "#/$defs/SeverityNumber",
+          "description": "Configure severity filtering.\nLog records with an non-zero (i.e. unspecified) severity number which is less than minimum_severity are not processed.\nValues include:\n* debug: debug, severity number 5.\n* debug2: debug2, severity number 6.\n* debug3: debug3, severity number 7.\n* debug4: debug4, severity number 8.\n* error: error, severity number 17.\n* error2: error2, severity number 18.\n* error3: error3, severity number 19.\n* error4: error4, severity number 20.\n* fatal: fatal, severity number 21.\n* fatal2: fatal2, severity number 22.\n* fatal3: fatal3, severity number 23.\n* fatal4: fatal4, severity number 24.\n* info: info, severity number 9.\n* info2: info2, severity number 10.\n* info3: info3, severity number 11.\n* info4: info4, severity number 12.\n* trace: trace, severity number 1.\n* trace2: trace2, severity number 2.\n* trace3: trace3, severity number 3.\n* trace4: trace4, severity number 4.\n* warn: warn, severity number 13.\n* warn2: warn2, severity number 14.\n* warn3: warn3, severity number 15.\n* warn4: warn4, severity number 16.\nIf omitted, severity filtering is not applied.\n"
+        },
+        "trace_based": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Configure trace based filtering.\nIf true, log records associated with unsampled trace contexts traces are not processed. If false, or if a log record is not associated with a trace context, trace based filtering is not applied.\nIf omitted or null, trace based filtering is not applied.\n"
+        }
+      }
+    },
+    "ExperimentalLoggerConfigurator": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "default_config": {
+          "$ref": "#/$defs/ExperimentalLoggerConfig",
+          "description": "Configure the default logger config used there is no matching entry in .logger_configurator.loggers.\nIf omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig.\n"
+        },
+        "loggers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ExperimentalLoggerMatcherAndConfig"
+          },
+          "description": "Configure loggers.\nIf omitted, all loggers use .default_config.\n"
+        }
+      }
+    },
+    "ExperimentalLoggerMatcherAndConfig": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": [
+            "string"
+          ],
+          "description": "Configure logger names to match. Matching is case-sensitive, evaluated as follows:\n\n * If the logger name exactly matches.\n * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.\nProperty is required and must be non-null.\n"
+        },
+        "config": {
+          "$ref": "#/$defs/ExperimentalLoggerConfig",
+          "description": "The logger config.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "name",
+        "config"
+      ]
+    },
+    "ExperimentalMessagingInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "semconv": {
+          "$ref": "#/$defs/ExperimentalSemconvConfig",
+          "description": "Configure messaging semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+        }
+      }
+    },
+    "ExperimentalMeterConfig": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean"
+          ],
+          "description": "Configure if the meter is enabled or not.\nIf omitted, true is used.\n"
+        }
+      }
+    },
+    "ExperimentalMeterConfigurator": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "default_config": {
+          "$ref": "#/$defs/ExperimentalMeterConfig",
+          "description": "Configure the default meter config used there is no matching entry in .meter_configurator.meters.\nIf omitted, unmatched .meters use default values as described in ExperimentalMeterConfig.\n"
+        },
+        "meters": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ExperimentalMeterMatcherAndConfig"
+          },
+          "description": "Configure meters.\nIf omitted, all meters used .default_config.\n"
+        }
+      }
+    },
+    "ExperimentalMeterMatcherAndConfig": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": [
+            "string"
+          ],
+          "description": "Configure meter names to match. Matching is case-sensitive, evaluated as follows:\n\n * If the meter name exactly matches.\n * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.\nProperty is required and must be non-null.\n"
+        },
+        "config": {
+          "$ref": "#/$defs/ExperimentalMeterConfig",
+          "description": "The meter config.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "name",
+        "config"
+      ]
+    },
+    "ExperimentalOtlpFileExporter": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "output_stream": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure output stream. \nValues include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.\nIf omitted or null, stdout is used.\n"
+        }
+      }
+    },
+    "ExperimentalOtlpFileMetricExporter": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "output_stream": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure output stream. \nValues include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.\nIf omitted or null, stdout is used.\n"
+        },
+        "temporality_preference": {
+          "$ref": "#/$defs/ExporterTemporalityPreference",
+          "description": "Configure temporality preference.\nValues include:\n* cumulative: Use cumulative aggregation temporality for all instrument types.\n* delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter.\n* low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types.\nIf omitted, cumulative is used.\n"
+        },
+        "default_histogram_aggregation": {
+          "$ref": "#/$defs/ExporterDefaultHistogramAggregation",
+          "description": "Configure default histogram aggregation.\nValues include:\n* base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments.\n* explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments.\nIf omitted, explicit_bucket_histogram is used.\n"
+        }
+      }
+    },
+    "ExperimentalProbabilitySampler": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Configure ratio.\nIf omitted or null, 1.0 is used.\n"
+        }
+      }
+    },
+    "ExperimentalProcessResourceDetector": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
+    "ExperimentalPrometheusMetricExporter": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Configure host.\nIf omitted or null, localhost is used.\n"
+        },
+        "port": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Configure port.\nIf omitted or null, 9464 is used.\n"
+        },
+        "scope_info_enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Configure Prometheus Exporter to produce metrics with scope labels.\nIf omitted or null, true is used.\n"
+        },
+        "target_info_enabled": {
+          "stability": "development",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Configure Prometheus Exporter to produce metrics with a target info metric for the resource.\nIf omitted or null, true is used.\n"
+        },
+        "resource_constant_labels": {
+          "$ref": "#/$defs/IncludeExclude",
+          "description": "Configure Prometheus Exporter to add resource attributes as metrics attributes, where the resource attribute keys match the patterns.\nIf omitted, no resource attributes are added.\n"
+        },
+        "translation_strategy": {
+          "$ref": "#/$defs/ExperimentalPrometheusTranslationStrategy",
+          "description": "Configure how metric names are translated to Prometheus metric names.\nValues include:\n* no_translation: Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered.\n* no_utf8_escaping_with_suffixes: Special character escaping is disabled. Type and unit suffixes are enabled.\n* underscore_escaping_with_suffixes: Special character escaping is enabled. Type and unit suffixes are enabled.\n* underscore_escaping_without_suffixes: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility.\nIf omitted, underscore_escaping_with_suffixes is used.\n"
+        }
+      }
+    },
+    "ExperimentalPrometheusTranslationStrategy": {
+      "stability": "development",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "underscore_escaping_with_suffixes",
+        "underscore_escaping_without_suffixes",
+        "no_utf8_escaping_with_suffixes",
+        "no_translation"
+      ],
+      "enumStability": {
+        "no_translation": "development",
+        "no_utf8_escaping_with_suffixes": "development",
+        "underscore_escaping_without_suffixes": "development"
+      }
+    },
+    "ExperimentalResourceDetection": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attributes": {
+          "$ref": "#/$defs/IncludeExclude",
+          "description": "Configure attributes provided by resource detectors.\nIf omitted, all attributes from resource detectors are added.\n"
+        },
+        "detectors": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ExperimentalResourceDetector"
+          },
+          "description": "Configure resource detectors.\nResource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. \nIf omitted, no resource detectors are enabled.\n"
+        }
+      }
+    },
+    "ExperimentalResourceDetector": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "object",
+          "null"
+        ]
+      },
+      "minProperties": 1,
+      "maxProperties": 1,
+      "properties": {
+        "container": {
+          "$ref": "#/$defs/ExperimentalContainerResourceDetector",
+          "description": "Enable the container resource detector, which populates container.* attributes.\nIf omitted, ignore.\n"
+        },
+        "host": {
+          "$ref": "#/$defs/ExperimentalHostResourceDetector",
+          "description": "Enable the host resource detector, which populates host.* and os.* attributes.\nIf omitted, ignore.\n"
+        },
+        "process": {
+          "$ref": "#/$defs/ExperimentalProcessResourceDetector",
+          "description": "Enable the process resource detector, which populates process.* attributes.\nIf omitted, ignore.\n"
+        },
+        "service": {
+          "$ref": "#/$defs/ExperimentalServiceResourceDetector",
+          "description": "Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.\nIf omitted, ignore.\n"
+        }
+      }
+    },
+    "ExperimentalRpcInstrumentation": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "semconv": {
+          "$ref": "#/$defs/ExperimentalSemconvConfig",
+          "description": "Configure RPC semantic convention version and migration behavior.\n\nThis property takes precedence over the .instrumentation.general.stability_opt_in_list setting.\n\nSee RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/\nIf omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.\n"
+        }
+      }
+    },
+    "ExperimentalSanitization": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "$ref": "#/$defs/ExperimentalUrlSanitization",
+          "description": "Configure URL sanitization options.\nIf omitted, defaults as described in ExperimentalUrlSanitization are used.\n"
+        }
+      }
+    },
+    "ExperimentalSemconvConfig": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 0,
+          "description": "The target semantic convention version for this domain (e.g., 1).\nIf omitted or null, the latest stable version is used, or if no stable version is available and .experimental is true then the latest experimental version is used.\n"
+        },
+        "experimental": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "Use latest experimental semantic conventions (before stable is available or to enable experimental features on top of stable conventions).\nIf omitted or null, false is used.\n"
+        },
+        "dual_emit": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "description": "When true, also emit the previous major version alongside the target version.\nFor version=1, the previous version refers to the pre-stable conventions that the instrumentation emitted before the first stable semantic convention version was defined.\nFor version=2 and above, the previous version is the prior stable major version (e.g., version=2, dual_emit=true emits both v2 and v1).\nEnables dual-emit for phased migration between versions.\nIf omitted or null, false is used.\n"
+        }
+      }
+    },
+    "ExperimentalServiceResourceDetector": {
+      "stability": "development",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false
+    },
+    "ExperimentalSpanParent": {
+      "stability": "development",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "none",
+        "remote",
+        "local"
+      ]
+    },
+    "ExperimentalTracerConfig": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": [
+            "boolean"
+          ],
+          "description": "Configure if the tracer is enabled or not.\nIf omitted, true is used.\n"
+        }
+      }
+    },
+    "ExperimentalTracerConfigurator": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "default_config": {
+          "$ref": "#/$defs/ExperimentalTracerConfig",
+          "description": "Configure the default tracer config used there is no matching entry in .tracer_configurator.tracers.\nIf omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig.\n"
+        },
+        "tracers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ExperimentalTracerMatcherAndConfig"
+          },
+          "description": "Configure tracers.\nIf omitted, all tracers use .default_config.\n"
+        }
+      }
+    },
+    "ExperimentalTracerMatcherAndConfig": {
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": [
+            "string"
+          ],
+          "description": "Configure tracer names to match. Matching is case-sensitive, evaluated as follows:\n\n * If the tracer name exactly matches.\n * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.\nProperty is required and must be non-null.\n"
+        },
+        "config": {
+          "$ref": "#/$defs/ExperimentalTracerConfig",
+          "description": "The tracer config.\nProperty is required and must be non-null.\n"
+        }
+      },
+      "required": [
+        "name",
+        "config"
+      ]
+    },
+    "ExperimentalUrlSanitization": {
+      "stability": "development",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sensitive_query_parameters": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string"
+          },
+          "description": "List of query parameter names whose values should be redacted from URLs.\nQuery parameter names are case-sensitive.\nThis is a full override of the default sensitive query parameter keys, it is not a list of keys in addition to the defaults.\nSet to an empty array to disable query parameter redaction.\nIf omitted, the default sensitive query parameter list as defined by the url semantic conventions (https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/url.md) is used.\n"
+        }
+      }
+    },
+    "ExperimentalViewMatchingMode": {
+      "stability": "development",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "independent",
+        "composable"
+      ]
+    },
     "ExplicitBucketHistogramAggregation": {
       "type": [
         "object",
@@ -677,6 +1631,11 @@
         "limits": {
           "$ref": "#/$defs/LogRecordLimits",
           "description": "Configure log record limits. See also attribute_limits.\nIf omitted, default values as described in LogRecordLimits are used.\n"
+        },
+        "logger_configurator": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalLoggerConfigurator",
+          "description": "Configure loggers.\nIf omitted, all loggers use default values as described in ExperimentalLoggerConfig.\n"
         }
       },
       "required": [
@@ -701,6 +1660,11 @@
         "otlp_grpc": {
           "$ref": "#/$defs/OtlpGrpcExporter",
           "description": "Configure exporter to be OTLP with gRPC transport.\nIf omitted, ignore.\n"
+        },
+        "otlp_file": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalOtlpFileExporter",
+          "description": "Configure exporter to be OTLP with file transport.\nIf omitted, ignore.\n"
         },
         "console": {
           "$ref": "#/$defs/ConsoleExporter",
@@ -756,14 +1720,23 @@
         "simple": {
           "$ref": "#/$defs/SimpleLogRecordProcessor",
           "description": "Configure a simple log record processor.\nIf omitted, ignore.\n"
+        },
+        "event_to_span_event_bridge": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalEventToSpanEventBridgeLogRecordProcessor",
+          "description": "Configure an event to span event bridge log record processor.\nIf omitted, ignore.\n"
         }
       }
     },
     "MaturityLevel": {
       "type": "string",
       "enum": [
-        "stable"
-      ]
+        "stable",
+        "development"
+      ],
+      "enumStability": {
+        "development": "development"
+      }
     },
     "MeterProvider": {
       "type": "object",
@@ -788,6 +1761,16 @@
         "exemplar_filter": {
           "$ref": "#/$defs/ExemplarFilter",
           "description": "Configure the exemplar filter.\nValues include:\n* always_off: ExemplarFilter which makes no measurements eligible for being an Exemplar.\n* always_on: ExemplarFilter which makes all measurements eligible for being an Exemplar.\n* trace_based: ExemplarFilter which makes measurements recorded in the context of a sampled parent span eligible for being an Exemplar.\nIf omitted, trace_based is used.\n"
+        },
+        "meter_configurator": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalMeterConfigurator",
+          "description": "Configure meters.\nIf omitted, all meters use default values as described in ExperimentalMeterConfig.\n"
+        },
+        "view_matching_mode": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalViewMatchingMode",
+          "description": "Controls how multiple matching Views are applied to an Instrument.\nValues include:\n* composable: Combines (merges) matching Views into unified metric streams unless distinct stream names are configured.\n* independent: Creates separate metric streams independently for each matching View.\nIf omitted, independent is used.\n"
         }
       },
       "required": [
@@ -1205,6 +2188,15 @@
           "minimum": 0,
           "description": "Configure maximum allowed time (in milliseconds) to export data. \nValue must be non-negative. A value of 0 indicates no limit (infinity).\nIf omitted or null, 30000 is used.\n"
         },
+        "max_export_batch_size": {
+          "stability": "development",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1,
+          "description": "Configure maximum export batch size.\nIf omitted or null, no limit is used.\n"
+        },
         "exporter": {
           "$ref": "#/$defs/PushMetricExporter",
           "description": "Configure exporter.\nProperty is required and must be non-null.\n"
@@ -1257,7 +2249,13 @@
       },
       "minProperties": 1,
       "maxProperties": 1,
-      "properties": {}
+      "properties": {
+        "prometheus": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalPrometheusMetricExporter",
+          "description": "Configure exporter to be prometheus.\nIf omitted, ignore.\n"
+        }
+      }
     },
     "PullMetricReader": {
       "type": "object",
@@ -1303,6 +2301,11 @@
           "$ref": "#/$defs/OtlpGrpcMetricExporter",
           "description": "Configure exporter to be OTLP with gRPC transport.\nIf omitted, ignore.\n"
         },
+        "otlp_file": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalOtlpFileMetricExporter",
+          "description": "Configure exporter to be OTLP with file transport.\nIf omitted, ignore.\n"
+        },
         "console": {
           "$ref": "#/$defs/ConsoleMetricExporter",
           "description": "Configure exporter to be console.\nIf omitted, ignore.\n"
@@ -1327,6 +2330,11 @@
             "$ref": "#/$defs/AttributeNameValue"
           },
           "description": "Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.\nIf omitted, no resource attributes are added.\n"
+        },
+        "detection": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalResourceDetection",
+          "description": "Configure resource detection.\nIf omitted, resource detection is disabled.\n"
         },
         "schema_url": {
           "type": [
@@ -1367,9 +2375,24 @@
           "$ref": "#/$defs/AlwaysRecordSampler",
           "description": "Configure sampler to be always_record.\nIf omitted, ignore.\n"
         },
+        "composite": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalComposableSampler",
+          "description": "Configure sampler to be composite.\nIf omitted, ignore.\n"
+        },
+        "jaeger_remote": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalJaegerRemoteSampler",
+          "description": "Configure sampler to be jaeger_remote.\nIf omitted, ignore.\n"
+        },
         "parent_based": {
           "$ref": "#/$defs/ParentBasedSampler",
           "description": "Configure sampler to be parent_based.\nIf omitted, ignore.\n"
+        },
+        "probability": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalProbabilitySampler",
+          "description": "Configure sampler to be probability.\nIf omitted, ignore.\n"
         },
         "trace_id_ratio_based": {
           "$ref": "#/$defs/TraceIdRatioBasedSampler",
@@ -1453,6 +2476,11 @@
         "otlp_grpc": {
           "$ref": "#/$defs/OtlpGrpcExporter",
           "description": "Configure exporter to be OTLP with gRPC transport.\nIf omitted, ignore.\n"
+        },
+        "otlp_file": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalOtlpFileExporter",
+          "description": "Configure exporter to be OTLP with file transport.\nIf omitted, ignore.\n"
         },
         "console": {
           "$ref": "#/$defs/ConsoleExporter",
@@ -1640,6 +2668,11 @@
         "id_generator": {
           "$ref": "#/$defs/IdGenerator",
           "description": "Configure the trace and span ID generator.\nIf omitted, RandomIdGenerator is used.\n"
+        },
+        "tracer_configurator": {
+          "stability": "development",
+          "$ref": "#/$defs/ExperimentalTracerConfigurator",
+          "description": "Configure tracers.\nIf omitted, all tracers use default values as described in ExperimentalTracerConfig.\n"
         }
       },
       "required": [

--- a/schema/common.yaml
+++ b/schema/common.yaml
@@ -196,6 +196,7 @@ $defs:
           Value must be non-negative. A value of 0 indicates no limit (infinity).
         defaultBehavior: 10000 is used
   ExperimentalOtlpFileExporter:
+    stability: development
     type:
       - object
       - "null"

--- a/schema/instrumentation.yaml
+++ b/schema/instrumentation.yaml
@@ -73,6 +73,7 @@ properties:
     defaultBehavior: instrumentation defaults are used
 $defs:
   ExperimentalGeneralInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -140,7 +141,7 @@ $defs:
           Multiple values can be specified as a comma-separated list (e.g., "http,database/dup").
           Additional signal types may be supported in future versions.
 
-          Domain-specific semconv properties (e.g., .instrumentation/development.general.db.semconv) take precedence over this general setting.
+          Domain-specific semconv properties (e.g., .instrumentation.general.db.semconv) take precedence over this general setting.
 
           See:
           - HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
@@ -149,6 +150,7 @@ $defs:
           - Messaging: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
         defaultBehavior: no opt-in is configured and instrumentations continue emitting their default semantic convention version
   ExperimentalSemconvConfig:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -172,6 +174,7 @@ $defs:
           Enables dual-emit for phased migration between versions.
         defaultBehavior: "false is used"
   ExperimentalHttpClientInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -202,6 +205,7 @@ $defs:
           This is a full override of the default known methods, not a list of known methods in addition to the defaults.
         defaultBehavior: HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known
   ExperimentalHttpServerInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -232,6 +236,7 @@ $defs:
           This is a full override of the default known methods, not a list of known methods in addition to the defaults.
         defaultBehavior: HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known
   ExperimentalHttpInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -240,7 +245,7 @@ $defs:
         description: |
           Configure HTTP semantic convention version and migration behavior.
 
-          This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.
+          This property takes precedence over the .instrumentation.general.stability_opt_in_list setting.
 
           See HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
         defaultBehavior: uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set
@@ -253,6 +258,7 @@ $defs:
         description: Configure instrumentations following the http server semantic conventions.
         defaultBehavior: defaults as described in ExperimentalHttpServerInstrumentation are used
   ExperimentalCodeInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -261,11 +267,12 @@ $defs:
         description: |
           Configure code semantic convention version and migration behavior.
 
-          This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.
+          This property takes precedence over the .instrumentation.general.stability_opt_in_list setting.
 
           See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/
         defaultBehavior: uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set
   ExperimentalDbInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -274,11 +281,12 @@ $defs:
         description: |
           Configure database semantic convention version and migration behavior.
 
-          This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.
+          This property takes precedence over the .instrumentation.general.stability_opt_in_list setting.
 
           See database migration: https://opentelemetry.io/docs/specs/semconv/database/
         defaultBehavior: uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set
   ExperimentalGenAiInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -287,11 +295,12 @@ $defs:
         description: |
           Configure GenAI semantic convention version and migration behavior.
 
-          This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.
+          This property takes precedence over the .instrumentation.general.stability_opt_in_list setting.
 
           See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/
         defaultBehavior: uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set
   ExperimentalRpcInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -300,11 +309,12 @@ $defs:
         description: |
           Configure RPC semantic convention version and migration behavior.
 
-          This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.
+          This property takes precedence over the .instrumentation.general.stability_opt_in_list setting.
 
           See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/
         defaultBehavior: uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set
   ExperimentalMessagingInstrumentation:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -313,11 +323,12 @@ $defs:
         description: |
           Configure messaging semantic convention version and migration behavior.
 
-          This property takes precedence over the .instrumentation/development.general.stability_opt_in_list setting.
+          This property takes precedence over the .instrumentation.general.stability_opt_in_list setting.
 
           See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/
         defaultBehavior: uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set
   ExperimentalSanitization:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -327,6 +338,7 @@ $defs:
           Configure URL sanitization options.
         defaultBehavior: defaults as described in ExperimentalUrlSanitization are used
   ExperimentalUrlSanitization:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -342,6 +354,7 @@ $defs:
           Set to an empty array to disable query parameter redaction.
         defaultBehavior: the default sensitive query parameter list as defined by the url semantic conventions (https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/url.md) is used
   ExperimentalLanguageSpecificInstrumentation:
+    stability: development
     type: object
     additionalProperties:
       type: object

--- a/schema/logger_provider.yaml
+++ b/schema/logger_provider.yaml
@@ -11,7 +11,8 @@ properties:
     $ref: "#/$defs/LogRecordLimits"
     description: Configure log record limits. See also attribute_limits.
     defaultBehavior: default values as described in LogRecordLimits are used
-  logger_configurator/development:
+  logger_configurator:
+    stability: development
     $ref: "#/$defs/ExperimentalLoggerConfigurator"
     description: |
       Configure loggers.
@@ -72,6 +73,7 @@ $defs:
     required:
       - exporter
   ExperimentalEventToSpanEventBridgeLogRecordProcessor:
+    stability: development
     type:
       - object
       - "null"
@@ -93,7 +95,8 @@ $defs:
         $ref: common.yaml#/$defs/OtlpGrpcExporter
         description: Configure exporter to be OTLP with gRPC transport.
         defaultBehavior: ignore
-      otlp_file/development:
+      otlp_file:
+        stability: development
         $ref: common.yaml#/$defs/ExperimentalOtlpFileExporter
         description: |
           Configure exporter to be OTLP with file transport.
@@ -153,19 +156,21 @@ $defs:
         $ref: "#/$defs/SimpleLogRecordProcessor"
         description: Configure a simple log record processor.
         defaultBehavior: ignore
-      event_to_span_event_bridge/development:
+      event_to_span_event_bridge:
+        stability: development
         $ref: "#/$defs/ExperimentalEventToSpanEventBridgeLogRecordProcessor"
         description: Configure an event to span event bridge log record processor.
         defaultBehavior: ignore
     isSdkExtensionPlugin: true
   ExperimentalLoggerConfigurator:
+    stability: development
     type:
       - object
     additionalProperties: false
     properties:
       default_config:
         $ref: "#/$defs/ExperimentalLoggerConfig"
-        description: Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.
+        description: Configure the default logger config used there is no matching entry in .logger_configurator.loggers.
         defaultBehavior: unmatched .loggers use default values as described in ExperimentalLoggerConfig
       loggers:
         type: array
@@ -175,6 +180,7 @@ $defs:
         description: Configure loggers.
         defaultBehavior: all loggers use .default_config
   ExperimentalLoggerMatcherAndConfig:
+    stability: development
     type:
       - object
     additionalProperties: false
@@ -194,6 +200,7 @@ $defs:
       - name
       - config
   ExperimentalLoggerConfig:
+    stability: development
     type:
       - object
     additionalProperties: false

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -105,6 +105,9 @@ typeSupportStatuses:
     propertyOverrides:
       - property: event_to_span_event_bridge
         status: not_implemented
+  - type: MaturityLevel
+    status: unknown
+    enumOverrides: []
   - type: MeterProvider
     status: supported
     propertyOverrides:

--- a/schema/meta_schema_language_cpp.yaml
+++ b/schema/meta_schema_language_cpp.yaml
@@ -103,12 +103,12 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge/development
+      - property: event_to_span_event_bridge
         status: not_implemented
   - type: MeterProvider
     status: supported
     propertyOverrides:
-      - property: view_matching_mode/development
+      - property: view_matching_mode
         status: not_implemented
   - type: MetricProducer
     status: supported
@@ -162,7 +162,7 @@ typeSupportStatuses:
   - type: PeriodicMetricReader
     status: supported
     propertyOverrides:
-      - property: max_export_batch_size/development
+      - property: max_export_batch_size
         status: not_implemented
   - type: Propagator
     status: supported
@@ -339,11 +339,11 @@ typeSupportStatuses:
   - type: ExperimentalPrometheusTranslationStrategy
     status: supported
     enumOverrides:
-      - enumValue: no_translation/development
+      - enumValue: no_translation
         status: not_implemented
-      - enumValue: no_utf8_escaping_with_suffixes/development
+      - enumValue: no_utf8_escaping_with_suffixes
         status: not_implemented
-      - enumValue: underscore_escaping_without_suffixes/development
+      - enumValue: underscore_escaping_without_suffixes
         status: supported
   - type: ExperimentalResourceDetection
     status: supported

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -96,12 +96,12 @@ typeSupportStatuses:
   - type: LoggerProvider
     status: supported
     propertyOverrides:
-      - property: logger_configurator/development
+      - property: logger_configurator
         status: not_implemented
   - type: LogRecordExporter
     status: supported
     propertyOverrides:
-      - property: otlp_file/development
+      - property: otlp_file
         status: not_implemented
   - type: LogRecordLimits
     status: supported
@@ -111,12 +111,12 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge/development
+      - property: event_to_span_event_bridge
         status: unknown
   - type: MeterProvider
     status: supported
     propertyOverrides:
-      - property: view_matching_mode/development
+      - property: view_matching_mode
         status: not_implemented
   - type: MetricProducer
     status: unknown
@@ -180,7 +180,7 @@ typeSupportStatuses:
     propertyOverrides:
       - property: cardinality_limits
         status: not_implemented
-      - property: max_export_batch_size/development
+      - property: max_export_batch_size
         status: not_implemented
       - property: producers
         status: not_implemented
@@ -207,11 +207,11 @@ typeSupportStatuses:
     propertyOverrides:
       - property: always_record
         status: unknown
-      - property: composite/development
+      - property: composite
         status: not_implemented
-      - property: jaeger_remote/development
+      - property: jaeger_remote
         status: not_implemented
-      - property: probability/development
+      - property: probability
         status: not_implemented
   - type: SeverityNumber
     status: unknown
@@ -225,7 +225,7 @@ typeSupportStatuses:
   - type: SpanExporter
     status: supported
     propertyOverrides:
-      - property: otlp_file/development
+      - property: otlp_file
         status: not_implemented
   - type: SpanKind
     status: unknown

--- a/schema/meta_schema_language_go.yaml
+++ b/schema/meta_schema_language_go.yaml
@@ -113,6 +113,9 @@ typeSupportStatuses:
     propertyOverrides:
       - property: event_to_span_event_bridge
         status: unknown
+  - type: MaturityLevel
+    status: unknown
+    enumOverrides: []
   - type: MeterProvider
     status: supported
     propertyOverrides:

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -109,12 +109,12 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge/development
+      - property: event_to_span_event_bridge
         status: unknown
   - type: MeterProvider
     status: supported
     propertyOverrides:
-      - property: view_matching_mode/development
+      - property: view_matching_mode
         status: not_implemented
   - type: MetricProducer
     status: ignored
@@ -174,7 +174,7 @@ typeSupportStatuses:
   - type: PeriodicMetricReader
     status: supported
     propertyOverrides:
-      - property: max_export_batch_size/development
+      - property: max_export_batch_size
         status: not_implemented
       - property: producers
         status: not_implemented

--- a/schema/meta_schema_language_java.yaml
+++ b/schema/meta_schema_language_java.yaml
@@ -111,6 +111,9 @@ typeSupportStatuses:
     propertyOverrides:
       - property: event_to_span_event_bridge
         status: unknown
+  - type: MaturityLevel
+    status: unknown
+    enumOverrides: []
   - type: MeterProvider
     status: supported
     propertyOverrides:

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -107,6 +107,9 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides: []
+  - type: MaturityLevel
+    status: unknown
+    enumOverrides: []
   - type: MeterProvider
     status: supported
     propertyOverrides:

--- a/schema/meta_schema_language_js.yaml
+++ b/schema/meta_schema_language_js.yaml
@@ -110,7 +110,7 @@ typeSupportStatuses:
   - type: MeterProvider
     status: supported
     propertyOverrides:
-      - property: view_matching_mode/development
+      - property: view_matching_mode
         status: not_implemented
   - type: MetricProducer
     status: supported
@@ -164,7 +164,7 @@ typeSupportStatuses:
   - type: PeriodicMetricReader
     status: supported
     propertyOverrides:
-      - property: max_export_batch_size/development
+      - property: max_export_batch_size
         status: not_implemented
   - type: Propagator
     status: supported

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -113,6 +113,9 @@ typeSupportStatuses:
     propertyOverrides:
       - property: event_to_span_event_bridge
         status: unknown
+  - type: MaturityLevel
+    status: unknown
+    enumOverrides: []
   - type: MeterProvider
     status: supported
     propertyOverrides:

--- a/schema/meta_schema_language_php.yaml
+++ b/schema/meta_schema_language_php.yaml
@@ -111,12 +111,12 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides:
-      - property: event_to_span_event_bridge/development
+      - property: event_to_span_event_bridge
         status: unknown
   - type: MeterProvider
     status: supported
     propertyOverrides:
-      - property: view_matching_mode/development
+      - property: view_matching_mode
         status: not_implemented
   - type: MetricProducer
     status: not_implemented
@@ -190,7 +190,7 @@ typeSupportStatuses:
     propertyOverrides:
       - property: interval
         status: not_implemented
-      - property: max_export_batch_size/development
+      - property: max_export_batch_size
         status: not_implemented
       - property: producers
         status: not_implemented
@@ -217,11 +217,11 @@ typeSupportStatuses:
     propertyOverrides:
       - property: always_record
         status: unknown
-      - property: composite/development
+      - property: composite
         status: not_implemented
-      - property: jaeger_remote/development
+      - property: jaeger_remote
         status: not_implemented
-      - property: probability/development
+      - property: probability
         status: not_implemented
   - type: SeverityNumber
     status: supported

--- a/schema/meta_schema_language_python.yaml
+++ b/schema/meta_schema_language_python.yaml
@@ -102,7 +102,7 @@ typeSupportStatuses:
   - type: MeterProvider
     status: supported
     propertyOverrides:
-      - property: view_matching_mode/development
+      - property: view_matching_mode
         status: not_implemented
   - type: MetricProducer
     status: ignored

--- a/schema/meta_schema_language_python.yaml
+++ b/schema/meta_schema_language_python.yaml
@@ -99,6 +99,9 @@ typeSupportStatuses:
   - type: LogRecordProcessor
     status: supported
     propertyOverrides: []
+  - type: MaturityLevel
+    status: unknown
+    enumOverrides: []
   - type: MeterProvider
     status: supported
     propertyOverrides:

--- a/schema/meter_provider.yaml
+++ b/schema/meter_provider.yaml
@@ -21,12 +21,14 @@ properties:
     description: |
       Configure the exemplar filter.
     defaultBehavior: trace_based is used
-  meter_configurator/development:
+  meter_configurator:
+    stability: development
     $ref: "#/$defs/ExperimentalMeterConfigurator"
     description: |
       Configure meters.
     defaultBehavior: all meters use default values as described in ExperimentalMeterConfig
-  view_matching_mode/development:
+  view_matching_mode:
+    stability: development
     $ref: "#/$defs/ExperimentalViewMatchingMode"
     description: |
       Controls how multiple matching Views are applied to an Instrument.
@@ -68,7 +70,8 @@ $defs:
           Configure maximum allowed time (in milliseconds) to export data. 
           Value must be non-negative. A value of 0 indicates no limit (infinity).
         defaultBehavior: 30000 is used
-      max_export_batch_size/development:
+      max_export_batch_size:
+        stability: development
         type:
           - integer
           - "null"
@@ -200,7 +203,8 @@ $defs:
         description: |
           Configure exporter to be OTLP with gRPC transport.
         defaultBehavior: ignore
-      otlp_file/development:
+      otlp_file:
+        stability: development
         $ref: "#/$defs/ExperimentalOtlpFileMetricExporter"
         description: |
           Configure exporter to be OTLP with file transport.
@@ -220,7 +224,8 @@ $defs:
     minProperties: 1
     maxProperties: 1
     properties:
-      prometheus/development:
+      prometheus:
+        stability: development
         $ref: "#/$defs/ExperimentalPrometheusMetricExporter"
         description: |
           Configure exporter to be prometheus.
@@ -261,6 +266,7 @@ $defs:
       See also the
       [OpenCensus sunset announcement](https://opentelemetry.io/blog/2023/sunsetting-opencensus/).
   ExperimentalPrometheusMetricExporter:
+    stability: development
     type:
       - object
       - "null"
@@ -287,7 +293,8 @@ $defs:
         description: |
           Configure Prometheus Exporter to produce metrics with scope labels.
         defaultBehavior: true is used
-      target_info_enabled/development:
+      target_info_enabled:
+        stability: development
         type:
           - boolean
           - "null"
@@ -303,19 +310,24 @@ $defs:
         description: Configure how metric names are translated to Prometheus metric names.
         defaultBehavior: underscore_escaping_with_suffixes is used
   ExperimentalPrometheusTranslationStrategy:
+    stability: development
     type:
       - string
       - "null"
     enum:
       - underscore_escaping_with_suffixes
-      - underscore_escaping_without_suffixes/development
-      - no_utf8_escaping_with_suffixes/development
-      - no_translation/development
+      - underscore_escaping_without_suffixes
+      - no_utf8_escaping_with_suffixes
+      - no_translation
     enumDescriptions:
-      no_translation/development: Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered.
-      no_utf8_escaping_with_suffixes/development: Special character escaping is disabled. Type and unit suffixes are enabled.
-      underscore_escaping_without_suffixes/development: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility.
+      no_translation: Special character escaping is disabled. Type and unit suffixes are disabled. Metric names are unaltered.
+      no_utf8_escaping_with_suffixes: Special character escaping is disabled. Type and unit suffixes are enabled.
+      underscore_escaping_without_suffixes: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility.
       underscore_escaping_with_suffixes: Special character escaping is enabled. Type and unit suffixes are enabled.
+    enumStability:
+      no_translation: development
+      no_utf8_escaping_with_suffixes: development
+      underscore_escaping_without_suffixes: development
   MetricReader:
     type: object
     additionalProperties: false
@@ -517,6 +529,7 @@ $defs:
           Configure default histogram aggregation.
         defaultBehavior: explicit_bucket_histogram is used
   ExperimentalOtlpFileMetricExporter:
+    stability: development
     type:
       - object
       - "null"
@@ -770,13 +783,14 @@ $defs:
       - "null"
     additionalProperties: false
   ExperimentalMeterConfigurator:
+    stability: development
     type:
       - object
     additionalProperties: false
     properties:
       default_config:
         $ref: "#/$defs/ExperimentalMeterConfig"
-        description: Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.
+        description: Configure the default meter config used there is no matching entry in .meter_configurator.meters.
         defaultBehavior: unmatched .meters use default values as described in ExperimentalMeterConfig
       meters:
         type: array
@@ -786,6 +800,7 @@ $defs:
         description: Configure meters.
         defaultBehavior: all meters used .default_config
   ExperimentalMeterMatcherAndConfig:
+    stability: development
     type:
       - object
     additionalProperties: false
@@ -805,6 +820,7 @@ $defs:
       - name
       - config
   ExperimentalMeterConfig:
+    stability: development
     type:
       - object
     additionalProperties: false
@@ -815,6 +831,7 @@ $defs:
         description: Configure if the meter is enabled or not.
         defaultBehavior: true is used
   ExperimentalViewMatchingMode:
+    stability: development
     type:
       - string
       - "null"

--- a/schema/opentelemetry_configuration.yaml
+++ b/schema/opentelemetry_configuration.yaml
@@ -50,7 +50,8 @@ properties:
     description: |
       Configure resource for all signals.
     defaultBehavior: the default resource is used
-  instrumentation/development:
+  instrumentation:
+    stability: development
     $ref: "#/$defs/ExperimentalInstrumentation"
     description: |
       Configure instrumentation.
@@ -110,6 +111,7 @@ $defs:
   Resource:
     $ref: resource.yaml
   ExperimentalInstrumentation:
+    stability: development
     $ref: instrumentation.yaml
   Distribution:
     type: object

--- a/schema/opentelemetry_configuration.yaml
+++ b/schema/opentelemetry_configuration.yaml
@@ -8,6 +8,13 @@ properties:
       Represented as a string including the semver major, minor version numbers (and optionally the meta tag). For example: "0.4", "1.0-rc.2", "1.0" (after stable release).
       See https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md for more details.
       The yaml format is documented at https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema
+  maturity_level:
+    $ref: "#/$defs/MaturityLevel"
+    description: |
+      The maturity level of the schema this file is written against.
+      A file that omits this property is read with the stable schema and may use stable properties only. A file that declares development is read with the development schema and may also use properties that are under development.
+      See https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md for more details.
+    defaultBehavior: stable is used
   disabled:
     type:
       - boolean
@@ -100,6 +107,16 @@ $defs:
           Configure max attribute count. 
           Value must be non-negative.
         defaultBehavior: 128 is used
+  MaturityLevel:
+    type: string
+    enum:
+      - stable
+      - development
+    enumDescriptions:
+      stable: The file is read with the stable schema and may use stable properties only.
+      development: The file is read with the development schema and may also use properties that are under development, which may change or be removed in any release.
+    enumStability:
+      development: development
   LoggerProvider:
     $ref: logger_provider.yaml
   MeterProvider:

--- a/schema/resource.yaml
+++ b/schema/resource.yaml
@@ -9,7 +9,8 @@ properties:
     description: |
       Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.
     defaultBehavior: no resource attributes are added
-  detection/development:
+  detection:
+    stability: development
     $ref: "#/$defs/ExperimentalResourceDetection"
     description: |
       Configure resource detection.
@@ -91,6 +92,7 @@ $defs:
       string: String attribute value.
       string_array: String array attribute value.
   ExperimentalResourceDetection:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -108,6 +110,7 @@ $defs:
           Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
         defaultBehavior: no resource detectors are enabled
   ExperimentalResourceDetector:
+    stability: development
     type: object
     additionalProperties:
       type:
@@ -138,21 +141,25 @@ $defs:
         defaultBehavior: ignore
     isSdkExtensionPlugin: true
   ExperimentalContainerResourceDetector:
+    stability: development
     type:
       - object
       - "null"
     additionalProperties: false
   ExperimentalHostResourceDetector:
+    stability: development
     type:
       - object
       - "null"
     additionalProperties: false
   ExperimentalProcessResourceDetector:
+    stability: development
     type:
       - object
       - "null"
     additionalProperties: false
   ExperimentalServiceResourceDetector:
+    stability: development
     type:
       - object
       - "null"

--- a/schema/tracer_provider.yaml
+++ b/schema/tracer_provider.yaml
@@ -21,7 +21,8 @@ properties:
     description: |
       Configure the trace and span ID generator.
     defaultBehavior: RandomIdGenerator is used
-  tracer_configurator/development:
+  tracer_configurator:
+    stability: development
     $ref: "#/$defs/ExperimentalTracerConfigurator"
     description: |
       Configure tracers.
@@ -46,6 +47,7 @@ $defs:
       producer: producer, a producer span.
       consumer: consumer, a consumer span.
   ExperimentalSpanParent:
+    stability: development
     type:
       - string
       - "null"
@@ -121,11 +123,13 @@ $defs:
         $ref: "#/$defs/AlwaysRecordSampler"
         description: Configure sampler to be always_record.
         defaultBehavior: ignore
-      composite/development:
+      composite:
+        stability: development
         $ref: "#/$defs/ExperimentalComposableSampler"
         description: Configure sampler to be composite.
         defaultBehavior: ignore
-      jaeger_remote/development:
+      jaeger_remote:
+        stability: development
         $ref: "#/$defs/ExperimentalJaegerRemoteSampler"
         description: Configure sampler to be jaeger_remote.
         defaultBehavior: ignore
@@ -133,7 +137,8 @@ $defs:
         $ref: "#/$defs/ParentBasedSampler"
         description: Configure sampler to be parent_based.
         defaultBehavior: ignore
-      probability/development:
+      probability:
+        stability: development
         $ref: "#/$defs/ExperimentalProbabilitySampler"
         description: Configure sampler to be probability.
         defaultBehavior: ignore
@@ -166,6 +171,7 @@ $defs:
     required:
       - root
   ExperimentalJaegerRemoteSampler:
+    stability: development
     type:
       - object
       - "null"
@@ -220,6 +226,7 @@ $defs:
           Configure local_parent_not_sampled sampler.
         defaultBehavior: always_off is used
   ExperimentalProbabilitySampler:
+    stability: development
     type:
       - object
       - "null"
@@ -250,16 +257,19 @@ $defs:
           Configure trace_id_ratio.
         defaultBehavior: 1.0 is used
   ExperimentalComposableAlwaysOffSampler:
+    stability: development
     type:
       - object
       - "null"
     additionalProperties: false
   ExperimentalComposableAlwaysOnSampler:
+    stability: development
     type:
       - object
       - "null"
     additionalProperties: false
   ExperimentalComposableParentThresholdSampler:
+    stability: development
     type:
       - object
     additionalProperties: false
@@ -270,6 +280,7 @@ $defs:
     required:
       - root
   ExperimentalComposableProbabilitySampler:
+    stability: development
     type:
       - object
       - "null"
@@ -285,6 +296,7 @@ $defs:
           Configure ratio.
         defaultBehavior: 1.0 is used
   ExperimentalComposableRuleBasedSampler:
+    stability: development
     type:
       - object
       - 'null'
@@ -302,6 +314,7 @@ $defs:
           If no rules match, the span is not sampled.
         defaultBehavior: no span is sampled
   ExperimentalComposableRuleBasedSamplerRule:
+    stability: development
     type: object
     description: |
       A rule for ExperimentalComposableRuleBasedSampler. A rule can have multiple match conditions - the sampler will be applied if all match. 
@@ -342,6 +355,7 @@ $defs:
     required:
       - sampler
   ExperimentalComposableRuleBasedSamplerRuleAttributeValues:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -358,6 +372,7 @@ $defs:
       - key
       - values
   ExperimentalComposableRuleBasedSamplerRuleAttributePatterns:
+    stability: development
     type: object
     additionalProperties: false
     properties:
@@ -389,6 +404,7 @@ $defs:
     required:
       - key
   ExperimentalComposableSampler:
+    stability: development
     type: object
     additionalProperties:
       type:
@@ -463,7 +479,8 @@ $defs:
         $ref: common.yaml#/$defs/OtlpGrpcExporter
         description: Configure exporter to be OTLP with gRPC transport.
         defaultBehavior: ignore
-      otlp_file/development:
+      otlp_file:
+        stability: development
         $ref: common.yaml#/$defs/ExperimentalOtlpFileExporter
         description: |
           Configure exporter to be OTLP with file transport.
@@ -561,13 +578,14 @@ $defs:
         defaultBehavior: ignore
     isSdkExtensionPlugin: true
   ExperimentalTracerConfigurator:
+    stability: development
     type:
       - object
     additionalProperties: false
     properties:
       default_config:
         $ref: "#/$defs/ExperimentalTracerConfig"
-        description: Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.
+        description: Configure the default tracer config used there is no matching entry in .tracer_configurator.tracers.
         defaultBehavior: unmatched .tracers use default values as described in ExperimentalTracerConfig
       tracers:
         type: array
@@ -577,6 +595,7 @@ $defs:
         description: Configure tracers.
         defaultBehavior: all tracers use .default_config
   ExperimentalTracerMatcherAndConfig:
+    stability: development
     type:
       - object
     additionalProperties: false
@@ -596,6 +615,7 @@ $defs:
       - name
       - config
   ExperimentalTracerConfig:
+    stability: development
     type:
       - object
     additionalProperties: false

--- a/scripts/compile-schema.js
+++ b/scripts/compile-schema.js
@@ -8,10 +8,9 @@ import {
 } from "./util.js";
 import {readSourceTypesByType} from "./source-schema.js";
 
-// See the schema modeling rules in CONTRIBUTING.md. /alpha and /beta suffixes
-// are also permitted but omitted here as the schema has no instances of them.
+// See the schema modeling rules in CONTRIBUTING.md. A name is an identifier and
+// nothing else: the maturity of a node is recorded in its stability annotation.
 const identifier = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const maturitySuffix = /\/development$/;
 const pascalCaseTypeName = /^[A-Z][A-Za-z0-9]*$/;
 
 // Read source schema
@@ -218,15 +217,15 @@ function noSubschemas(sourceSchemaType, messages) {
 }
 
 function namesShouldBeValidIdentifiers(sourceSchemaType, messages) {
-    const isValidName = name => identifier.test(name.replace(maturitySuffix, ''));
+    const isValidName = name => identifier.test(name);
     sourceSchemaType.properties.forEach(property => {
         if (!isValidName(property.property)) {
-            messages.push(`Property name '${property.property}' in ${sourceSchemaType.type} must match ${identifier} (optionally followed by a /development maturity suffix)`);
+            messages.push(`Property name '${property.property}' in ${sourceSchemaType.type} must match ${identifier}. Record maturity in '${stabilityKey}', not in the name.`);
         }
     });
     (sourceSchemaType.enumValues || []).forEach(enumValue => {
         if (typeof enumValue === 'string' && !isValidName(enumValue)) {
-            messages.push(`Enum value '${enumValue}' in ${sourceSchemaType.type} must match ${identifier} (optionally followed by a /development maturity suffix)`);
+            messages.push(`Enum value '${enumValue}' in ${sourceSchemaType.type} must match ${identifier}. Record maturity in '${enumStabilityKey}', not in the name.`);
         }
     });
 }

--- a/scripts/compile-schema.js
+++ b/scripts/compile-schema.js
@@ -1,5 +1,11 @@
 import fs from 'fs';
-import {rootTypeName, schemaPath} from "./util.js";
+import {
+    enumStabilityKey,
+    rootTypeName,
+    schemaPath,
+    stabilityKey,
+    stabilityValues
+} from "./util.js";
 import {readSourceTypesByType} from "./source-schema.js";
 
 // See the schema modeling rules in CONTRIBUTING.md. /alpha and /beta suffixes
@@ -21,6 +27,7 @@ sourceTypes.forEach(sourceSchemaType => {
     optionalPropertiesHaveDefaultBehavior(sourceSchemaType, messages);
     namesShouldBeValidIdentifiers(sourceSchemaType, messages);
     typeNamesShouldBePascalCase(sourceSchemaType, messages);
+    stabilityAnnotationsShouldBeValid(sourceSchemaType, messages);
 });
 if (messages.length > 0) {
     messages.forEach(message => console.log(message));
@@ -70,6 +77,8 @@ function prepareSchemaForOutput(sourceSchemaType, sourceTypes) {
 function stripMetadata(schema) {
     delete schema['enumDescriptions'];
     delete schema['isSdkExtensionPlugin'];
+    delete schema[stabilityKey];
+    delete schema[enumStabilityKey];
 
     const properties = schema.properties;
     if (!properties) {
@@ -78,6 +87,7 @@ function stripMetadata(schema) {
     Object.values(properties).forEach(propertySchema => {
         delete propertySchema['defaultBehavior'];
         delete propertySchema['nullBehavior'];
+        delete propertySchema[stabilityKey];
     });
 }
 
@@ -218,6 +228,34 @@ function namesShouldBeValidIdentifiers(sourceSchemaType, messages) {
         if (typeof enumValue === 'string' && !isValidName(enumValue)) {
             messages.push(`Enum value '${enumValue}' in ${sourceSchemaType.type} must match ${identifier} (optionally followed by a /development maturity suffix)`);
         }
+    });
+}
+
+function stabilityAnnotationsShouldBeValid(sourceSchemaType, messages) {
+    const reportInvalidStability = (stability, location) => {
+        if (stability !== undefined && !stabilityValues.includes(stability)) {
+            messages.push(`'${stabilityKey}' of ${location} must be one of ${stabilityValues.join(', ')}, found '${stability}'.`);
+        }
+    };
+
+    reportInvalidStability(sourceSchemaType.schema[stabilityKey], sourceSchemaType.type);
+    sourceSchemaType.properties.forEach(property => {
+        reportInvalidStability(property.schema[stabilityKey], `${sourceSchemaType.type}.${property.property}`);
+    });
+
+    const enumStability = sourceSchemaType.schema[enumStabilityKey];
+    if (!enumStability) {
+        return;
+    }
+    if (!sourceSchemaType.isEnumType()) {
+        messages.push(`Please remove '${enumStabilityKey}' from ${sourceSchemaType.type}, which is not an enum type.`);
+        return;
+    }
+    Object.entries(enumStability).forEach(([enumValue, stability]) => {
+        if (!sourceSchemaType.enumValues.includes(enumValue)) {
+            messages.push(`Please remove entry for ${enumValue} from '${enumStabilityKey}' for ${sourceSchemaType.type}.`);
+        }
+        reportInvalidStability(stability, `${sourceSchemaType.type}.${enumValue}`);
     });
 }
 

--- a/scripts/compile-schema.js
+++ b/scripts/compile-schema.js
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import {
+    developmentSchemaPath,
+    developmentStability,
     enumStabilityKey,
     rootTypeName,
     schemaPath,
@@ -35,49 +37,81 @@ if (messages.length > 0) {
 
 // If we make it here, source schema is valid.
 
-// Construct and write full schema into single output file
-// All types go in $defs, except root type, which is the top level schema
+// One source schema, two compiled schemas. The stable one holds nothing that is
+// under development. The development one holds everything, and keeps the
+// annotation so that a reader can still tell which parts are under development.
 sourceTypes.sort((a, b) => a.type.localeCompare(b.type));
-const defs = {};
-sourceTypes.filter(sourceSchemaType => sourceSchemaType.type !== rootTypeName)
-    .forEach(sourceSchemaType => {
-        defs[sourceSchemaType.type] = prepareSchemaForOutput(sourceSchemaType, sourceTypes);
-    });
 
-const rootType = sourceTypes.find(sourceSchemaType => sourceSchemaType.type === rootTypeName);
-if (!rootType) {
-    throw new Error(`Root type ${rootTypeName} not found in source schema.`);
-}
-const rootTypeSchema = prepareSchemaForOutput(rootType, sourceTypes);
-
-const output = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": rootTypeName,
-    ...rootTypeSchema,
-    "$defs": defs
-};
-
-fs.writeFileSync(schemaPath, JSON.stringify(output, null, 2));
+fs.writeFileSync(schemaPath, JSON.stringify(compile(sourceTypes, false), null, 2));
+fs.writeFileSync(developmentSchemaPath, JSON.stringify(compile(sourceTypes, true), null, 2));
 
 // Helper functions
 
-function prepareSchemaForOutput(sourceSchemaType, sourceTypes) {
+function compile(sourceTypes, includeDevelopment) {
+    const includedTypes = sourceTypes.filter(sourceSchemaType => includeDevelopment || !sourceSchemaType.isDevelopment());
+
+    const defs = {};
+    includedTypes.filter(sourceSchemaType => sourceSchemaType.type !== rootTypeName)
+        .forEach(sourceSchemaType => {
+            defs[sourceSchemaType.type] = prepareSchemaForOutput(sourceSchemaType, sourceTypes, includeDevelopment);
+        });
+
+    const rootType = includedTypes.find(sourceSchemaType => sourceSchemaType.type === rootTypeName);
+    if (!rootType) {
+        throw new Error(`Root type ${rootTypeName} not found in source schema.`);
+    }
+
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": rootTypeName,
+        ...prepareSchemaForOutput(rootType, sourceTypes, includeDevelopment),
+        "$defs": defs
+    };
+}
+
+function prepareSchemaForOutput(sourceSchemaType, sourceTypes, includeDevelopment) {
     const schema = JSON.parse(JSON.stringify(sourceSchemaType.schema));
 
     delete schema['$defs'];
 
-    stripMetadata(schema);
+    if (!includeDevelopment) {
+        removeDevelopmentNodes(sourceSchemaType, schema);
+    }
+    stripMetadata(schema, includeDevelopment);
     replaceCrossFileRefs(schema);
-    enrichDescriptions(sourceSchemaType, schema, sourceTypes);
+    enrichDescriptions(sourceSchemaType, schema, sourceTypes, includeDevelopment);
+    if (includeDevelopment && sourceSchemaType.isDevelopment()) {
+        // A type annotated on a cross file stub loses the annotation when the
+        // stub is replaced, so state it on the way out.
+        schema[stabilityKey] = developmentStability;
+    }
 
     return schema;
 }
 
-function stripMetadata(schema) {
+function removeDevelopmentNodes(sourceSchemaType, schema) {
+    sourceSchemaType.properties
+        .filter(property => property.isDevelopment)
+        .forEach(property => {
+            delete schema.properties[property.property];
+            const required = schema['required'];
+            if (required) {
+                schema['required'] = required.filter(name => name !== property.property);
+            }
+        });
+
+    if (sourceSchemaType.isEnumType()) {
+        schema['enum'] = sourceSchemaType.enumValues.filter(enumValue => !sourceSchemaType.isDevelopmentEnumValue(enumValue));
+    }
+}
+
+function stripMetadata(schema, includeDevelopment) {
     delete schema['enumDescriptions'];
     delete schema['isSdkExtensionPlugin'];
-    delete schema[stabilityKey];
-    delete schema[enumStabilityKey];
+    if (!includeDevelopment) {
+        delete schema[stabilityKey];
+        delete schema[enumStabilityKey];
+    }
 
     const properties = schema.properties;
     if (!properties) {
@@ -86,7 +120,9 @@ function stripMetadata(schema) {
     Object.values(properties).forEach(propertySchema => {
         delete propertySchema['defaultBehavior'];
         delete propertySchema['nullBehavior'];
-        delete propertySchema[stabilityKey];
+        if (!includeDevelopment) {
+            delete propertySchema[stabilityKey];
+        }
     });
 }
 
@@ -110,7 +146,7 @@ function replaceCrossFileRefs(schema) {
     });
 }
 
-function enrichDescriptions(sourceSchemaType, schema, sourceTypes) {
+function enrichDescriptions(sourceSchemaType, schema, sourceTypes, includeDevelopment) {
     const properties = schema.properties;
     if (!properties) {
         return;
@@ -124,7 +160,9 @@ function enrichDescriptions(sourceSchemaType, schema, sourceTypes) {
         if (enumSourceType) {
             description = maybeAddLineBreak(description);
             description += 'Values include:\n';
-            enumSourceType.sortedEnumValues().forEach(enumValue => {
+            enumSourceType.sortedEnumValues()
+                .filter(enumValue => includeDevelopment || !enumSourceType.isDevelopmentEnumValue(enumValue))
+                .forEach(enumValue => {
                 const enumDescription = enumSourceType.schema['enumDescriptions'][enumValue];
                 description += `* ${enumValue}: ${enumDescription}\n`;
             });

--- a/scripts/language-implementations.js
+++ b/scripts/language-implementations.js
@@ -4,8 +4,7 @@ import {
     metaSchemaLanguageStatusPath,
     metaSchemaLanguageStatusFileName,
     schemaSourceDirPath,
-    metaSchemaLanguageFilePrefix,
-    isExperimentalType
+    metaSchemaLanguageFilePrefix
 } from "./util.js";
 import {readSourceTypesByType} from "./source-schema.js";
 
@@ -67,12 +66,13 @@ export class LanguageImplementation {
     }
 
     toJson() {
-        // Types in lexicographical order, with non-experimental first
-        const typeSupportStatuses = this.typeSupportStatuses.map(typeSupportStatus => typeSupportStatus.toJson());
-        typeSupportStatuses.sort((a, b) => {
-            const differentMaturities = isExperimentalType(a.type) - isExperimentalType(b.type);
+        // Types in lexicographical order, with stable types first
+        const sorted = this.typeSupportStatuses.slice();
+        sorted.sort((a, b) => {
+            const differentMaturities = a.isDevelopment - b.isDevelopment;
             return differentMaturities === 0 ? a.type.localeCompare(b.type) : +differentMaturities;
         });
+        const typeSupportStatuses = sorted.map(typeSupportStatus => typeSupportStatus.toJson());
 
         return {
             latestSupportedFileFormat: this.latestSupportedFileFormat,
@@ -99,13 +99,15 @@ export class TypeSupportStatus {
     propertyOverrides; // null if enum
     enumOverrides; // null if not enum
     notes;
+    isDevelopment; // read from the source schema, not serialized
 
-    constructor(type, status, propertyOverrides, enumOverrides, notes) {
+    constructor(type, status, propertyOverrides, enumOverrides, notes, isDevelopment = false) {
         this.type = type;
         this.status = status;
         this.propertyOverrides = propertyOverrides;
         this.enumOverrides = enumOverrides;
         this.notes = notes;
+        this.isDevelopment = isDevelopment;
     }
 
     toJson() {
@@ -270,6 +272,10 @@ function reconcileLanguageImplementations(languageImplementations, sourceTypesBy
             }
         });
 
+        reconciledTypeSupportStatuses.forEach(typeSupportStatus => {
+            const sourceSchemaType = sourceTypesByType[typeSupportStatus.type];
+            typeSupportStatus.isDevelopment = sourceSchemaType ? sourceSchemaType.isDevelopment() : false;
+        });
         languageImplementation.typeSupportStatuses = reconciledTypeSupportStatuses;
     });
 
@@ -298,7 +304,7 @@ function emptyLanguageImplementation(language, sourceTypesByType) {
     return new LanguageImplementation(
         language,
         'TODO',
-        Object.values(sourceTypesByType).map(sourceSchemaType => new TypeSupportStatus(sourceSchemaType.type, IMPLEMENTATION_STATUS_UNKNOWN, [], sourceSchemaType.enumValues === null ? null : [], null)));
+        Object.values(sourceTypesByType).map(sourceSchemaType => new TypeSupportStatus(sourceSchemaType.type, IMPLEMENTATION_STATUS_UNKNOWN, [], sourceSchemaType.enumValues === null ? null : [], null, sourceSchemaType.isDevelopment())));
 }
 
 function parseEnum(rawJson, propertyName, errorMessage, knownValues) {

--- a/scripts/source-schema.js
+++ b/scripts/source-schema.js
@@ -3,11 +3,10 @@ import {
     developmentStability,
     enumStabilityKey,
     isDevelopmentSchema,
-    isExperimentalProperty,
-    isExperimentalType,
     metaSchemaFilePrefix,
     rootTypeName,
-    schemaSourceDirPath
+    schemaSourceDirPath,
+    stabilityKey
 } from "./util.js";
 import yaml from "yaml";
 
@@ -50,6 +49,11 @@ export function readSourceTypesByType() {
         sourceSchemaType.sourceFile = ref;
         sourceSchemaType.jsonSchemaPath = '.';
         sourceSchemaType.schema = topLevelSchema;
+        // The stub being replaced here is the only place a cross file type can
+        // be annotated, so its maturity has to outlive it.
+        if (sourceSchemaType.stability === undefined) {
+            sourceSchemaType.stability = topLevelSchema[stabilityKey];
+        }
     });
 
     // Resolve properties, enum values
@@ -159,7 +163,7 @@ export class SourceSchemaProperty {
         this.isSeq = isSeq;
         this.isRequired = isRequired;
         this.isNullable = types.includes('null');
-        this.isDevelopment = isDevelopmentSchema(schema) || isExperimentalProperty(property);
+        this.isDevelopment = isDevelopmentSchema(schema);
         this.schema = schema;
     }
 
@@ -191,6 +195,7 @@ export class SourceSchemaType {
     schema;
     properties;
     enumValues; // null if not enum
+    stability;
 
     constructor(type, sourceFile, fileContent, jsonSchemaPath, schema) {
         this.type = type;
@@ -200,6 +205,7 @@ export class SourceSchemaType {
         this.schema = schema;
         this.properties = [];
         this.enumValues = null;
+        this.stability = schema[stabilityKey];
     }
 
     isEnumType() {
@@ -207,7 +213,7 @@ export class SourceSchemaType {
     }
 
     isDevelopment() {
-        return isDevelopmentSchema(this.schema) || isExperimentalType(this.type);
+        return this.stability === developmentStability;
     }
 
     enumStability() {
@@ -215,10 +221,7 @@ export class SourceSchemaType {
     }
 
     isDevelopmentEnumValue(enumValue) {
-        if (this.enumStability()[enumValue] === developmentStability) {
-            return true;
-        }
-        return typeof enumValue === 'string' && isExperimentalProperty(enumValue);
+        return this.enumStability()[enumValue] === developmentStability;
     }
 
     jsonSchemaRef() {

--- a/scripts/source-schema.js
+++ b/scripts/source-schema.js
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import {
+    developmentStability,
+    enumStabilityKey,
+    isDevelopmentSchema,
     isExperimentalProperty,
+    isExperimentalType,
     metaSchemaFilePrefix,
     rootTypeName,
     schemaSourceDirPath
@@ -146,6 +150,7 @@ export class SourceSchemaProperty {
     isSeq;
     isRequired;
     isNullable;
+    isDevelopment;
     schema;
 
     constructor(property, types, isSeq, isRequired, schema) {
@@ -154,6 +159,7 @@ export class SourceSchemaProperty {
         this.isSeq = isSeq;
         this.isRequired = isRequired;
         this.isNullable = types.includes('null');
+        this.isDevelopment = isDevelopmentSchema(schema) || isExperimentalProperty(property);
         this.schema = schema;
     }
 
@@ -200,6 +206,21 @@ export class SourceSchemaType {
         return this.enumValues !== null;
     }
 
+    isDevelopment() {
+        return isDevelopmentSchema(this.schema) || isExperimentalType(this.type);
+    }
+
+    enumStability() {
+        return this.schema[enumStabilityKey] || {};
+    }
+
+    isDevelopmentEnumValue(enumValue) {
+        if (this.enumStability()[enumValue] === developmentStability) {
+            return true;
+        }
+        return typeof enumValue === 'string' && isExperimentalProperty(enumValue);
+    }
+
     jsonSchemaRef() {
         let ref = this.sourceFile;
         if (this.jsonSchemaPath !== '.') {
@@ -216,9 +237,9 @@ export class SourceSchemaType {
 
     sortedProperties() {
         const sorted = this.properties.slice();
-        // Sort in lexigraphical order, with non-experimental properties first
+        // Sort in lexigraphical order, with stable properties first
         sorted.sort((a, b) => {
-            const differentMaturities = isExperimentalProperty(a.property) - isExperimentalProperty(b.property);
+            const differentMaturities = a.isDevelopment - b.isDevelopment;
             return differentMaturities === 0 ? a.property.localeCompare(b.property) : +differentMaturities;
         });
         return sorted;

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -13,6 +13,19 @@ export const metaSchemaLanguageFilePrefix = `${metaSchemaFilePrefix}_language`;
 export const metaSchemaLanguageStatusFileName = (language) => `${metaSchemaLanguageFilePrefix}_${language}.yaml`;
 export const metaSchemaLanguageStatusPath = (language) => schemaSourceDirPath + metaSchemaLanguageStatusFileName(language);
 
+// Maturity is metadata about a node, not part of the name of that node.
+// `stability` annotates a property or a type, `enumStability` maps an enum value
+// to its maturity. Both are stripped when the schema is compiled.
+export const stabilityKey = 'stability';
+export const enumStabilityKey = 'enumStability';
+export const developmentStability = 'development';
+export const stableStability = 'stable';
+export const stabilityValues = [stableStability, developmentStability];
+
+export const isDevelopmentSchema = (schema) => schema != null && schema[stabilityKey] === developmentStability;
+
+// Maturity used to be recorded in the name. Retained only until the source
+// schema has been migrated to the annotations above.
 export const isExperimentalProperty = (property) => property.endsWith('/development');
 export const isExperimentalType = (type) => type.startsWith('Experimental');
 

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -7,6 +7,7 @@ const __dirname = path.dirname(__filename);
 export const metaSchemaFilePrefix = "meta_schema";
 export const schemaSourceDirPath = __dirname + "/../schema/";
 export const schemaPath = __dirname + `/../opentelemetry_configuration.json`;
+export const developmentSchemaPath = __dirname + `/../opentelemetry_configuration_development.json`;
 export const languageSupportStatusPath = __dirname + "/../language-support-status.md";
 
 export const metaSchemaLanguageFilePrefix = `${metaSchemaFilePrefix}_language`;
@@ -21,6 +22,7 @@ export const enumStabilityKey = 'enumStability';
 export const developmentStability = 'development';
 export const stableStability = 'stable';
 export const stabilityValues = [stableStability, developmentStability];
+export const maturityLevelKey = 'maturity_level';
 
 export const isDevelopmentSchema = (schema) => schema != null && schema[stabilityKey] === developmentStability;
 

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -24,10 +24,5 @@ export const stabilityValues = [stableStability, developmentStability];
 
 export const isDevelopmentSchema = (schema) => schema != null && schema[stabilityKey] === developmentStability;
 
-// Maturity used to be recorded in the name. Retained only until the source
-// schema has been migrated to the annotations above.
-export const isExperimentalProperty = (property) => property.endsWith('/development');
-export const isExperimentalType = (type) => type.startsWith('Experimental');
-
 export const snippetsDirPath = __dirname + "/../snippets/";
 export const rootTypeName = 'OpenTelemetryConfiguration';

--- a/scripts/validate-snippets.js
+++ b/scripts/validate-snippets.js
@@ -1,13 +1,12 @@
 import fs from "fs";
-import {rootTypeName, schemaPath} from "./util.js";
+import {developmentSchemaPath, developmentStability, maturityLevelKey, rootTypeName, schemaPath} from "./util.js";
 import Ajv from "ajv/dist/2020.js";
 import {readSnippets} from "./snippets.js";
 import {readSourceTypesByType} from "./source-schema.js";
 
-// Initialize ajv
-const ajv = new Ajv({ allErrors: true });
-const outputSchema = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
-ajv.addSchema(outputSchema);
+// One validator per compiled schema. A file says which one reads it.
+const stableAjv = newValidator(schemaPath, true);
+const developmentAjv = newValidator(developmentSchemaPath, false);
 
 const sourceTypesByType = readSourceTypesByType();
 
@@ -18,6 +17,7 @@ const messages = [];
 
 readSnippets()
     .forEach(snippet => {
+        const ajv = validatorFor(snippet.parsedFullContent);
         const rootValidator = ajv.getSchema(rootJsonSchemaTypeRef);
         if (!rootValidator) {
             throw new Error(`Unable to resolve root schema for JSON schema type ref: ${rootJsonSchemaTypeRef}`);
@@ -54,6 +54,20 @@ if (messages.length > 0) {
 }
 
 // Helper functions
+
+function newValidator(path, strict) {
+    // The development schema keeps the stability annotation. A validator is
+    // required to ignore a keyword it does not know, but the strict mode of ajv
+    // is stricter than that.
+    const ajv = new Ajv({allErrors: true, strict});
+    ajv.addSchema(JSON.parse(fs.readFileSync(path, "utf-8")));
+    return ajv;
+}
+
+function validatorFor(parsedContent) {
+    const declared = parsedContent && parsedContent[maturityLevelKey];
+    return declared === developmentStability ? developmentAjv : stableAjv;
+}
 
 function validate(snippetFile, ajvValidator, ajvRef, data) {
     try {

--- a/snippets/ExperimentalGeneralInstrumentation_semconv_stability_opt_in.yaml
+++ b/snippets/ExperimentalGeneralInstrumentation_semconv_stability_opt_in.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 instrumentation:
   general:

--- a/snippets/ExperimentalGeneralInstrumentation_semconv_stability_opt_in.yaml
+++ b/snippets/ExperimentalGeneralInstrumentation_semconv_stability_opt_in.yaml
@@ -1,6 +1,6 @@
 file_format: "1.1"
 
-instrumentation/development:
+instrumentation:
   general:
     # SNIPPET_START
     # Configure semantic convention stability opt-in using a comma-separated list

--- a/snippets/ExperimentalInstrumentation_kitchen_sink.yaml
+++ b/snippets/ExperimentalInstrumentation_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 instrumentation:
   # SNIPPET_START

--- a/snippets/ExperimentalInstrumentation_kitchen_sink.yaml
+++ b/snippets/ExperimentalInstrumentation_kitchen_sink.yaml
@@ -1,6 +1,6 @@
 file_format: "1.1"
 
-instrumentation/development:
+instrumentation:
   # SNIPPET_START
   general:
     http:

--- a/snippets/ExperimentalLoggerConfigurator_kitchen_sink.yaml
+++ b/snippets/ExperimentalLoggerConfigurator_kitchen_sink.yaml
@@ -5,7 +5,7 @@ logger_provider:
     - simple:
         exporter:
           console:
-  logger_configurator/development:
+  logger_configurator:
     # SNIPPET_START
     default_config:
       enabled: false

--- a/snippets/ExperimentalLoggerConfigurator_kitchen_sink.yaml
+++ b/snippets/ExperimentalLoggerConfigurator_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 logger_provider:
   processors:

--- a/snippets/ExperimentalMeterConfigurator_kitchen_sink.yaml
+++ b/snippets/ExperimentalMeterConfigurator_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 meter_provider:
   readers:

--- a/snippets/ExperimentalMeterConfigurator_kitchen_sink.yaml
+++ b/snippets/ExperimentalMeterConfigurator_kitchen_sink.yaml
@@ -5,7 +5,7 @@ meter_provider:
     - periodic:
         exporter:
           console:
-  meter_configurator/development:
+  meter_configurator:
     # SNIPPET_START
     default_config:
       enabled: false

--- a/snippets/ExperimentalOtlpFileExporter_logs_file.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_logs_file.yaml
@@ -4,6 +4,6 @@ logger_provider:
   processors:
     - batch:
         exporter:
-          otlp_file/development:
+          otlp_file:
             # SNIPPET_START
             output_stream: file:///var/log/logs.jsonl

--- a/snippets/ExperimentalOtlpFileExporter_logs_file.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_logs_file.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 logger_provider:
   processors:

--- a/snippets/ExperimentalOtlpFileExporter_logs_stdout.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_logs_stdout.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 logger_provider:
   processors:

--- a/snippets/ExperimentalOtlpFileExporter_logs_stdout.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_logs_stdout.yaml
@@ -4,6 +4,6 @@ logger_provider:
   processors:
     - batch:
         exporter:
-          otlp_file/development:
+          otlp_file:
             # SNIPPET_START
             output_stream: stdout

--- a/snippets/ExperimentalOtlpFileExporter_traces_file.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_traces_file.yaml
@@ -4,6 +4,6 @@ tracer_provider:
   processors:
     - batch:
         exporter:
-          otlp_file/development:
+          otlp_file:
             # SNIPPET_START
             output_stream: file:///var/log/traces.jsonl

--- a/snippets/ExperimentalOtlpFileExporter_traces_file.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_traces_file.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 tracer_provider:
   processors:

--- a/snippets/ExperimentalOtlpFileExporter_traces_stdout.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_traces_stdout.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 tracer_provider:
   processors:

--- a/snippets/ExperimentalOtlpFileExporter_traces_stdout.yaml
+++ b/snippets/ExperimentalOtlpFileExporter_traces_stdout.yaml
@@ -4,6 +4,6 @@ tracer_provider:
   processors:
     - batch:
         exporter:
-          otlp_file/development:
+          otlp_file:
             # SNIPPET_START
             output_stream: stdout

--- a/snippets/ExperimentalOtlpFileMetricExporter_metrics_file.yaml
+++ b/snippets/ExperimentalOtlpFileMetricExporter_metrics_file.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 meter_provider:
   readers:

--- a/snippets/ExperimentalOtlpFileMetricExporter_metrics_file.yaml
+++ b/snippets/ExperimentalOtlpFileMetricExporter_metrics_file.yaml
@@ -4,7 +4,7 @@ meter_provider:
   readers:
     - periodic:
         exporter:
-          otlp_file/development:
+          otlp_file:
             # SNIPPET_START
             output_stream: file:///var/log/metrics.jsonl
             temporality_preference: cumulative

--- a/snippets/ExperimentalOtlpFileMetricExporter_metrics_stdout.yaml
+++ b/snippets/ExperimentalOtlpFileMetricExporter_metrics_stdout.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 meter_provider:
   readers:

--- a/snippets/ExperimentalOtlpFileMetricExporter_metrics_stdout.yaml
+++ b/snippets/ExperimentalOtlpFileMetricExporter_metrics_stdout.yaml
@@ -4,7 +4,7 @@ meter_provider:
   readers:
     - periodic:
         exporter:
-          otlp_file/development:
+          otlp_file:
             # SNIPPET_START
             output_stream: stdout
             temporality_preference: cumulative

--- a/snippets/ExperimentalPrometheusMetricExporter_kitchen_sink.yaml
+++ b/snippets/ExperimentalPrometheusMetricExporter_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 meter_provider:
   readers:

--- a/snippets/ExperimentalPrometheusMetricExporter_kitchen_sink.yaml
+++ b/snippets/ExperimentalPrometheusMetricExporter_kitchen_sink.yaml
@@ -4,12 +4,12 @@ meter_provider:
   readers:
     - pull:
         exporter:
-          prometheus/development:
+          prometheus:
             # SNIPPET_START
             host: localhost
             port: 9464
             scope_info_enabled: true
-            target_info_enabled/development: true
+            target_info_enabled: true
             resource_constant_labels:
               included:
                 - "service*"

--- a/snippets/ExperimentalTracerConfigurator_kitchen_sink.yaml
+++ b/snippets/ExperimentalTracerConfigurator_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 tracer_provider:
   processors:

--- a/snippets/ExperimentalTracerConfigurator_kitchen_sink.yaml
+++ b/snippets/ExperimentalTracerConfigurator_kitchen_sink.yaml
@@ -5,7 +5,7 @@ tracer_provider:
     - simple:
         exporter:
           console:
-  tracer_configurator/development:
+  tracer_configurator:
     # SNIPPET_START
     default_config:
       enabled: false

--- a/snippets/MeterProvider_composable_views.yaml
+++ b/snippets/MeterProvider_composable_views.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 meter_provider:
   # SNIPPET_START

--- a/snippets/MeterProvider_composable_views.yaml
+++ b/snippets/MeterProvider_composable_views.yaml
@@ -20,4 +20,4 @@ meter_provider:
         instrument_name: my_instrument
       stream:
         aggregation_cardinality_limit: 1000
-  view_matching_mode/development: composable
+  view_matching_mode: composable

--- a/snippets/Resource_kitchen_sink.yaml
+++ b/snippets/Resource_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 resource:
   # SNIPPET_START

--- a/snippets/Resource_kitchen_sink.yaml
+++ b/snippets/Resource_kitchen_sink.yaml
@@ -30,7 +30,7 @@ resource:
       value: [ 1.1, 2.2 ]
       type: double_array
   attributes_list: "service.namespace=my-namespace,service.version=1.0.0"
-  detection/development:
+  detection:
     attributes:
       included:
         - process.*

--- a/snippets/Sampler_composite_rule_based_drop_redis_ping.yaml
+++ b/snippets/Sampler_composite_rule_based_drop_redis_ping.yaml
@@ -10,7 +10,7 @@ tracer_provider:
     # Use the composite rule_based sampler to suppress noisy Redis health check spans,
     # while falling back to standard parent-based sampling for all other spans.
     # Rules are matched in order; if no rule matches, the span is not sampled.
-    composite/development:
+    composite:
       rule_based:
         rules:
           # Drop Redis PING health check spans. These are CLIENT spans where db.operation=PING.

--- a/snippets/Sampler_composite_rule_based_drop_redis_ping.yaml
+++ b/snippets/Sampler_composite_rule_based_drop_redis_ping.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 tracer_provider:
   processors:

--- a/snippets/Sampler_probability_kitchen_sink.yaml
+++ b/snippets/Sampler_probability_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 tracer_provider:
   processors:

--- a/snippets/Sampler_probability_kitchen_sink.yaml
+++ b/snippets/Sampler_probability_kitchen_sink.yaml
@@ -7,5 +7,5 @@ tracer_provider:
           console:
   sampler:
     # SNIPPET_START
-    probability/development:
+    probability:
       ratio: 0.001

--- a/snippets/Sampler_rule_based_kitchen_sink.yaml
+++ b/snippets/Sampler_rule_based_kitchen_sink.yaml
@@ -1,4 +1,5 @@
 file_format: "1.1"
+maturity_level: development
 
 tracer_provider:
   processors:

--- a/snippets/Sampler_rule_based_kitchen_sink.yaml
+++ b/snippets/Sampler_rule_based_kitchen_sink.yaml
@@ -7,7 +7,7 @@ tracer_provider:
           console:
   sampler:
     # SNIPPET_START
-    composite/development:
+    composite:
       rule_based:
         # The rules for the sampler, matched in order. Each rule can have multiple match conditions - the sampler will be applied if all match.
         # If no conditions are specified, the rule matches all spans that reach it. If no rules match, the span is not sampled.

--- a/validator/Makefile
+++ b/validator/Makefile
@@ -35,6 +35,7 @@ tools: $(GOVULNCHECK)
 validator-copy-schema:
 	mkdir -p ${ROOT_DIR}/schema
 	cp ${PARENT_DIR}/opentelemetry_configuration.json ${ROOT_DIR}/schema/opentelemetry_configuration.json
+	cp ${PARENT_DIR}/opentelemetry_configuration_development.json ${ROOT_DIR}/schema/opentelemetry_configuration_development.json
 	find ${PARENT_DIR} -path '*/schema/*.json' ! -path '*/validator/schema/*.json' -exec cp '{}' "${ROOT_DIR}/schema/" ';'
 
 validator: validator-copy-schema

--- a/validator/main.go
+++ b/validator/main.go
@@ -150,6 +150,27 @@ func add_resources_from_embed(c *jsonschema.Compiler) {
 }
 
 
+// A configuration file says which of the two compiled schemas reads it. A file
+// that declares nothing is read with the stable schema, which holds no property
+// that is under development.
+func schemaURLFor(expandedConfig interface{}) string {
+	const (
+		stableSchemaURL      = "https://opentelemetry.io/otelconfig/opentelemetry_configuration.json"
+		developmentSchemaURL = "https://opentelemetry.io/otelconfig/opentelemetry_configuration_development.json"
+		maturityLevelKey     = "maturity_level"
+		developmentMaturity  = "development"
+	)
+
+	config, ok := expandedConfig.(map[string]interface{})
+	if !ok {
+		return stableSchemaURL
+	}
+	if maturityLevel, ok := config[maturityLevelKey].(string); ok && maturityLevel == developmentMaturity {
+		return developmentSchemaURL
+	}
+	return stableSchemaURL
+}
+
 func validateConfiguration(configFile string, outfileExt string, schemaDir *string) []byte {
 	c := jsonschema.NewCompiler()
 	if schemaDir != nil {
@@ -158,12 +179,12 @@ func validateConfiguration(configFile string, outfileExt string, schemaDir *stri
 		add_resources_from_embed(c)
 	}
 
-	schema, err := c.Compile("https://opentelemetry.io/otelconfig/opentelemetry_configuration.json")
+	expandedConfig, outFile := decodeFile(configFile, outfileExt)
+
+	schema, err := c.Compile(schemaURLFor(expandedConfig))
 	if err != nil {
 		log.Fatalf("%#v", err)
 	}
-
-	expandedConfig, outFile := decodeFile(configFile, outfileExt)
 
 	if err = schema.Validate(expandedConfig); err != nil {
 		if ve, ok := err.(*jsonschema.ValidationError); ok {

--- a/validator/shelltests/invalid_view_matching_mode.test
+++ b/validator/shelltests/invalid_view_matching_mode.test
@@ -1,4 +1,4 @@
 otel_config_validator shelltests/invalid_view_matching_mode.yaml
 >>>2
-jsonschema: '/meter_provider/view_matching_mode~1development' does not validate with https://opentelemetry.io/otelconfig/opentelemetry_configuration.json#/properties/meter_provider/$ref/properties/view_matching_mode~1development/$ref/enum: value must be one of "independent", "composable"
+jsonschema: '/meter_provider/view_matching_mode' does not validate with https://opentelemetry.io/otelconfig/opentelemetry_configuration_development.json#/properties/meter_provider/$ref/properties/view_matching_mode/$ref/enum: value must be one of "independent", "composable"
 >>>= 1

--- a/validator/shelltests/invalid_view_matching_mode.yaml
+++ b/validator/shelltests/invalid_view_matching_mode.yaml
@@ -1,6 +1,7 @@
 file_format: "1.1"
+maturity_level: development
 meter_provider:
-  view_matching_mode/development: merge_all
+  view_matching_mode: merge_all
   readers:
     - periodic:
         exporter:


### PR DESCRIPTION
> [!NOTE]
> This is a draft, but **not** because it is unfinished or not ready to be read. It is a draft because it implements one of the options being weighed in [#689](https://github.com/open-telemetry/opentelemetry-configuration/issues/689), and that discussion has not settled on an approach yet. It exists to show in code what [this comment](https://github.com/open-telemetry/opentelemetry-configuration/issues/689#issuecomment-5554080786) describes in prose, so the tradeoffs can be argued about against something real rather than against a description. It should not be merged before #689 reaches a decision.

Records the maturity of a property, a type or an enum value as an annotation beside it in the source schema instead of as a suffix in its name, and compiles that one source into two published artifacts.

## What changes

`schema/*.yaml` gains two annotations:

```yaml
detection:
  stability: development
  $ref: "#/$defs/ResourceDetection"
```

```yaml
enumStability:
  no_translation: development
```

`stability` marks a property or a type. `enumStability` marks individual values of an enum, which matters because enum values carry maturity today as well as properties, and a name on the type cannot express that only three of four values are under development.

Every name that carried a suffix loses it. `detection/development` becomes `detection`, and no key in either published artifact contains a `/`.

Two artifacts are compiled from that one source:

* `opentelemetry_configuration.json` holds nothing under development.
* `opentelemetry_configuration_development.json` holds everything, and keeps the annotations so a reader can still tell which parts are under development.

A configuration file selects one with a new root property:

```yaml
maturity_level: development
```

A file that omits it, which is every file written so far, is read with the stable schema. The stable artifact restricts that property to `enum: ["stable"]`, so a file declaring `development` is rejected by the stable schema rather than silently accepted.

## Behaviour

| configuration | stable schema | development schema |
| --- | --- | --- |
| stable properties only, no declaration | accepted | accepted |
| uses `resource.detection`, no declaration | rejected | accepted |
| uses `resource.detection`, declares `maturity_level: development` | rejected | accepted |

Stabilizing a property is deleting its `stability: development` line. Nothing is renamed, so a configuration file written against the development artifact stays valid, and no SDK needs to accept two spellings of one property.

## Commits

* `Let the source schema record maturity as an annotation` adds the vocabulary and its validation, with the compiled output byte identical, so the mechanism can be reviewed before anything moves.
* `Move maturity out of the name of every node that carried it` migrates 16 properties, 3 enum values and 47 types, and renames them in the examples, snippets and per language support status files.
* `Read maturity only from the annotation` removes the name based fallbacks.
* `Compile the source into a stable schema and a development schema` adds the second artifact and `maturity_level`.
* `Describe maturity as an annotation in the contributor and versioning docs` updates `CONTRIBUTING.md` and `VERSIONING.md`.
* `Teach the validator which of the two schemas reads a file` wires the selection into `otel_config_validator`.

## Known limits, stated up front

* **The split cannot be enforced at an extension point.** Fourteen types, including `Sampler`, `SpanExporter` and `LogRecordProcessor`, set `additionalProperties` so an SDK can be configured with a plugin the schema has never heard of. The stable artifact therefore accepts the name of a component under development exactly as it accepts an unknown third party one. This is a ceiling on any split into two artifacts, and the suffix convention in use today does not enforce it either. It is recorded in both `CONTRIBUTING.md` and `VERSIONING.md`.
* **`stability` is not a JSON Schema keyword.** The specification requires a validator to ignore keywords it does not know, and every validator tried here does, but the strict mode of `ajv` is stricter than the specification, so the development artifact is compiled and validated with `--strict=false`.
* **Nothing here migrates a configuration file that already uses a suffixed key.** That is discussed in the linked comment and is deliberately not attempted in this branch.
* **The tailored diagnostics in the linked comment are not implemented.** Rejecting an undeclared development property currently produces the ordinary JSON Schema message. The annotation is what makes better messages possible; writing them is separate work.
* `Experimental*` type name prefixes are left alone. They are now redundant with the annotation, and renaming them is mechanical and noisy, so it is better done separately if this direction is taken.

## Verification

`make compile-schema` is idempotent, `ajv` compiles both artifacts, all 36 snippets and all 3 examples validate against the right artifact, `fix-language-implementations` is silent on a second run, `generate-markdown` is clean, the Go validator builds, and the shelltests pass.
